### PR TITLE
docs: clean up action notes and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 # 🏛️ govbot
 
-- Download the legislation of [47 states/jurisdicitions](github.com/govbot-data) in under 1 minute.
-- Tag/summarize bills with with private/local models optimized to run on free Github Actions.
+- Download the legislation of [56 states/jurisdictions](https://github.com/orgs/govbot-data/repositories) in under 1 minute.
+- Tag/summarize bills with private/local models optimized to run on free Github Actions.
 
-`govbot` enables distributed data anaylsis of government updates via a friendly terminal interface. Git repos function as datasets, including the legislation of all 47 states/jurisdictions.
+`govbot` enables distributed data analysis of government updates via a friendly terminal interface. Git repos function as datasets, including the legislation of all 56 states/jurisdictions.
 
 ## Example Projects
 
@@ -61,15 +61,11 @@ govbot --help              # see all commands and options
 
 # 🏛️ Govbot Legislation Data Catalogs
 
-See the data catalogs [here](//github.com/govbot-data).
+Formatted legislation data for all 56 jurisdictions is available at [github.com/govbot-data](https://github.com/orgs/govbot-data/repositories).
 
-- Nearly all state governments
-- Federal
-
-WIP: Ideally, these scripts should be accessible via the following ways.
-
-- CLI / Unix pipe friendliness where possible. CLI is the most portable of solutions.
-- GitHub Actionable if possible
+- All 50 US states
+- Federal (USA)
+- DC, Puerto Rico, Guam, US Virgin Islands, Northern Mariana Islands
 
 ## Contribute
 

--- a/actions/pipeline-manager/README.md
+++ b/actions/pipeline-manager/README.md
@@ -1,56 +1,50 @@
-Tools to manage the potentially 100s or 10s of 1000s of repos inside `windy-civi-pipelines`.
+# Pipeline Manager
 
-## Template System
+Manages all 57 scraper repos and 57 format repos via a declarative config + template system.
 
-This directory includes a template rendering system that generates files for each locale based on a config YAML file. Uses bash and standard tools - no pip installs required!
+## Config files
 
-### Usage
+- `chn-openstates-scrape.yml` — scraper repos (`govbot-openstates-scrapers/{state}-legislation`)
+- `chn-openstates-files.yml` — format repos (`chn-openstates-files/{state}-legislation`)
 
-Render templates for all managed locales:
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `render.py` | Renders templates for all locales into `generated/` |
+| `apply.py` | Pushes generated files to GitHub repos via `gh` CLI |
+| `check-sessions.py` | Queries OpenStates API, flips scraper repos between active and paused templates |
+
+## Templates
+
+Templates live in `templates/` and use `✏️{ variable }✏️` substitution syntax:
+
+- `openstates-scrape/` — active scraper (daily cron at 8 AM UTC)
+- `openstates-scrape-paused/` — paused scraper (workflow_dispatch only, for out-of-session states)
+- `openstates-to-ocd-files/` — format/transform pipeline
+
+## Session management
+
+`check-sessions.py` runs daily via `.github/workflows/check-sessions.yml`. It queries the OpenStates v3 API for each of the 56 jurisdictions and flips `chn-openstates-scrape.yml` between `openstates-scrape` and `openstates-scrape-paused` based on whether a legislative session is currently active.
+
+- **Weekdays**: applies changes only for locales whose template actually changed
+- **Sundays**: applies all 56 repos as a full reconciliation pass
+
+## Common commands
 
 ```bash
-./render.sh [output_directory]
+# Render templates without pushing
+python3 render.py -c chn-openstates-scrape.yml
+
+# Push template changes for specific test states
+python3 apply.py --config chn-openstates-scrape.yml --test-states al,ak,wy
+
+# Push to all 56 scraper repos
+python3 apply.py --config chn-openstates-scrape.yml --all-states --no-delete
+
+# Check session status (dry run — no writes)
+OPENSTATES_API_KEY=your_key python3 check-sessions.py --dry-run
+
+# Check specific states only
+OPENSTATES_API_KEY=your_key python3 check-sessions.py --dry-run --only nc,pa,dc
 ```
-
-By default, rendered files are written to `generated/` directory, organized by locale:
-
-```
-generated/
-  al/
-    workflow.yml
-    ...
-  ak/
-    workflow.yml
-    ...
-```
-
-### Template Variables
-
-In your template files, you can use the following variables:
-
-- **Variables**: `✏️{ variable }✏️` - Replaced with the actual value from the config YAML file
-
-Example:
-
-```yaml
-name: Scrape and Format Data For ✏️{ locale }✏️
-env:
-  STATE_CODE: ✏️{ locale }✏️
-  TOOLKIT_BRANCH: ✏️{ toolkit_branch }✏️
-```
-
-**Note**:
-
-- GitHub Actions syntax like `${{ env.STATE_CODE }}` will be left untouched and work correctly in the rendered output.
-- This is a simple variable substitution system - for complex logic, use shell scripting or other tools.
-
-### Directory Structure
-
-The template system maintains the exact directory structure from `templates/`:
-
-- `templates/workflow.yml.j2` → `generated/{locale}/workflow.yml`
-- `templates/subdir/file.txt.j2` → `generated/{locale}/subdir/file.txt`
-
-### Example
-
-See `templates/openstates-to-ocd-decentralized/workflow.yml.j2` for a complete example template that includes both template variables and GitHub Actions syntax.

--- a/actions/scrape/error-tracking.md
+++ b/actions/scrape/error-tracking.md
@@ -4,38 +4,19 @@ Track the status of the scrape action across all 57 jurisdictions.
 
 **Statuses:** `✅ OK` | `❌ Broken` | `⚠️ Intermittent` | `⏸️ Unknown`
 
-Last updated: 2026-06-27
+Last updated: 2026-06-30
+
+## Session Pause Automation
+
+Out-of-session states are now automatically paused via `check-sessions.py` (`.github/workflows/check-sessions.yml`). States where the scraper returns no data because the legislature is not in session will have their workflow flipped to `openstates-scrape-paused` (dispatch-only). This runs daily and reconciles all repos every Sunday.
 
 ## Summary of Failures
 
 ### A — Out of Session (scraper finds no data, legislature not meeting)
-These should not be hard failures. `ct`, `nm`
-
-**Fix in progress:** Branch `fix/scrape-no-new-data` updates `action.yml` to treat a non-zero
-scraper exit code as a soft failure when fallback data is available. The workflow yml files in
-`ct-legislation` and `nm-legislation` repos have been temporarily pointed
-to `chihacknight/govbot/actions/scrape@fix/scrape-no-new-data` for testing.
-
-✅ All test repos updated back to `@main` on 2026-06-27.
+These are soft failures — `action.yml` treats a non-zero exit code as a warning when fallback data is available (merged in PR #42). Out-of-session states are automatically paused by the session-check automation above.
 
 ### F — Active Scraper Blocking (state is deliberately preventing automated access to public data)
-`tx`
-
-Texas returns `ConnectionRefusedError [Errno 111]` — the server is actively refusing TCP
-connections from GitHub Actions IP ranges before any HTTP request is even made. This is not
-an out-of-session issue: the Texas legislature actively meets and produces data, but access
-is being blocked. This is a transparency problem and a priority to fix.
-
-Unlike a timeout or a site being down, connection refused is an intentional firewall-level
-decision. The `fix/scrape-no-new-data` branch will prevent daily hard failures for TX by
-falling back to prior data, but that is a stopgap — TX data will go stale without a real fix.
-
-**Options to investigate:**
-- Route TX scrapes through a non-GitHub-Actions IP (self-hosted runner, proxy, or VPS)
-- Check if OpenStates has an alternative data source for TX that doesn't hit capitol.texas.gov directly
-- Monitor whether other civic tech orgs (e.g., Plural Policy, LegiScan) have TX data available
-
-✅ tx-legislation updated back to `@main` on 2026-06-27.
+`tx` — **Resolved.** Texas blocks GitHub Actions IP ranges at the firewall level. Fixed by routing all TX scrapes through a self-hosted runner on Tamara's laptop (`~/actions-runner/`). See `tx-backfill-runbook.md` for backfill procedures.
 
 ### B — Government Site Structure Changed (need OpenStates scraper fixes)
 The source website changed its HTML/API; the OpenStates scraper is broken until updated upstream.
@@ -84,7 +65,7 @@ Files to update: `actions/scrape/action.yml`, `actions/format/action.yml`, `acti
 | California | ca | ✅ OK | | |
 | Colorado | co | ✅ OK | | |
 | Connecticut | ct | ❌ Broken | `ScrapeError: no objects returned from CTBillScraper scrape` | Category A — Legislature likely out of session |
-| District of Columbia | dc | ❌ Broken | `S6_VALIDATION` (or `H3_RATE_LIMITED` intermittently) | Category C — Non-PDF attachments in `leg_details["actions"]` set `mimetype=None`, failing OCD schema validation on `media_type`. Scraper crashes mid-run; bills after the failing record are dropped. DC_API_KEY is working fine. PR submitted to openstates/openstates-scrapers: fix/dc-media-type-null. 2026-06-27 run showed H3_RATE_LIMITED — may have gotten further before dying; validation error is the root cause. |
+| District of Columbia | dc | ✅ OK | | PRs #5706 and #5711 merged — mimetype=None and PDF query string issues both fixed. |
 | Delaware | de | ✅ OK | | |
 | Florida | fl | ✅ OK | | |
 | Georgia | ga | ✅ OK | | |
@@ -110,7 +91,7 @@ Files to update: `actions/scrape/action.yml`, `actions/format/action.yml`, `acti
 | North Dakota | nd | ✅ OK | | |
 | Nebraska | ne | ✅ OK | | |
 | New Hampshire | nh | ❌ Broken | `H3_RATE_LIMITED` (was `ConnectTimeoutError`) | Category D — Session ended 2026-03-14; site returning rate limit errors. Timeout observed previously; may rotate between the two. |
-| New Jersey | nj | ❌ Broken | `KeyError: 'A4029'` | Category B — Bill lookup dict missing expected key; site format changed |
+| New Jersey | nj | ✅ OK | | PR #5707 merged — vote bill_id guard added. |
 | New Mexico | nm | ❌ Broken | `ValueError: ftp://www.nmlegis.gov/other/ contains no matching files` | Category A — NM FTP has no files; likely out of session |
 | Nevada | nv | ✅ OK | | |
 | New York | ny | ✅ OK | | Requires `NEW_YORK_API_KEY` secret (confirmed present). |
@@ -123,7 +104,7 @@ Files to update: `actions/scrape/action.yml`, `actions/format/action.yml`, `acti
 | South Carolina | sc | ✅ OK | | |
 | South Dakota | sd | ✅ OK | | |
 | Tennessee | tn | ❌ Broken | `H4_SERVER_DOWN` (was `IndexError`) | Category B — Session ended 2026-04-15; server returning 503. IndexError (site structure bug) is the real issue to fix when 2027 session opens. |
-| Texas | tx | ❌ Broken | `ConnectionError: capitol.texas.gov connection refused` | Category F — Active IP block; TX rotates between connection refused (N1) and 503 (H4) depending on the run |
+| Texas | tx | ✅ OK | | Self-hosted runner on Tamara's laptop bypasses IP block. Backfill complete (89R, 891, 892). See `tx-backfill-runbook.md`. |
 | USA | usa | ✅ OK | | |
 | Utah | ut | ✅ OK | | |
 | Virginia | va | ❌ Broken | Workflows disabled | Category E — No runs since 2026-04-01; scheduled runs appear disabled. Requires `USER_AGENT` secret (confirmed present). Uses `csv_bills` scraper, not standard bills scraper. |

--- a/actions/scrape/scrape-failure-types.md
+++ b/actions/scrape/scrape-failure-types.md
@@ -44,22 +44,22 @@ fallback data exists, so stale data doesn't quietly accumulate unnoticed.
 
 ---
 
-## Known State Examples (as of 2026-06-26)
+## Known State Examples (as of 2026-06-30)
 
 | State | Error Type | Notes |
 |---|---|---|
-| tx | `N1` — Active block | `capitol.texas.gov` refusing all connections from GitHub Actions IPs. Priority to fix — TX actively tries to obscure legislative activity. |
-| nh | `N2` — Persistent timeout | `gc.nh.gov` timing out consistently. |
-| wi | `N2` — Transient timeout | `docs.legis.wisconsin.gov` timed out 2026-06-26 only; intermittent. |
-| ct | `S1` — Out of session | `CTBillScraper` returns 0 objects. Legislature not in session. |
-| nm | `S2` — Out of session | NM FTP has no files. Legislature not in session. |
-| az | `S3` — Session config | `AssertionError: Session ID not in bill list`. Scraper session mapping stale. |
-| dc | `S6` — Validation | `ScrapeValueError: validation of Bill failed`. OCD schema mismatch. Requires `DC_API_KEY`. |
-| mp | `S6` — Validation | `ScrapeValueError: validation of Bill failed`. OCD schema mismatch. |
-| hi | `S4` — Site structure | `KeyError: 'Report Title'`. Hawaii site changed structure. |
-| nj | `S4` — Site structure | `KeyError: 'A4029'`. Bill lookup key missing; site format changed. |
-| la | `S5` — Site structure | `ValueError: not enough values to unpack (expected 5, got 4)`. |
-| tn | `S5` — Site structure | `IndexError: list index out of range`. TN site structure changed. |
+| tx | ✅ Resolved | Was `N1` — self-hosted runner on Tamara's laptop bypasses IP block. |
+| nh | `N2` — Persistent timeout | `gc.nh.gov` timing out. Out of session — paused by automation. |
+| wi | `N2` — Transient timeout | `docs.legis.wisconsin.gov` intermittent; not consistent. |
+| ct | `S1` — Out of session | `CTBillScraper` returns 0 objects. Paused by session automation. |
+| nm | `S2` — Out of session | NM FTP has no files. Paused by session automation. |
+| az | `S3` — Session config | `AssertionError: Session ID not in bill list`. Stale session mapping — re-check when 2027 session opens. |
+| dc | ✅ Resolved | Was `S6` — PRs #5706 and #5711 merged upstream. |
+| mp | `S6` — Validation | `ScrapeValueError: validation of Bill failed`. OCD schema mismatch. No session data in OpenStates. |
+| hi | `S4` — Site structure | `KeyError: 'Report Title'`. Hawaii site changed structure. Out of session — paused by automation. |
+| nj | ✅ Resolved | Was `S4` — PR #5707 merged upstream. |
+| la | `S5` — Site structure | `ValueError: not enough values to unpack (expected 5, got 4)`. Out of session — paused by automation. |
+| tn | `S5` — Site structure | `IndexError: list index out of range`. TN site structure changed. Out of session — paused by automation. |
 
 ---
 
@@ -81,4 +81,4 @@ S3, S4, S5, S6  →  SCRAPER BROKEN — warn; use stale fallback; needs upstream
 - [x] Encode `failure_type` and `is_active_block` fields in `scrape-summary.json` — done in `scrape.sh`
 - [x] Surface stale-data age in GitHub Actions summary when fallback is used — done in `action.yml`
 - [x] For active blocks (N1, N3, N4, H1): post a visible `::error::` annotation even when fallback succeeds — done in `action.yml`
-- [ ] Investigate TX specifically — route scrape through non-GitHub-Actions IP to confirm IP block vs. all-traffic block
+- [x] Investigate TX specifically — confirmed GitHub Actions IP block; resolved via self-hosted runner


### PR DESCRIPTION
## Summary

- Rewrite `actions/pipeline-manager/README.md` — was referencing old `windy-civi-pipelines` org and `render.sh` (bash); now documents `render.py`, `apply.py`, `check-sessions.py`, and session-pause automation
- Update `actions/scrape/error-tracking.md` — mark DC, NJ, TX resolved; remove stale `fix/scrape-no-new-data` branch note (merged PR #42); add session-pause automation context
- Update `actions/scrape/scrape-failure-types.md` — update known examples table, mark TX TODO done
- Update root `README.md` — fix jurisdiction count (47 → 56), fix `govbot-data` org link, fix typos, remove stale WIP section

## Test plan

- [ ] Spot-check links in README resolve correctly
- [ ] Review error-tracking table for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)