### PR TITLE
feat: un-pause all 27 paused states, default self-hosted locales to tinyproxy

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -9,14 +9,33 @@ on:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: ak
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ 'self-hosted' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('self-hosted' == 'self-hosted' && 'ubuntu-latest' || 'self-hosted') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -41,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -1,20 +1,41 @@
 name: OpenStates Scrape for id
 
 on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
   workflow_dispatch:
     inputs:
       force-update:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: id
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ 'ubuntu-latest' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -39,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/README.md
@@ -1,8 +1,3 @@
-# 🏛️ Idaho Open States Scraper (Paused)
+# 🏛️ Idaho Open States Scraper
 
-Scheduled scraping is paused — Idaho is currently out of session.
-
-The workflow can still be triggered manually via workflow_dispatch when needed.
-
-Session status is checked daily by the govbot `check-sessions` workflow, which will
-automatically switch this repo back to the active scrape template when a new session begins.
+Runs the official openstates docker container to scrape data for legislation and push on a nightly basis.

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -1,20 +1,41 @@
 name: OpenStates Scrape for mt
 
 on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
   workflow_dispatch:
     inputs:
       force-update:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: mt
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ 'ubuntu-latest' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -39,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/README.md
@@ -1,8 +1,3 @@
-# 🏛️ Montana Open States Scraper (Paused)
+# 🏛️ Montana Open States Scraper
 
-Scheduled scraping is paused — Montana is currently out of session.
-
-The workflow can still be triggered manually via workflow_dispatch when needed.
-
-Session status is checked daily by the govbot `check-sessions` workflow, which will
-automatically switch this repo back to the active scrape template when a new session begins.
+Runs the official openstates docker container to scrape data for legislation and push on a nightly basis.

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
@@ -9,14 +9,33 @@ on:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: pr
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ 'ubuntu-latest' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -41,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -1,20 +1,41 @@
 name: OpenStates Scrape for wy
 
 on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
   workflow_dispatch:
     inputs:
       force-update:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: wy
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ 'ubuntu-latest' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -39,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/README.md
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/README.md
@@ -1,8 +1,3 @@
-# 🏛️ Wyoming Open States Scraper (Paused)
+# 🏛️ Wyoming Open States Scraper
 
-Scheduled scraping is paused — Wyoming is currently out of session.
-
-The workflow can still be triggered manually via workflow_dispatch when needed.
-
-Session status is checked daily by the govbot `check-sessions` workflow, which will
-automatically switch this repo back to the active scrape template when a new session begins.
+Runs the official openstates docker container to scrape data for legislation and push on a nightly basis.

--- a/actions/pipeline-manager/chn-openstates-scrape.yml
+++ b/actions/pipeline-manager/chn-openstates-scrape.yml
@@ -14,7 +14,7 @@ templates:
     - .github
 locales:
   al:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Alabama
     toolkit_branch: main
   ak:
@@ -23,7 +23,7 @@ locales:
     toolkit_branch: main
     runner: self-hosted
   az:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Arizona
     toolkit_branch: main
     runner: self-hosted
@@ -39,11 +39,11 @@ locales:
     name: California
     toolkit_branch: main
   co:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Colorado
     toolkit_branch: main
   ct:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Connecticut
     toolkit_branch: main
     runner: self-hosted
@@ -52,13 +52,13 @@ locales:
     name: District of Columbia
     toolkit_branch: main
   de:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Delaware
     toolkit_branch: main
     labels:
     - working
   fl:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Florida
     toolkit_branch: main
     runner: self-hosted
@@ -71,12 +71,12 @@ locales:
     labels:
     - working
   hi:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Hawaii
     toolkit_branch: main
     runner: self-hosted
   id:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Idaho
     toolkit_branch: main
   il:
@@ -104,13 +104,13 @@ locales:
     labels:
     - working
   ky:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Kentucky
     toolkit_branch: main
     labels:
     - working
   la:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Louisiana
     toolkit_branch: main
     labels:
@@ -120,7 +120,7 @@ locales:
     name: Maine
     toolkit_branch: main
   md:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Maryland
     toolkit_branch: main
   ma:
@@ -134,23 +134,23 @@ locales:
     toolkit_branch: main
     runner: self-hosted
   mn:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Minnesota
     toolkit_branch: main
     labels:
     - working
   ms:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Mississippi
     toolkit_branch: main
   mo:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Missouri
     toolkit_branch: main
     labels:
     - working
   mt:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Montana
     toolkit_branch: main
     labels:
@@ -170,7 +170,7 @@ locales:
     labels:
     - working
   nh:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: New Hampshire
     toolkit_branch: main
     labels:
@@ -201,7 +201,7 @@ locales:
     labels:
     - working
   nd:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: North Dakota
     toolkit_branch: main
     labels:
@@ -212,13 +212,13 @@ locales:
     toolkit_branch: main
     runner: self-hosted
   ok:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Oklahoma
     toolkit_branch: main
     labels:
     - working
   or:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Oregon
     toolkit_branch: main
     labels:
@@ -231,7 +231,7 @@ locales:
     labels:
     - working
   ri:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Rhode Island
     toolkit_branch: main
     labels:
@@ -244,24 +244,24 @@ locales:
     labels:
     - working
   sd:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: South Dakota
     toolkit_branch: main
   tn:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Tennessee
     toolkit_branch: main
     runner: self-hosted
     labels:
     - working
   tx:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Texas
     toolkit_branch: main
     labels:
     - working
   ut:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Utah
     toolkit_branch: main
     labels:
@@ -279,7 +279,7 @@ locales:
     toolkit_branch: main
     runner: self-hosted
   wa:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Washington
     toolkit_branch: main
     labels:
@@ -292,13 +292,13 @@ locales:
     labels:
     - working
   wi:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Wisconsin
     toolkit_branch: main
     labels:
     - working
   wy:
-    template: openstates-scrape-paused
+    template: openstates-scrape
     name: Wyoming
     toolkit_branch: main
     labels:

--- a/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
@@ -7,14 +7,22 @@ on:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: ✏️{ locale.key }✏️
+  # See the active (non-paused) template for the full explanation -- same
+  # logic here, just no schedule trigger, since "paused" means dispatch-only
+  # by design.
+  USE_PROXY: ${{ '✏️{ locale.runner }✏️' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ✏️{ locale.runner }✏️
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('✏️{ locale.runner }✏️' == 'self-hosted' && 'ubuntu-latest' || '✏️{ locale.runner }✏️') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -39,5 +47,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -9,14 +9,33 @@ on:
         type: boolean
         description: "Force push even if upstream changed (use with caution)"
         default: false
+      use-self-hosted:
+        type: boolean
+        description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
+        default: false
 
 env:
   STATE_CODE: ✏️{ locale.key }✏️
+  # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),
+  # not a runtime value -- runs-on: and this env: block can't read each other
+  # or their own sibling keys, so the literal gets inlined directly wherever
+  # it's needed below instead of routed through a shared variable.
+  #
+  # inputs.use-self-hosted only ever populates on a workflow_dispatch event --
+  # it's simply unset (falsy) on the nightly `schedule` trigger regardless of
+  # its declared default, so a plain `inputs.use-self-hosted` check would only
+  # ever fire on a manual run. For a self-hosted-flagged locale, route through
+  # tinyproxy on a GitHub-hosted runner by default and treat self-hosted as an
+  # explicit manual opt-out -- proxy running unattended was the whole point;
+  # self-hosted alone silently depended on a laptop being on and connected for
+  # every single automatic run. Locales that were never self-hosted (the
+  # literal below is "ubuntu-latest") are untouched by any of this.
+  USE_PROXY: ${{ '✏️{ locale.runner }✏️' == 'self-hosted' && !(github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) }}
 
 jobs:
   scrape:
     name: "🕷️ Scrape Data"
-    runs-on: ✏️{ locale.runner }✏️
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('✏️{ locale.runner }✏️' == 'self-hosted' && 'ubuntu-latest' || '✏️{ locale.runner }✏️') }}
     timeout-minutes: 720
     permissions:
       contents: write
@@ -41,5 +60,7 @@ jobs:
               "DC_API_KEY": "${{ secrets.DC_API_KEY }}",
               "NEW_YORK_API_KEY": "${{ secrets.NEW_YORK_API_KEY }}",
               "INDIANA_API_KEY": "${{ secrets.INDIANA_API_KEY }}",
-              "USER_AGENT": "${{ secrets.USER_AGENT }}"
+              "USER_AGENT": "${{ secrets.USER_AGENT }}",
+              "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
+              "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }


### PR DESCRIPTION
## Summary
- Un-pauses all 27 states currently on the `openstates-scrape-paused` template. `check-sessions.py` (the automation that used to manage this pause/resume cycle based on OpenStates session dates) has been disabled since 2026-07-14 due to repeated false pauses, and nothing has corrected these since — they'll stay stuck regardless of actual session status until manually flipped back.
- Fixes both scrape templates (active + paused) so any locale configured `runner: self-hosted` now defaults to routing through tinyproxy on a GitHub-hosted runner instead of actually running self-hosted. `self-hosted` becomes an explicit manual opt-out (`use-self-hosted` dispatch input) rather than the default — mirrors the fix already hand-applied to `wv-legislation` and validated live there. Locales that were never self-hosted are untouched.

## Test plan
- [ ] Confirm `apply.py --all-states` (or targeted subset) pushes cleanly to all affected repos
- [ ] Spot-check a formerly-paused state picks up its schedule again
- [ ] Spot-check a formerly-self-hosted state (esp. FL) actually runs on `ubuntu-latest` + proxy on its next scheduled/dispatched run, not self-hosted

🤖 Generated with [Claude Code](https://claude.com/claude-code)