### PR TITLE
fix: correct dict assignment and field name in write_action_logs

### DIFF
--- a/actions/format/utils/file_utils.py
+++ b/actions/format/utils/file_utils.py
@@ -230,7 +230,6 @@ def write_action_logs(
         {timestamp}_{slugified_description}.json
     """
     for action in actions:
-        action_log = {}
         date = action.get("date")
         desc = action.get("description", "no_description")
         timestamp = format_timestamp(date) if date else "unknown"
@@ -255,19 +254,19 @@ def write_action_logs(
             filename = f"{timestamp}_{slug}.json"
 
         output_file = Path(log_folder) / filename
-        action_log.add({
+        action_log = {
             "action": {
                 "description": action.get("description", "no_description"),
                 "occurred_at": action.get("date", "no_date"),
                 "jurisdiction_id": action.get("organization_id", "no_jurisdiction"),
                 "session_id": session_id,
                 "entity_type": "bill",
-                "classifications": action.get("classifications", []),
+                "classifications": action.get("classification", []),
                 "related_entities": action.get("related_entities", []),
                 "sources": sources,
             },
             "bill_id": bill_identifier
-        })
+        }
 
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(action_log, f, indent=2)


### PR DESCRIPTION
## Summary

- Fixes `AttributeError: 'dict' object has no attribute 'add'` — `.add()` is a `set` method, not `dict`. Changed to direct dict assignment.
- Fixes wrong field key: `action.get("classifications", [])` → `action.get("classification", [])` to match the actual action data schema.

Both bugs were introduced in #37. Every bill with actions was crashing at the `write_action_logs` call.

## Test plan

- [ ] Trigger the format action on a state repo (e.g. ga-legislation-2test) and confirm it completes without `AttributeError`
- [ ] Verify log files are written with the `classifications` field populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)