### PR TITLE
docs: NH extraction confirmed clean (334/334) after data restore

### DIFF
--- a/actions/scrape/docs/2026-07-14-recovery-summary.md
+++ b/actions/scrape/docs/2026-07-14-recovery-summary.md
@@ -115,6 +115,7 @@ clean everywhere with zero failures. Extraction:
 | Arkansas | ✅ Clean | 2/2 bills extracted successfully, after a re-run (see below) |
 | New Mexico | ✅ 809/812 (99.6%) | 3 dead-link 404s on the source site, same minor category as Hawaii's known issue — not a real problem |
 | U.S. Virgin Islands | ✅ Clean | |
+| New Hampshire | ✅ Clean | 334/334 bills, 0 errors — run after the `scrape.sh` fallback-bug fix and full data restore (see above); confirms the restored data is fully extractable |
 
 **One real (and reassuring) finding along the way**: Arkansas and New Mexico both showed a
 hard `failure` on the *first* extraction attempt — but it turned out to be a sequencing


### PR DESCRIPTION
## Summary
- Small follow-up to #67 (which was squash-merged before this landed). NH's text extraction finished after that PR merged — confirms the restored data (from the `scrape.sh` fallback bug fix) is fully extractable: 334/334 bills, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)