### PR TITLE
fix: update scrape action reference to chihacknight/govbot

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run scraper action
         id: scrape
-        uses: windy-civi/toolkit/actions/scrape@main
+        uses: chihacknight/govbot/actions/scrape@main
         with:
           state: ${{ env.STATE_CODE }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,6 @@
-name: OpenStates Scrape for pr
+name: OpenStates Scrape for id
 
 on:
-  schedule:
-    - cron: "0 8 * * *" # Daily at 8:00 AM UTC (2:00 AM Chicago time)
   workflow_dispatch:
     inputs:
       force-update:
@@ -11,7 +9,7 @@ on:
         default: false
 
 env:
-  STATE_CODE: pr
+  STATE_CODE: id
 
 jobs:
   scrape:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/README.md
@@ -1,0 +1,8 @@
+# 🏛️ Idaho Open States Scraper (Paused)
+
+Scheduled scraping is paused — Idaho is currently out of session.
+
+The workflow can still be triggered manually via workflow_dispatch when needed.
+
+Session status is checked daily by the govbot `check-sessions` workflow, which will
+automatically switch this repo back to the active scrape template when a new session begins.

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,6 @@
-name: OpenStates Scrape for pr
+name: OpenStates Scrape for mt
 
 on:
-  schedule:
-    - cron: "0 8 * * *" # Daily at 8:00 AM UTC (2:00 AM Chicago time)
   workflow_dispatch:
     inputs:
       force-update:
@@ -11,7 +9,7 @@ on:
         default: false
 
 env:
-  STATE_CODE: pr
+  STATE_CODE: mt
 
 jobs:
   scrape:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/README.md
@@ -1,0 +1,8 @@
+# 🏛️ Montana Open States Scraper (Paused)
+
+Scheduled scraping is paused — Montana is currently out of session.
+
+The workflow can still be triggered manually via workflow_dispatch when needed.
+
+Session status is checked daily by the govbot `check-sessions` workflow, which will
+automatically switch this repo back to the active scrape template when a new session begins.

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,6 @@
-name: OpenStates Scrape for pr
+name: OpenStates Scrape for wy
 
 on:
-  schedule:
-    - cron: "0 8 * * *" # Daily at 8:00 AM UTC (2:00 AM Chicago time)
   workflow_dispatch:
     inputs:
       force-update:
@@ -11,7 +9,7 @@ on:
         default: false
 
 env:
-  STATE_CODE: pr
+  STATE_CODE: wy
 
 jobs:
   scrape:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/README.md
@@ -1,0 +1,8 @@
+# 🏛️ Wyoming Open States Scraper (Paused)
+
+Scheduled scraping is paused — Wyoming is currently out of session.
+
+The workflow can still be triggered manually via workflow_dispatch when needed.
+
+Session status is checked daily by the govbot `check-sessions` workflow, which will
+automatically switch this repo back to the active scrape template when a new session begins.

--- a/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run scraper action
         id: scrape
-        uses: windy-civi/toolkit/actions/scrape@✏️{ locale.toolkit_branch }✏️
+        uses: chihacknight/govbot/actions/scrape@✏️{ locale.toolkit_branch }✏️
         with:
           state: ${{ env.STATE_CODE }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run scraper action
         id: scrape
-        uses: windy-civi/toolkit/actions/scrape@✏️{ locale.toolkit_branch }✏️
+        uses: chihacknight/govbot/actions/scrape@✏️{ locale.toolkit_branch }✏️
         with:
           state: ${{ env.STATE_CODE }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Templates were pointing to windy-civi/toolkit/actions/scrape which caused all state repos to use the wrong action after the last apply run.