### PR TITLE
fix: apply.py self-configures git auth and shows full error output on failure

### DIFF
--- a/actions/pipeline-manager/apply.py
+++ b/actions/pipeline-manager/apply.py
@@ -46,6 +46,14 @@ def setup_git_auth():
     )
 
 
+def get_clone_url(full_repo: str) -> str:
+    """Return an HTTPS clone URL with embedded GH_TOKEN credentials when available."""
+    token = os.environ.get("GH_TOKEN")
+    if token:
+        return f"https://x-access-token:{token}@github.com/{full_repo}.git"
+    return f"https://github.com/{full_repo}.git"
+
+
 def check_requirements():
     """Check if required tools are installed and authenticated."""
     # Check if gh CLI is installed
@@ -236,7 +244,7 @@ def create_repo(
 
         try:
             run_shell(
-                f"gh repo clone '{full_repo}' '{repo_dir}' -- --depth 1 --quiet",
+                f"git clone '{get_clone_url(full_repo)}' '{repo_dir}' --depth 1 --quiet",
                 check=True,
             )
 
@@ -354,7 +362,7 @@ def update_repo(
     try:
         # Clone repo
         run_shell(
-            f"gh repo clone '{full_repo}' '{repo_dir}' -- --depth 1 --quiet", check=True
+            f"git clone '{get_clone_url(full_repo)}' '{repo_dir}' --depth 1 --quiet", check=True
         )
 
         changes_made = False

--- a/actions/pipeline-manager/apply.py
+++ b/actions/pipeline-manager/apply.py
@@ -26,8 +26,11 @@ def run_shell(cmd: str, check: bool = True, capture_output: bool = True) -> str:
             cmd, shell=True, check=check, capture_output=capture_output, text=True
         )
     except subprocess.CalledProcessError as e:
-        if capture_output and e.stderr and e.stderr.strip():
-            print(f"     stderr: {e.stderr.strip()}", file=sys.stderr)
+        if capture_output:
+            if e.stdout and e.stdout.strip():
+                print(f"     stdout: {e.stdout.strip()}", file=sys.stderr)
+            if e.stderr and e.stderr.strip():
+                print(f"     stderr: {e.stderr.strip()}", file=sys.stderr)
         raise
     if capture_output:
         return result.stdout.strip()

--- a/actions/pipeline-manager/apply.py
+++ b/actions/pipeline-manager/apply.py
@@ -21,12 +21,29 @@ from typing import Dict, Set, List, Tuple, Optional
 
 def run_shell(cmd: str, check: bool = True, capture_output: bool = True) -> str:
     """Run a shell command and return the result."""
-    result = subprocess.run(
-        cmd, shell=True, check=check, capture_output=capture_output, text=True
-    )
+    try:
+        result = subprocess.run(
+            cmd, shell=True, check=check, capture_output=capture_output, text=True
+        )
+    except subprocess.CalledProcessError as e:
+        if capture_output and e.stderr and e.stderr.strip():
+            print(f"     stderr: {e.stderr.strip()}", file=sys.stderr)
+        raise
     if capture_output:
         return result.stdout.strip()
     return ""
+
+
+def setup_git_auth():
+    """Configure git to use GH_TOKEN for HTTPS pushes to github.com."""
+    token = os.environ.get("GH_TOKEN")
+    if not token:
+        return
+    subprocess.run(
+        f'git config --global url."https://x-access-token:{token}@github.com/".insteadOf "https://github.com/"',
+        shell=True,
+        check=True,
+    )
 
 
 def check_requirements():
@@ -516,6 +533,7 @@ def main():
 
     # Check requirements
     check_requirements()
+    setup_git_auth()
 
     # Get script directory
     script_dir = Path(__file__).parent


### PR DESCRIPTION
## Summary
- `apply.py` now calls `setup_git_auth()` at startup to configure the global git URL rewrite from `GH_TOKEN`, making it self-contained instead of relying on the workflow to do it
- `apply.py` now uses `git clone` with a token-embedded URL instead of `gh repo clone`, ensuring the remote URL stored in `.git/config` always has credentials for pushes
- `run_shell()` now prints both stdout and stderr when a command fails, so errors like "refusing to allow PAT without workflow scope" are visible in CI logs instead of being swallowed

## What was happening
All pushes were failing silently — `capture_output=True` was eating the actual git error. Once stdout/stderr printing was added, we discovered the real issue: **APPLY_TOKEN was missing the `workflow` scope**, which GitHub requires to push `.github/workflows/` files via a PAT.

## Test plan
- [x] Triggered Apply Templates on this branch with `states=wy` → `✅ Updated 1/1 repositories`
- [ ] Merge and trigger Apply Templates with `config=scrape`, `states` blank → should update all 56 state repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)