### PR TITLE
fix: restore correct --session argument order for VA csv_bills scraper

### DIFF
--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -70,7 +70,7 @@ for i in 1 2 3; do
         -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
         "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
         ${DOCKER_IMAGE} \
-        ${STATE} csv_bills --session=2026 --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+        ${STATE} --session=2026 csv_bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
     then
       exit_code=0
       break


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by our own PR #52
- `--session=2026` was accidentally moved to *after* the module name (`csv_bills`)
- `os-update` treats anything after the module name as kwargs for `scrape()`, causing `TypeError: scrape() got an unexpected keyword argument '--session'`
- The correct order is `STATE --session=SESSION MODULE [module-flags]`

**Note:** VA's currently active session is `2026S1` (special session), but `--session=2026` explicitly targets the regular session which ended March 2026 — this is intentional for backfill.

## Error from failing run
```
va (scrape)
  csv_bills: {'--session': '2026'}
TypeError: scrape() got an unexpected keyword argument '--session'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)