### PR TITLE
feat: add DC to pipeline-manager config and regenerate templates

### DIFF
--- a/actions/pipeline-manager/chn-openstates-files.yml
+++ b/actions/pipeline-manager/chn-openstates-files.yml
@@ -62,6 +62,12 @@ locales:
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Connecticut
+  dc:
+    disabled_jobs:
+      - extract-text
+    template: openstates-to-ocd-files
+    toolkit_branch: main
+    name: District of Columbia
   de:
     disabled_jobs:
       - extract-text


### PR DESCRIPTION
Adds District of Columbia to chn-openstates-files.yml so apply.py will create govbot-data/dc-legislation and push the format workflow. DC has a working scraper in govbot-openstates-scrapers but was missing a format repo entirely.