### PR TITLE
Fix mdbook install step using peaceiris/actions-mdbook

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -34,6 +38,7 @@ jobs:
           path: docs/book
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,10 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install mdbook
-        run: |
-          mkdir -p $HOME/bin
-          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C $HOME/bin
-          echo "$HOME/bin" >> $GITHUB_PATH
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
 
       - name: Build docs
         run: mdbook build docs


### PR DESCRIPTION
The manual curl install failed due to incorrect tarball URL. Switch to the dedicated action for reliable installation.

https://claude.ai/code/session_015fHEs4euPvsn9cEXrkkhiS