### PR TITLE
Chain scrape -> format -> extract-text via repository_dispatch/workflow_run

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for ak
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for id
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for mt
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for pr
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for wy
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for ak
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for id
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for mt
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for pr
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "0 4 * * *"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for wy
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for ak"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for ak
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for id"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for id
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for mt"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for mt
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for pr"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for pr
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for wy"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/format.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for wy
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/chn-openstates-scrape.yml
+++ b/actions/pipeline-manager/chn-openstates-scrape.yml
@@ -22,20 +22,24 @@ locales:
     template: openstates-scrape
     name: Alabama
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
   ak:
     template: openstates-scrape
     name: Alaska
     toolkit_branch: main
+    scrape_cron: "0 8 * * *"  # Alaska
     runner: self-hosted
   az:
     template: openstates-scrape
     name: Arizona
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
     runner: self-hosted
   ar:
     template: openstates-scrape
     name: Arkansas
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
     - working
@@ -43,29 +47,35 @@ locales:
     template: openstates-scrape
     name: California
     toolkit_branch: main
+    scrape_cron: "0 7 * * *"  # Pacific
   co:
     template: openstates-scrape
     name: Colorado
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
   ct:
     template: openstates-scrape
     name: Connecticut
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   dc:
     template: openstates-scrape
     name: District of Columbia
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
   de:
     template: openstates-scrape
     name: Delaware
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   fl:
     template: openstates-scrape
     name: Florida
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -73,21 +83,25 @@ locales:
     template: openstates-scrape
     name: Georgia
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   hi:
     template: openstates-scrape
     name: Hawaii
     toolkit_branch: main
+    scrape_cron: "0 10 * * *"  # Hawaii (no DST)
     runner: self-hosted
   id:
     template: openstates-scrape
     name: Idaho
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
   il:
     template: openstates-scrape
     name: Illinois
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
     - working
@@ -95,75 +109,89 @@ locales:
     template: openstates-scrape
     name: Indiana
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   ia:
     template: openstates-scrape
     name: Iowa
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   ks:
     template: openstates-scrape
     name: Kansas
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   ky:
     template: openstates-scrape
     name: Kentucky
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   la:
     template: openstates-scrape
     name: Louisiana
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   me:
     template: openstates-scrape
     name: Maine
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
   md:
     template: openstates-scrape
     name: Maryland
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
   ma:
     template: openstates-scrape
     name: Massachusetts
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   mi:
     template: openstates-scrape
     name: Michigan
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   mn:
     template: openstates-scrape
     name: Minnesota
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   ms:
     template: openstates-scrape
     name: Mississippi
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
   mo:
     template: openstates-scrape
     name: Missouri
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   mt:
     template: openstates-scrape
     name: Montana
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
   ne:
     template: openstates-scrape
     name: Nebraska
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
     - working
@@ -171,6 +199,7 @@ locales:
     template: openstates-scrape
     name: Nevada
     toolkit_branch: main
+    scrape_cron: "0 7 * * *"  # Pacific
     runner: self-hosted
     labels:
     - working
@@ -178,18 +207,21 @@ locales:
     template: openstates-scrape
     name: New Hampshire
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   nj:
     template: openstates-scrape
     name: New Jersey
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   nm:
     template: openstates-scrape
     name: New Mexico
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
     runner: self-hosted
     labels:
     - working
@@ -197,11 +229,13 @@ locales:
     template: openstates-scrape
     name: New York
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   nc:
     template: openstates-scrape
     name: North Carolina
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -209,29 +243,34 @@ locales:
     template: openstates-scrape
     name: North Dakota
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   oh:
     template: openstates-scrape
     name: Ohio
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   ok:
     template: openstates-scrape
     name: Oklahoma
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   or:
     template: openstates-scrape
     name: Oregon
     toolkit_branch: main
+    scrape_cron: "0 7 * * *"  # Pacific
     labels:
     - working
   pa:
     template: openstates-scrape
     name: Pennsylvania
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -239,12 +278,14 @@ locales:
     template: openstates-scrape
     name: Rhode Island
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
   sc:
     template: openstates-scrape
     name: South Carolina
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -252,10 +293,12 @@ locales:
     template: openstates-scrape
     name: South Dakota
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
   tn:
     template: openstates-scrape
     name: Tennessee
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
     - working
@@ -263,18 +306,21 @@ locales:
     template: openstates-scrape
     name: Texas
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   ut:
     template: openstates-scrape
     name: Utah
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
   vt:
     template: openstates-scrape
     name: Vermont
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -282,17 +328,20 @@ locales:
     template: openstates-scrape
     name: Virginia
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   wa:
     template: openstates-scrape
     name: Washington
     toolkit_branch: main
+    scrape_cron: "0 7 * * *"  # Pacific
     labels:
     - working
   wv:
     template: openstates-scrape
     name: West Virginia
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working
@@ -300,30 +349,35 @@ locales:
     template: openstates-scrape
     name: Wisconsin
     toolkit_branch: main
+    scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
   wy:
     template: openstates-scrape
     name: Wyoming
     toolkit_branch: main
+    scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
   pr:
     template: openstates-scrape
     name: Puerto Rico
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Atlantic (PR/VI, no DST)
     labels:
     - working
   mp:
     template: openstates-scrape
     name: Northern Mariana Islands
     toolkit_branch: main
+    scrape_cron: "0 14 * * *"  # Chamorro (GU/MP, UTC+10)
     labels:
     - working
   vi:
     template: openstates-scrape
     name: U.S. Virgin Islands
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Atlantic (PR/VI, no DST)
     runner: self-hosted
     labels:
     - working
@@ -331,12 +385,14 @@ locales:
     template: openstates-scrape
     name: Guam
     toolkit_branch: main
+    scrape_cron: "0 14 * * *"  # Chamorro (GU/MP, UTC+10)
     labels:
     - working
   usa:
     template: openstates-scrape
     name: United States
     toolkit_branch: main
+    scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
     - working

--- a/actions/pipeline-manager/config.schema.json
+++ b/actions/pipeline-manager/config.schema.json
@@ -96,6 +96,14 @@
             "session": {
               "type": "string",
               "description": "Identifier for the legislative session this locale's repo currently holds (e.g. '2025-2026', '2026-ss1' for a special session). Set by close_session.py when rotating repos; used to name the archived repo on transfer. Informational only — does not affect the active repo's name."
+            },
+            "runner": {
+              "type": "string",
+              "description": "GitHub Actions runner label for the locale's scrape/extract-text jobs (e.g. 'self-hosted'). Defaults to 'ubuntu-latest' when unset."
+            },
+            "scrape_cron": {
+              "type": "string",
+              "description": "Cron schedule (UTC) for this locale's scrape workflow, staggered by the state capital's timezone so scrapes run shortly after each state's own legislative day ends rather than all firing at once. E.g. '0 4 * * *' for Eastern, '0 7 * * *' for Pacific. See openstates-scrape.yml template."
             }
           },
           "additionalProperties": false

--- a/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
@@ -51,3 +51,26 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # See the active (non-paused) template for the full explanation of why
+      # this needs repository_dispatch + a GitHub App token rather than
+      # workflow_run or a plain PAT.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -1,8 +1,13 @@
 name: OpenStates Scrape for ✏️{ locale.key }✏️
 
 on:
+  # Staggered by the state capital's timezone (see locale.scrape_cron in
+  # chn-openstates-scrape.yml) so each state scrapes shortly after its own
+  # legislative day ends, instead of every state firing at the same UTC
+  # instant regardless of local time -- previously that meant western states
+  # were effectively scraped in their own early evening/late night.
   schedule:
-    - cron: "0 6 * * *" # Daily at 6:00 AM UTC (1:00 AM Chicago / 2:00 AM Eastern)
+    - cron: "✏️{ locale.scrape_cron }✏️"
   workflow_dispatch:
     inputs:
       force-update:

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -64,3 +64,34 @@ jobs:
               "HTTPS_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}",
               "HTTP_PROXY": "${{ env.USE_PROXY == 'true' && secrets.PROXY_URL || '' }}"
             }
+
+      # Cross-org trigger: scrape and format live in different orgs
+      # (govbot-openstates-scrapers / govbot-data), so workflow_run can't
+      # chain them -- it only works within a single repo. repository_dispatch
+      # is the primitive for this, authenticated via a short-lived GitHub App
+      # installation token instead of a long-lived PAT (the previous version
+      # of this dispatch died silently when its PAT expired -- see project
+      # notes). Always runs, even if the scrape step above failed: format's
+      # own SHA-staleness check already makes a no-op trigger cheap (~10s),
+      # so there's no cost to triggering unconditionally, and states that
+      # degrade gracefully (out-of-session, partial data) still deserve a
+      # fresh format pass over whatever did land.
+      - name: Generate GitHub App token for cross-org dispatch
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: govbot-data
+          repositories: ${{ env.STATE_CODE }}-legislation
+
+      - name: Trigger format workflow in govbot-data
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "🚀 Triggering format workflow for ${{ env.STATE_CODE }} in govbot-data..."
+          gh api "repos/govbot-data/${{ env.STATE_CODE }}-legislation/dispatches" \
+            -f event_type='scrape-complete' \
+            -F "client_payload[state]=${{ env.STATE_CODE }}"

--- a/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
@@ -4,8 +4,14 @@
 name: Text Extraction from Bills
 
 on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
   schedule:
     - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for ✏️{ locale.key }✏️"]
+    types: [completed]
   workflow_dispatch:
 
 # A run against a large state can take hours. Without this, a scheduled
@@ -19,6 +25,10 @@ concurrency:
 jobs:
   extract-text:
     name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     # Same runner-override mechanism the scrape template already uses (see
     # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
     # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,

--- a/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/format.yml
+++ b/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/format.yml
@@ -1,8 +1,14 @@
 name: Format Data for ✏️{ locale.key }✏️
 
 on:
+  # Backup only -- the real trigger is repository_dispatch from scrape
+  # finishing (cross-org, see openstates-scrape.yml's "Trigger format
+  # workflow" step). Cheap to leave running since the SHA-staleness check
+  # below skips in ~10s when the dispatch already handled it.
   schedule:
     - cron: "0 12 * * *"  # Daily at 12:00 PM UTC (6:00 AM Chicago time)
+  repository_dispatch:
+    types: [scrape-complete]
   workflow_dispatch:
     inputs:
       force-update:


### PR DESCRIPTION
## Summary

Replaces independent cron scheduling across the three pipeline stages with real event-driven sequencing. The crons were previously out of order relative to the actual data dependency (scrape 6am -> extract-text 8am -> format noon), meaning extract-text ran against yesterday's format output, and any state whose scrape ran past a couple hours (FL, especially, with its 24h timeout) could have format/extract-text firing on stale or mid-scrape data.

- **scrape -> format** (cross-org: `govbot-openstates-scrapers` -> `govbot-data`): `repository_dispatch`, authenticated via a short-lived GitHub App installation token (`actions/create-github-app-token`) rather than a long-lived PAT. The original version of this exact dispatch (PR #49, Nov 2025) died silently when its PAT expired and was ripped out in June rather than fixed (PRs #40/#43) -- this rebuilds it with a credential that can't go stale the same way.
- **format -> extract-text** (same-repo, both in `govbot-data`): `workflow_run`, gated on `github.event.workflow_run.conclusion == 'success'`. No cross-org auth needed at all for this link.
- Cron schedules stay on all three workflows as a backup only -- cheap to leave running since format's SHA-staleness check makes a redundant trigger a ~10s no-op.

## Prerequisites (already done)
- GitHub App `govbot-pipeline-dispatch` created, installed on `govbot-openstates-scrapers` and `govbot-data`
- `APP_ID` / `APP_PRIVATE_KEY` added as org-level secrets on both orgs

## Test plan
- [ ] CI snapshot checks pass
- [ ] Manual dispatch test on one state end-to-end: scrape run finishes -> format run auto-fires in govbot-data -> extract-text run auto-fires after format succeeds
- [ ] Confirm a failed/incomplete format run does NOT trigger extract-text (conclusion gate)