### PR TITLE
fix: restore extract-text.yml on govbot-data (stale disabled_jobs regression)

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
@@ -1,0 +1,109 @@
+# Example caller workflow for text extraction
+# Copy this to your state data repo as .github/workflows/extract-text.yml
+
+name: Text Extraction from Bills
+
+on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
+  schedule:
+    - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for ak"]
+    types: [completed]
+  workflow_dispatch:
+
+# A run against a large state can take hours. Without this, a scheduled
+# trigger landing mid-run cancels the in-progress run outright ("runner
+# received a shutdown signal") instead of queuing behind it -- discovered
+# live when the daily cron fired on top of an overnight manual run.
+concurrency:
+  group: extract-text
+  cancel-in-progress: false
+
+jobs:
+  extract-text:
+    name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same runner-override mechanism the scrape template already uses (see
+    # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
+    # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,
+    # e.g. MA (malegislature.gov), same reason its scrape step needs it.
+    # Defaults to ubuntu-latest when unset.
+    runs-on: ubuntu-latest
+    timeout-minutes: 355 # ~5.9 hours (close to GitHub's 6-hour limit)
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout state repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run text extraction action
+        id: extract
+        uses: chihacknight/govbot/actions/extract@main
+        with:
+          state: ak
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-update: "false"
+          # Org-level secret, not yet provisioned -- action skips notifying
+          # silently while this is unset/empty. See project notes.
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Display extraction summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ".extraction_summary.txt" ]; then
+            cat .extraction_summary.txt
+          else
+            echo "⚠️  Summary file not found"
+          fi
+
+  # Auto-restart job if extraction was cancelled (timeout) or failed
+  check-and-restart:
+    name: Check Status & Restart if Needed
+    needs: extract-text
+    runs-on: ubuntu-latest
+    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Checkout to check completion status
+        uses: actions/checkout@v7
+
+      - name: Check if more work remains
+        id: check
+        shell: bash
+        run: |
+          # Count bills that still need text extraction
+          # Bills without _processing.text_extraction_latest_update need processing
+          TOTAL_BILLS=$(find country:us/state:*/sessions/*/bills/*/metadata.json 2>/dev/null | wc -l || echo "0")
+
+          if [ "$TOTAL_BILLS" -gt 0 ]; then
+            echo "📊 Found $TOTAL_BILLS bills total"
+            echo "needs_restart=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ No bills found or extraction complete"
+            echo "needs_restart=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger workflow restart
+        if: steps.check.outputs.needs_restart == 'true'
+        env:
+          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
+          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+        run: |
+          echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
+          echo "   (Incremental processing will skip already-completed bills)"
+          gh workflow run extract-text.yml --repo ${{ github.repository }}

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
@@ -1,0 +1,109 @@
+# Example caller workflow for text extraction
+# Copy this to your state data repo as .github/workflows/extract-text.yml
+
+name: Text Extraction from Bills
+
+on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
+  schedule:
+    - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for id"]
+    types: [completed]
+  workflow_dispatch:
+
+# A run against a large state can take hours. Without this, a scheduled
+# trigger landing mid-run cancels the in-progress run outright ("runner
+# received a shutdown signal") instead of queuing behind it -- discovered
+# live when the daily cron fired on top of an overnight manual run.
+concurrency:
+  group: extract-text
+  cancel-in-progress: false
+
+jobs:
+  extract-text:
+    name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same runner-override mechanism the scrape template already uses (see
+    # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
+    # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,
+    # e.g. MA (malegislature.gov), same reason its scrape step needs it.
+    # Defaults to ubuntu-latest when unset.
+    runs-on: ubuntu-latest
+    timeout-minutes: 355 # ~5.9 hours (close to GitHub's 6-hour limit)
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout state repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run text extraction action
+        id: extract
+        uses: chihacknight/govbot/actions/extract@main
+        with:
+          state: id
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-update: "false"
+          # Org-level secret, not yet provisioned -- action skips notifying
+          # silently while this is unset/empty. See project notes.
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Display extraction summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ".extraction_summary.txt" ]; then
+            cat .extraction_summary.txt
+          else
+            echo "⚠️  Summary file not found"
+          fi
+
+  # Auto-restart job if extraction was cancelled (timeout) or failed
+  check-and-restart:
+    name: Check Status & Restart if Needed
+    needs: extract-text
+    runs-on: ubuntu-latest
+    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Checkout to check completion status
+        uses: actions/checkout@v7
+
+      - name: Check if more work remains
+        id: check
+        shell: bash
+        run: |
+          # Count bills that still need text extraction
+          # Bills without _processing.text_extraction_latest_update need processing
+          TOTAL_BILLS=$(find country:us/state:*/sessions/*/bills/*/metadata.json 2>/dev/null | wc -l || echo "0")
+
+          if [ "$TOTAL_BILLS" -gt 0 ]; then
+            echo "📊 Found $TOTAL_BILLS bills total"
+            echo "needs_restart=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ No bills found or extraction complete"
+            echo "needs_restart=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger workflow restart
+        if: steps.check.outputs.needs_restart == 'true'
+        env:
+          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
+          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+        run: |
+          echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
+          echo "   (Incremental processing will skip already-completed bills)"
+          gh workflow run extract-text.yml --repo ${{ github.repository }}

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
@@ -1,0 +1,109 @@
+# Example caller workflow for text extraction
+# Copy this to your state data repo as .github/workflows/extract-text.yml
+
+name: Text Extraction from Bills
+
+on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
+  schedule:
+    - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for mt"]
+    types: [completed]
+  workflow_dispatch:
+
+# A run against a large state can take hours. Without this, a scheduled
+# trigger landing mid-run cancels the in-progress run outright ("runner
+# received a shutdown signal") instead of queuing behind it -- discovered
+# live when the daily cron fired on top of an overnight manual run.
+concurrency:
+  group: extract-text
+  cancel-in-progress: false
+
+jobs:
+  extract-text:
+    name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same runner-override mechanism the scrape template already uses (see
+    # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
+    # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,
+    # e.g. MA (malegislature.gov), same reason its scrape step needs it.
+    # Defaults to ubuntu-latest when unset.
+    runs-on: ubuntu-latest
+    timeout-minutes: 355 # ~5.9 hours (close to GitHub's 6-hour limit)
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout state repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run text extraction action
+        id: extract
+        uses: chihacknight/govbot/actions/extract@main
+        with:
+          state: mt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-update: "false"
+          # Org-level secret, not yet provisioned -- action skips notifying
+          # silently while this is unset/empty. See project notes.
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Display extraction summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ".extraction_summary.txt" ]; then
+            cat .extraction_summary.txt
+          else
+            echo "⚠️  Summary file not found"
+          fi
+
+  # Auto-restart job if extraction was cancelled (timeout) or failed
+  check-and-restart:
+    name: Check Status & Restart if Needed
+    needs: extract-text
+    runs-on: ubuntu-latest
+    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Checkout to check completion status
+        uses: actions/checkout@v7
+
+      - name: Check if more work remains
+        id: check
+        shell: bash
+        run: |
+          # Count bills that still need text extraction
+          # Bills without _processing.text_extraction_latest_update need processing
+          TOTAL_BILLS=$(find country:us/state:*/sessions/*/bills/*/metadata.json 2>/dev/null | wc -l || echo "0")
+
+          if [ "$TOTAL_BILLS" -gt 0 ]; then
+            echo "📊 Found $TOTAL_BILLS bills total"
+            echo "needs_restart=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ No bills found or extraction complete"
+            echo "needs_restart=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger workflow restart
+        if: steps.check.outputs.needs_restart == 'true'
+        env:
+          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
+          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+        run: |
+          echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
+          echo "   (Incremental processing will skip already-completed bills)"
+          gh workflow run extract-text.yml --repo ${{ github.repository }}

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
@@ -1,0 +1,109 @@
+# Example caller workflow for text extraction
+# Copy this to your state data repo as .github/workflows/extract-text.yml
+
+name: Text Extraction from Bills
+
+on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
+  schedule:
+    - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for pr"]
+    types: [completed]
+  workflow_dispatch:
+
+# A run against a large state can take hours. Without this, a scheduled
+# trigger landing mid-run cancels the in-progress run outright ("runner
+# received a shutdown signal") instead of queuing behind it -- discovered
+# live when the daily cron fired on top of an overnight manual run.
+concurrency:
+  group: extract-text
+  cancel-in-progress: false
+
+jobs:
+  extract-text:
+    name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same runner-override mechanism the scrape template already uses (see
+    # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
+    # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,
+    # e.g. MA (malegislature.gov), same reason its scrape step needs it.
+    # Defaults to ubuntu-latest when unset.
+    runs-on: ubuntu-latest
+    timeout-minutes: 355 # ~5.9 hours (close to GitHub's 6-hour limit)
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout state repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run text extraction action
+        id: extract
+        uses: chihacknight/govbot/actions/extract@main
+        with:
+          state: pr
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-update: "false"
+          # Org-level secret, not yet provisioned -- action skips notifying
+          # silently while this is unset/empty. See project notes.
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Display extraction summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ".extraction_summary.txt" ]; then
+            cat .extraction_summary.txt
+          else
+            echo "⚠️  Summary file not found"
+          fi
+
+  # Auto-restart job if extraction was cancelled (timeout) or failed
+  check-and-restart:
+    name: Check Status & Restart if Needed
+    needs: extract-text
+    runs-on: ubuntu-latest
+    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Checkout to check completion status
+        uses: actions/checkout@v7
+
+      - name: Check if more work remains
+        id: check
+        shell: bash
+        run: |
+          # Count bills that still need text extraction
+          # Bills without _processing.text_extraction_latest_update need processing
+          TOTAL_BILLS=$(find country:us/state:*/sessions/*/bills/*/metadata.json 2>/dev/null | wc -l || echo "0")
+
+          if [ "$TOTAL_BILLS" -gt 0 ]; then
+            echo "📊 Found $TOTAL_BILLS bills total"
+            echo "needs_restart=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ No bills found or extraction complete"
+            echo "needs_restart=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger workflow restart
+        if: steps.check.outputs.needs_restart == 'true'
+        env:
+          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
+          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+        run: |
+          echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
+          echo "   (Incremental processing will skip already-completed bills)"
+          gh workflow run extract-text.yml --repo ${{ github.repository }}

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
@@ -1,0 +1,109 @@
+# Example caller workflow for text extraction
+# Copy this to your state data repo as .github/workflows/extract-text.yml
+
+name: Text Extraction from Bills
+
+on:
+  # Backup only -- the real trigger is workflow_run below, firing right after
+  # this repo's own "Format Data" workflow completes. Same-repo, so no
+  # cross-org token needed (unlike scrape -> format, see openstates-scrape.yml).
+  schedule:
+    - cron: "0 8 * * *" # Daily at 8 AM UTC (~3 AM ET, ~12 AM PT)
+  workflow_run:
+    workflows: ["Format Data for wy"]
+    types: [completed]
+  workflow_dispatch:
+
+# A run against a large state can take hours. Without this, a scheduled
+# trigger landing mid-run cancels the in-progress run outright ("runner
+# received a shutdown signal") instead of queuing behind it -- discovered
+# live when the daily cron fired on top of an overnight manual run.
+concurrency:
+  group: extract-text
+  cancel-in-progress: false
+
+jobs:
+  extract-text:
+    name: Text Extraction
+    # Only proceed on a workflow_run if format actually succeeded -- otherwise
+    # extraction would run against a format pass that didn't finish (same
+    # guard synthetic-test.yml uses for its own workflow_run trigger).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same runner-override mechanism the scrape template already uses (see
+    # openstates-scrape.yml) -- set locales.<code>.runner: self-hosted in
+    # config for states whose bill-text host blocks GitHub-hosted (Azure) IPs,
+    # e.g. MA (malegislature.gov), same reason its scrape step needs it.
+    # Defaults to ubuntu-latest when unset.
+    runs-on: ubuntu-latest
+    timeout-minutes: 355 # ~5.9 hours (close to GitHub's 6-hour limit)
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout state repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run text extraction action
+        id: extract
+        uses: chihacknight/govbot/actions/extract@main
+        with:
+          state: wy
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-update: "false"
+          # Org-level secret, not yet provisioned -- action skips notifying
+          # silently while this is unset/empty. See project notes.
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Display extraction summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ".extraction_summary.txt" ]; then
+            cat .extraction_summary.txt
+          else
+            echo "⚠️  Summary file not found"
+          fi
+
+  # Auto-restart job if extraction was cancelled (timeout) or failed
+  check-and-restart:
+    name: Check Status & Restart if Needed
+    needs: extract-text
+    runs-on: ubuntu-latest
+    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Checkout to check completion status
+        uses: actions/checkout@v7
+
+      - name: Check if more work remains
+        id: check
+        shell: bash
+        run: |
+          # Count bills that still need text extraction
+          # Bills without _processing.text_extraction_latest_update need processing
+          TOTAL_BILLS=$(find country:us/state:*/sessions/*/bills/*/metadata.json 2>/dev/null | wc -l || echo "0")
+
+          if [ "$TOTAL_BILLS" -gt 0 ]; then
+            echo "📊 Found $TOTAL_BILLS bills total"
+            echo "needs_restart=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ No bills found or extraction complete"
+            echo "needs_restart=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger workflow restart
+        if: steps.check.outputs.needs_restart == 'true'
+        env:
+          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
+          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+        run: |
+          echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
+          echo "   (Incremental processing will skip already-completed bills)"
+          gh workflow run extract-text.yml --repo ${{ github.repository }}

--- a/actions/pipeline-manager/chn-openstates-files.yml
+++ b/actions/pipeline-manager/chn-openstates-files.yml
@@ -21,435 +21,323 @@ locales:
     template: openstates-to-ocd-files
     toolkit_branch: main # Defaults to main, but can make whatever.
     name: Alabama
-    disabled_jobs:
-      - extract-text # Exclude extract-text.yml workflow
     labels:
       - working
   ak:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Alaska
     labels:
       - working
   az:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Arizona
   ar:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Arkansas
     labels:
       - working
   ca:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: California
     labels:
       - working
   co:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Colorado
     labels:
       - working
   ct:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Connecticut
   dc:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: District of Columbia
   de:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Delaware
     labels:
       - working
   fl:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Florida
     labels:
       - working
   ga:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Georgia
     labels:
       - working
   hi:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Hawaii
     labels:
       - working
   id:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Idaho
     labels:
       - working
   il:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Illinois
     labels:
       - working
   in:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Indiana
     labels:
       - working
   ia:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Iowa
     labels:
       - working
   ks:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Kansas
     labels:
       - working
   ky:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Kentucky
     labels:
       - working
   la:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Louisiana
     labels:
       - working
   me:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Maine
     labels:
       - working
   md:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Maryland
     labels:
       - working
   ma:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Massachusetts
     labels:
       - working
   mi:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Michigan
     labels:
       - working
   mn:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Minnesota
     labels:
       - working
   ms:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Mississippi
     labels:
       - working
   mo:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Missouri
     labels:
       - working
   mt:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Montana
     labels:
       - working
   ne:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Nebraska
     labels:
       - working
   nv:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Nevada
     labels:
       - working
   nh:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: New Hampshire
     labels:
       - working
   nj:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: New Jersey
     labels:
       - working
   nm:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: New Mexico
     labels:
       - working
   ny:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: New York
     labels:
       - working
   nc:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: North Carolina
     labels:
       - working
   nd:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: North Dakota
     labels:
       - working
   oh:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Ohio
     labels:
       - working
   ok:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Oklahoma
     labels:
       - working
   or:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Oregon
     labels:
       - working
   pa:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Pennsylvania
     labels:
       - working
   ri:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Rhode Island
     labels:
       - working
   sc:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: South Carolina
     labels:
       - working
   sd:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: South Dakota
     labels:
       - working
   tn:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Tennessee
     labels:
       - working
   tx:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Texas
   ut:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Utah
     labels:
       - working
   vt:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Vermont
     labels:
       - working
   va:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Virginia
   wa:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Washington
     labels:
       - working
   wv:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: West Virginia
     labels:
       - working
   wi:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Wisconsin
     labels:
       - working
   wy:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Wyoming
     labels:
       - working
   pr:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Puerto Rico
     labels:
       - working
   mp:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Northern Mariana Islands
     labels:
       - working
   vi:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: U.S. Virgin Islands
     labels:
       - working
   gu:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: Guam
     labels:
       - working
   usa:
-    disabled_jobs:
-      - extract-text
     template: openstates-to-ocd-files
     toolkit_branch: main
     name: United States


### PR DESCRIPTION
## Summary

Fixes a regression from the last apply.py rollout: every locale in `chn-openstates-files.yml` had `disabled_jobs: [extract-text]` set, a leftover from when `govbot-data` was the empty placeholder org (format@main only, no text extraction). Since then, `govbot-test`'s real repos (with working `extract-text.yml`) were transferred into `govbot-data` to become the official org. Running `apply.py -c chn-openstates-files.yml --all-states` against the stale config deleted `extract-text.yml` from all 56 `govbot-data` repos.

This PR removes the stale `disabled_jobs` entries so the next `apply.py` run restores `extract-text.yml` (now including the `workflow_run` trigger from #79) across all 56 repos.

## Test plan
- [x] Verified all 56 `disabled_jobs: [extract-text]` blocks removed, config still parses with all 56 locales
- [x] Regenerated snapshots -- `extract-text.yml` now present in `chn-openstates-files` test-state snapshots
- [ ] After merge: re-run `apply.py -c chn-openstates-files.yml --all-states` and confirm `extract-text.yml` restored on all 56 govbot-data repos

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>