### PR TITLE
Add nightly synthetic real-world test for govbot

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -14,11 +14,18 @@ jobs:
     name: Synthetic Real-World Test
     runs-on: ubuntu-latest
     steps:
-      - name: Install govbot via install script
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Build govbot
         run: |
-          sh -c "$(curl -fsSL https://raw.githubusercontent.com/windy-civi/toolkit/main/actions/govbot/scripts/install-nightly.sh)"
+          cd actions/govbot
+          cargo build --release
           # Add to PATH for subsequent steps
-          echo "${HOME}/.govbot/bin" >> $GITHUB_PATH
+          echo "${GITHUB_WORKSPACE}/actions/govbot/target/release" >> $GITHUB_PATH
 
       - name: Verify govbot installation
         run: |
@@ -87,6 +94,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Install | ${{ steps.clone.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | ${{ steps.clone.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Clone | ${{ steps.clone.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Logs | ${{ steps.logs.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -25,19 +25,20 @@ jobs:
           govbot --version
           govbot --help
 
-      - name: Run govbot clone (Wyoming - small state for fast testing)
+      - name: Run govbot clone all
         id: clone
         run: |
-          # Clone a single small state repository
-          govbot clone wy --verbose
+          # Clone all repositories
+          govbot clone all --verbose
 
-          # Verify the clone produced output
-          if [ ! -d "${HOME}/.govbot/repos/wy-legislation" ]; then
-            echo "::error::govbot clone failed - repository directory not created"
+          # Verify at least one repository was cloned
+          REPO_COUNT=$(ls -1 "${HOME}/.govbot/repos" 2>/dev/null | wc -l)
+          if [ "$REPO_COUNT" -eq 0 ]; then
+            echo "::error::govbot clone all failed - no repositories were cloned"
             exit 1
           fi
 
-          echo "Clone completed successfully"
+          echo "Clone completed successfully - $REPO_COUNT repositories"
 
       - name: Run govbot logs and validate output
         id: logs

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,91 @@
+name: Govbot Nightly Synthetic Test
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/test-nightly.yml'
+
+jobs:
+  synthetic-test:
+    name: Synthetic Real-World Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install govbot via install script
+        run: |
+          sh -c "$(curl -fsSL https://raw.githubusercontent.com/windy-civi/toolkit/main/actions/govbot/scripts/install-nightly.sh)"
+          # Add to PATH for subsequent steps
+          echo "${HOME}/.govbot/bin" >> $GITHUB_PATH
+
+      - name: Verify govbot installation
+        run: |
+          govbot --version
+          govbot --help
+
+      - name: Run govbot clone (Wyoming - small state for fast testing)
+        id: clone
+        run: |
+          # Clone a single small state repository
+          govbot clone wy --verbose
+
+          # Verify the clone produced output
+          if [ ! -d "${HOME}/.govbot/repos/wy-legislation" ]; then
+            echo "::error::govbot clone failed - repository directory not created"
+            exit 1
+          fi
+
+          echo "Clone completed successfully"
+
+      - name: Run govbot logs and validate output
+        id: logs
+        run: |
+          # Capture logs output
+          OUTPUT=$(govbot logs --limit 10 2>&1) || {
+            echo "::error::govbot logs command failed with exit code $?"
+            echo "Output: $OUTPUT"
+            exit 1
+          }
+
+          # Check for empty output
+          if [ -z "$OUTPUT" ]; then
+            echo "::error::govbot logs produced empty output"
+            exit 1
+          fi
+
+          # Count number of log entries (each line should be valid JSON)
+          LINE_COUNT=$(echo "$OUTPUT" | wc -l)
+          echo "Log entries retrieved: $LINE_COUNT"
+
+          if [ "$LINE_COUNT" -eq 0 ]; then
+            echo "::error::govbot logs produced zero entries"
+            exit 1
+          fi
+
+          # Validate that output is valid JSON Lines format
+          echo "$OUTPUT" | while read -r line; do
+            if [ -n "$line" ]; then
+              echo "$line" | jq . > /dev/null 2>&1 || {
+                echo "::error::Invalid JSON in govbot logs output"
+                echo "Invalid line: $line"
+                exit 1
+              }
+            fi
+          done
+
+          echo "Logs validation completed successfully"
+          echo "Sample output (first 3 lines):"
+          echo "$OUTPUT" | head -3
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Govbot Nightly Synthetic Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Install | ${{ steps.clone.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Clone | ${{ steps.clone.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Logs | ${{ steps.logs.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs daily at 6 AM UTC to validate
the basic govbot installation and usage flow:

- Installs govbot via the published nightly install script
- Runs 'govbot clone wy' to test repository cloning
- Runs 'govbot logs' and validates the output is non-empty valid JSON
- Reports test results in the GitHub Actions summary

This catches regressions in the install process and core functionality
before users encounter them.

https://claude.ai/code/session_019mSaEYKo7MFt1VVeTKNGfk