### PR TITLE
fix: write failure_type to GITHUB_ENV to fix blank summary table row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ sample_data/*
 project_docs/*
 WORKFLOW_PREFERENCES.md
 actions/scrape/session-notes-*.md
+actions/scrape/combined-status-*.md
 
 # Temporary files
 *.tmp

--- a/actions/scrape/action.yml
+++ b/actions/scrape/action.yml
@@ -223,7 +223,12 @@ runs:
           STATUS="❌ Failed"
         fi
 
-        # Read parsed data from summary JSON if available
+        # failure_type and exit_code come from GITHUB_ENV (set by scrape.sh directly)
+        # so they are always available even if the summary JSON path doesn't resolve.
+        FAILURE_TYPE="${SCRAPE_FAILURE_TYPE:-NONE}"
+        IS_ACTIVE_BLOCK="${SCRAPE_IS_ACTIVE_BLOCK:-false}"
+
+        # Read counts/duration from summary JSON if available
         if [ -f "$SUMMARY_FILE" ]; then
           # Main data objects
           BILL_COUNT=$(jq -r '.objects.bill // 0' "$SUMMARY_FILE")
@@ -236,8 +241,6 @@ runs:
           DURATION=$(jq -r '.duration // "unknown"' "$SUMMARY_FILE")
           ERROR_COUNT=$(jq -r '.error_count // 0' "$SUMMARY_FILE")
           ERRORS=$(jq -r '.errors | if length > 0 then .[] else empty end' "$SUMMARY_FILE" 2>/dev/null || echo "")
-          FAILURE_TYPE=$(jq -r '.failure_type // "NONE"' "$SUMMARY_FILE")
-          IS_ACTIVE_BLOCK=$(jq -r '.is_active_block // false' "$SUMMARY_FILE")
         else
           BILL_COUNT="N/A"
           VOTE_EVENT_COUNT="N/A"
@@ -247,8 +250,6 @@ runs:
           DURATION="N/A"
           ERROR_COUNT=0
           ERRORS=""
-          FAILURE_TYPE="NONE"
-          IS_ACTIVE_BLOCK="false"
         fi
 
         # Calculate metadata total
@@ -317,9 +318,9 @@ runs:
           exit 0
         fi
 
-        EXIT_CODE=$(jq -r '.exit_code // 0' "$SUMMARY_FILE")
-        FAILURE_TYPE=$(jq -r '.failure_type // "UNKNOWN"' "$SUMMARY_FILE")
-        IS_ACTIVE_BLOCK=$(jq -r '.is_active_block // false' "$SUMMARY_FILE")
+        EXIT_CODE="${SCRAPE_EXIT_CODE:-$(jq -r '.exit_code // 0' "$SUMMARY_FILE" 2>/dev/null || echo "0")}"
+        FAILURE_TYPE="${SCRAPE_FAILURE_TYPE:-$(jq -r '.failure_type // "UNKNOWN"' "$SUMMARY_FILE" 2>/dev/null || echo "UNKNOWN")}"
+        IS_ACTIVE_BLOCK="${SCRAPE_IS_ACTIVE_BLOCK:-$(jq -r '.is_active_block // false' "$SUMMARY_FILE" 2>/dev/null || echo "false")}"
 
         if [ "$EXIT_CODE" = "0" ]; then
           echo "✅ Scrape succeeded (failure_type: $FAILURE_TYPE)"

--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -256,5 +256,12 @@ EOF
 
 echo "📊 Scrape summary written to $SUMMARY_FILE"
 
+# Export to GITHUB_ENV so downstream steps can read these without re-parsing the JSON file
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "SCRAPE_FAILURE_TYPE=${FAILURE_TYPE}" >> "$GITHUB_ENV"
+  echo "SCRAPE_IS_ACTIVE_BLOCK=${IS_ACTIVE_BLOCK}" >> "$GITHUB_ENV"
+  echo "SCRAPE_EXIT_CODE=${exit_code}" >> "$GITHUB_ENV"
+fi
+
 exit $exit_code
 


### PR DESCRIPTION
## Summary

The `⚠️ Failure Type` row in the GitHub Actions scrape summary table was rendering blank for some states (observed on LA).

**Root cause:** The `Write scrape summary` step checks `if [ -f "$SUMMARY_FILE" ]` to read `failure_type` from the JSON file. This check was returning false in some runs (path not resolving as expected), causing the `else` branch to overwrite `FAILURE_TYPE` with `"NONE"` — so the condition to print the row was never met.

**Fix:** `scrape.sh` now writes `FAILURE_TYPE`, `IS_ACTIVE_BLOCK`, and `exit_code` directly to `$GITHUB_ENV` after the scrape. Downstream steps use these env vars as the source of truth, falling back to the JSON file only for counts and duration. This makes failure type reporting robust regardless of JSON file path resolution.

## Test plan
- [ ] Trigger a manual run on a state with a known failure type (e.g. `nj`, `mp`) and confirm the `⚠️ Failure Type` row renders correctly in the GH Actions summary table