### PR TITLE
fix: correct VA scraper session argument order and update to 2026

### DIFF
--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -63,8 +63,6 @@ for i in 1 2 3; do
   docker pull ${DOCKER_IMAGE} || true
   # Capture output to log file while still displaying it
   # Virginia uses csv_bills scraper (no API key needed)
-  # NOTE: VA 2026 session starts Jan 14, 2026. Will fail until openstates-scrapers
-  # Docker image is updated with 2026 session mapping. Code is correct and ready.
   if [ "${STATE}" = "va" ]; then
     if docker run \
         --dns 8.8.8.8 --dns 1.1.1.1 \
@@ -72,7 +70,7 @@ for i in 1 2 3; do
         -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
         "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
         ${DOCKER_IMAGE} \
-        ${STATE} --session=2025 csv_bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+        ${STATE} csv_bills --session=2026 --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
     then
       exit_code=0
       break


### PR DESCRIPTION
## Summary

- Fixes `--session` arg placement in `scrape.sh` for VA — it must come *after* the scraper name (`csv_bills`), not before, or OpenStates rejects it
- Updates session from `2025` to `2026` now that the 2026 session mapping is in the Docker image

## Context

VA workflows were disabled since 2026-04-01. Root cause: `scrape.sh` was passing `--session=2025 csv_bills` but OpenStates requires `csv_bills --session=2025`. Companion fix for the hardcoded session ID inside the scraper itself is in OpenStates PR [#5717](https://github.com/openstates/openstates-scrapers/pull/5717).

After this merges, an `apply-templates` run is needed to push the updated `scrape.sh` to `va-legislation`.

## Test plan

- [ ] Merge OpenStates PR #5717 (or confirm it's merged)
- [ ] Merge this PR
- [ ] Run apply-templates for VA
- [ ] Trigger manual dispatch on `va-legislation` and confirm bills are scraped

🤖 Generated with [Claude Code](https://claude.com/claude-code)