### PR TITLE
fix: correct VA csv_bills session kwarg syntax and scrape both 2026 sessions

### DIFF
--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -59,36 +59,66 @@ fi
 
 echo "🕷️ Scraping ${STATE} (with retries + DNS override)..."
 exit_code=1
-for i in 1 2 3; do
-  docker pull ${DOCKER_IMAGE} || true
-  # Capture output to log file while still displaying it
-  # Virginia uses csv_bills scraper (no API key needed)
-  if [ "${STATE}" = "va" ]; then
+
+if [ "${STATE}" = "va" ]; then
+  # Virginia uses csv_bills scraper for two sessions; run each independently with retries
+  va_regular_exit=1
+  for i in 1 2 3; do
+    docker pull ${DOCKER_IMAGE} || true
     if docker run \
         --dns 8.8.8.8 --dns 1.1.1.1 \
         -v "$(pwd)/_working/_data":/opt/openstates/openstates/_data \
         -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
         "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
         ${DOCKER_IMAGE} \
-        ${STATE} --session=2026 csv_bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+        ${STATE} csv_bills --scrape session=2026 --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+    then
+      va_regular_exit=0
+      break
+    fi
+    echo "⚠️ VA 2026 scrape attempt $i failed; sleeping 20s..." | tee -a "$SCRAPE_LOG"
+    sleep 20
+  done
+
+  va_special_exit=1
+  for i in 1 2 3; do
+    docker pull ${DOCKER_IMAGE} || true
+    if docker run \
+        --dns 8.8.8.8 --dns 1.1.1.1 \
+        -v "$(pwd)/_working/_data":/opt/openstates/openstates/_data \
+        -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
+        "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
+        ${DOCKER_IMAGE} \
+        ${STATE} csv_bills --scrape session=2026S1 --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+    then
+      va_special_exit=0
+      break
+    fi
+    echo "⚠️ VA 2026S1 scrape attempt $i failed; sleeping 20s..." | tee -a "$SCRAPE_LOG"
+    sleep 20
+  done
+
+  if [ $va_regular_exit -eq 0 ] && [ $va_special_exit -eq 0 ]; then
+    exit_code=0
+  fi
+else
+  for i in 1 2 3; do
+    docker pull ${DOCKER_IMAGE} || true
+    if docker run \
+        --dns 8.8.8.8 --dns 1.1.1.1 \
+        -v "$(pwd)/_working/_data":/opt/openstates/openstates/_data \
+        -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
+        "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
+        ${DOCKER_IMAGE} \
+        ${STATE} bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
     then
       exit_code=0
       break
     fi
-  elif docker run \
-      --dns 8.8.8.8 --dns 1.1.1.1 \
-      -v "$(pwd)/_working/_data":/opt/openstates/openstates/_data \
-      -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
-      "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
-      ${DOCKER_IMAGE} \
-      ${STATE} bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
-  then
-    exit_code=0
-    break
-  fi
-  echo "⚠️ scrape attempt $i failed; sleeping 20s..." | tee -a "$SCRAPE_LOG"
-  sleep 20
-done
+    echo "⚠️ scrape attempt $i failed; sleeping 20s..." | tee -a "$SCRAPE_LOG"
+    sleep 20
+  done
+fi
 
 # If anything was scraped, stage a tarball; otherwise fall back later
 JSON_DIR="_working/_data/${STATE}"


### PR DESCRIPTION
## Summary

- Fixes the VA scraper invocation in `scrape.sh` — `--session=2026` (flag syntax) has never worked in either position:
  - Before `csv_bills` → `CommandError: argument --session=2026 before scraper name`
  - After `csv_bills` but before `--scrape` → `TypeError: scrape() got an unexpected keyword argument '--session'`
- Correct syntax is `session=2026` passed as a kwarg after `--scrape`, consistent with how `os-update` passes args to `scrape()` (see comment in `bills.py`: `# os-update ma bills --scrape scrape_chunk_number=1`)
- Adds a second independent retry loop for `2026S1` (special session, Apr–May 2026) so both sessions are captured in one run
- Both sessions write into the same `_data/va/` output directory; `exit_code=0` only if both succeed
- Restructures the VA block out of the shared retry loop for clarity — no impact on other states

## Depends on
- OpenStates PR [#5717](https://github.com/openstates/openstates-scrapers/pull/5717) ✅ merged 2026-07-01 — fixes hardcoded `session_id="20251"` in `csv_bills.py`
- Docker image `openstates/scrapers:latest` must be rebuilt after #5717 merge before this will produce correct data

## Test plan
- [ ] Trigger a manual VA scrape run after merging and confirm both `2026` and `2026S1` produce bill JSON files
- [ ] Confirm other states are unaffected (change is gated behind `if [ "${STATE}" = "va" ]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)