### PR TITLE
fix: rewrite PDF extraction -- real bytes, one clean read, geometry-based markup flag

### DIFF
--- a/actions/extract/utils/pdf_extractor.py
+++ b/actions/extract/utils/pdf_extractor.py
@@ -1,324 +1,157 @@
-import re
 from typing import Optional
 
 
-def download_pdf_content(url: str, download_with_retry_func) -> Optional[str]:
-    """Download PDF content from URL and convert to text."""
+def _extract_pages_text(pdf_bytes: bytes) -> Optional[str]:
+    """Try pdfplumber, then PyPDF2, then PyMuPDF (fitz), in order of preference."""
+    import io
+
     try:
-        response = download_with_retry_func(url, max_retries=3, delay=1.0)
-        if not response:
-            return None
+        import pdfplumber
 
-        # Try multiple PDF parsing libraries in order of preference
-        pdf_content = None
-
-        # Try pdfplumber first (best for complex layouts)
-        try:
-            import pdfplumber
-            import io
-
-            pdf_file = io.BytesIO(response.content)
-            with pdfplumber.open(pdf_file) as pdf:
-                text_parts = []
-                for page in pdf.pages:
-                    page_text = page.extract_text()
-                    if page_text:
-                        text_parts.append(page_text)
-                pdf_content = "\n\n".join(text_parts)
-                if pdf_content:
-                    print(f"   ✅ Successfully extracted PDF text using pdfplumber")
-                    return pdf_content
-        except ImportError:
-            pass
-        except Exception as e:
-            print(f"   ⚠️ pdfplumber failed: {e}")
-
-        # Try PyPDF2 as fallback
-        try:
-            import PyPDF2
-            import io
-
-            pdf_file = io.BytesIO(response.content)
-            pdf_reader = PyPDF2.PdfReader(pdf_file)
-            text_parts = []
-            for page in pdf_reader.pages:
-                page_text = page.extract_text()
-                if page_text:
-                    text_parts.append(page_text)
-            pdf_content = "\n\n".join(text_parts)
-            if pdf_content:
-                print(f"   ✅ Successfully extracted PDF text using PyPDF2")
-                return pdf_content
-        except ImportError:
-            pass
-        except Exception as e:
-            print(f"   ⚠️ PyPDF2 failed: {e}")
-
-        # Try pymupdf (fitz) as another fallback
-        try:
-            import fitz  # PyMuPDF
-            import io
-
-            pdf_file = io.BytesIO(response.content)
-            doc = fitz.open(stream=pdf_file, filetype="pdf")
-            text_parts = []
-            for page in doc:
-                page_text = page.get_text()
-                if page_text:
-                    text_parts.append(page_text)
-            doc.close()
-            pdf_content = "\n\n".join(text_parts)
-            if pdf_content:
-                print(f"   ✅ Successfully extracted PDF text using PyMuPDF")
-                return pdf_content
-        except ImportError:
-            pass
-        except Exception as e:
-            print(f"   ⚠️ PyMuPDF failed: {e}")
-
-        # If all libraries fail, return a placeholder
-        print(f"   ⚠️ No PDF parsing libraries available")
-        return f"[PDF content from {url} - requires PDF parsing library (pdfplumber, PyPDF2, or PyMuPDF)]"
-
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            text_parts = [p.extract_text() for p in pdf.pages]
+            text = "\n\n".join(t for t in text_parts if t)
+            if text:
+                print(f"   ✅ Successfully extracted PDF text using pdfplumber")
+                return text
+    except ImportError:
+        pass
     except Exception as e:
-        print(f"   ❌ Failed to download PDF: {e}")
-        return None
+        print(f"   ⚠️ pdfplumber failed: {e}")
 
-
-def extract_text_from_pdf(pdf_content: str) -> dict:
-    """Extract text from PDF content."""
-    # The pdf_content is already extracted text from the PDF
-    # Clean up the text and structure it
-    lines = pdf_content.split("\n")
-    cleaned_lines = [line.strip() for line in lines if line.strip()]
-
-    # Try to identify title and sections
-    title = ""
-    sections = []
-    current_section = []
-
-    for line in cleaned_lines:
-        # Look for title patterns (usually at the top, all caps, or contains "AN ACT")
-        if not title and (
-            "AN ACT" in line.upper() or "BILL" in line.upper() or len(line) > 50
-        ):
-            title = line
-        # Look for section headers (numbers, "SECTION", etc.)
-        elif re.match(r"^(Section|§|\d+\.)", line, re.IGNORECASE):
-            if current_section:
-                sections.append("\n".join(current_section))
-                current_section = []
-            current_section.append(line)
-        else:
-            current_section.append(line)
-
-    # Add the last section
-    if current_section:
-        sections.append("\n".join(current_section))
-
-    # If no sections found, treat the whole content as one section
-    if not sections:
-        sections = [pdf_content]
-
-    return {
-        "title": title or "PDF Document",
-        "official_title": title or "",
-        "sections": sections,
-        "raw_text": pdf_content,
-    }
-
-
-def extract_text_with_strikethroughs(url: str, download_with_retry_func) -> dict:
-    """
-    Extract PDF text including strikethrough content using visual analysis.
-
-    This function attempts to detect strikethrough text by analyzing
-    the visual layout and character positioning in the PDF.
-    """
     try:
-        response = download_with_retry_func(url, max_retries=3, delay=1.0)
-        if not response:
-            return None
+        import PyPDF2
 
-        # Try pdfplumber with enhanced strikethrough detection
-        try:
-            import pdfplumber
-            import io
+        reader = PyPDF2.PdfReader(io.BytesIO(pdf_bytes))
+        text_parts = [p.extract_text() for p in reader.pages]
+        text = "\n\n".join(t for t in text_parts if t)
+        if text:
+            print(f"   ✅ Successfully extracted PDF text using PyPDF2")
+            return text
+    except ImportError:
+        pass
+    except Exception as e:
+        print(f"   ⚠️ PyPDF2 failed: {e}")
 
-            pdf_file = io.BytesIO(response.content)
-            with pdfplumber.open(pdf_file) as pdf:
-                text_parts = []
-                strikethrough_parts = []
+    try:
+        import fitz  # PyMuPDF
 
-                for page in pdf.pages:
-                    # Extract regular text
-                    page_text = page.extract_text()
-                    if page_text:
-                        text_parts.append(page_text)
+        doc = fitz.open(stream=io.BytesIO(pdf_bytes), filetype="pdf")
+        text_parts = [page.get_text() for page in doc]
+        doc.close()
+        text = "\n\n".join(t for t in text_parts if t)
+        if text:
+            print(f"   ✅ Successfully extracted PDF text using PyMuPDF")
+            return text
+    except ImportError:
+        pass
+    except Exception as e:
+        print(f"   ⚠️ PyMuPDF failed: {e}")
 
-                    # Try to detect strikethrough text using character analysis
-                    chars = page.chars
-                    if chars:
-                        strikethrough_text = detect_strikethrough_chars(chars)
-                        if strikethrough_text:
-                            strikethrough_parts.append(
-                                f"[DELETED: {strikethrough_text}]"
-                            )
+    return None
 
-                # Combine regular and strikethrough text
-                full_text = "\n\n".join(text_parts)
-                if strikethrough_parts:
-                    full_text += "\n\n" + "\n".join(strikethrough_parts)
 
-                if full_text:
-                    print(
-                        f"   ✅ Successfully extracted PDF text with strikethrough detection using pdfplumber"
+def _has_visual_markup(pdf_bytes: bytes) -> bool:
+    """
+    Cheap, deterministic check for whether a PDF likely contains redline markup
+    (strikethrough/underline showing deleted/added legislative text) -- the
+    common convention for amendment bills.
+
+    Rather than trying to infer strikethrough from font names, character
+    spacing, or color (unreliable -- most bill-drafting software doesn't
+    encode it that way, and the heuristic caught as much normal formatting
+    as real strikethroughs), this looks for what a real strikethrough
+    actually is in most legislative PDFs: a short horizontal vector line or
+    rectangle drawn over a line of text. Checks pdfplumber's `lines`/`rects`
+    for any object that's mostly horizontal (much wider than tall) and
+    vertically overlaps a text character's line -- a hallmark of an
+    intentionally-drawn strike mark rather than a table border or page
+    decoration (which tend to span a full column width or be vertical).
+
+    This is a signal for routing (does this document need full-fidelity
+    handling, e.g. handing the raw PDF to a vision-capable model, instead of
+    plain text extraction), not an attempt to reconstruct the struck text
+    itself.
+    """
+    import io
+
+    try:
+        import pdfplumber
+    except ImportError:
+        return False
+
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            for page in pdf.pages:
+                chars = page.chars
+                if not chars:
+                    continue
+
+                candidates = list(page.lines) + list(page.rects)
+                if not candidates:
+                    continue
+
+                for obj in candidates:
+                    width = obj["x1"] - obj["x0"]
+                    height = obj.get("y1", obj.get("bottom", 0)) - obj.get(
+                        "y0", obj.get("top", 0)
                     )
-                    return {
-                        "raw_text": full_text,
-                        "has_strikethroughs": len(strikethrough_parts) > 0,
-                        "strikethrough_count": len(strikethrough_parts),
-                    }
+                    height = abs(height)
+                    if width < 3 or width < height * 3:
+                        # Not a short, wide, mostly-horizontal mark.
+                        continue
 
-        except ImportError:
-            pass
-        except Exception as e:
-            print(f"   ⚠️ pdfplumber strikethrough detection failed: {e}")
+                    obj_top = min(obj.get("top", 0), obj.get("bottom", 0))
+                    obj_bottom = max(obj.get("top", 0), obj.get("bottom", 0))
 
-        # Fallback to regular extraction
-        return None
-
+                    for char in chars:
+                        if char["x0"] >= obj["x1"] or char["x1"] <= obj["x0"]:
+                            continue  # No horizontal overlap
+                        # Covers both strikethrough (mark through the middle
+                        # of the character) and underline (mark at the
+                        # bottom edge) -- both matter equally here, since
+                        # either indicates redline markup (added/deleted
+                        # text) rather than a table border or page rule,
+                        # which wouldn't line up with a character's height
+                        # at all.
+                        pad = 2
+                        if (char["top"] - pad) <= obj_bottom and obj_top <= (
+                            char["bottom"] + pad
+                        ):
+                            return True
     except Exception as e:
-        print(f"   ❌ Failed to download PDF for strikethrough analysis: {e}")
-        return None
-
-
-def detect_strikethrough_chars(chars: list) -> str:
-    """
-    Detect strikethrough text by analyzing character positioning and formatting.
-
-    Args:
-        chars: List of character objects from pdfplumber
-
-    Returns:
-        String containing detected strikethrough text
-    """
-    strikethrough_text = []
-
-    # Group characters by line
-    lines = {}
-    for char in chars:
-        y_pos = round(char["top"], 2)  # Round to handle floating point precision
-        if y_pos not in lines:
-            lines[y_pos] = []
-        lines[y_pos].append(char)
-
-    # Analyze each line for strikethrough patterns
-    for y_pos, line_chars in lines.items():
-        # Sort characters by x position
-        line_chars.sort(key=lambda x: x["x0"])
-
-        # Look for patterns that might indicate strikethrough
-        for i, char in enumerate(line_chars):
-            # Check if character has strikethrough-like properties
-            if is_likely_strikethrough(char, line_chars, i):
-                strikethrough_text.append(char["text"])
-
-    return "".join(strikethrough_text)
-
-
-def is_likely_strikethrough(char: dict, line_chars: list, index: int) -> bool:
-    """
-    Determine if a character is likely part of strikethrough text.
-
-    This is a heuristic approach that looks for visual indicators
-    of strikethrough text in PDF character data.
-    """
-    # Check for strikethrough font properties
-    font_name = char.get("fontname", "").lower()
-    if any(
-        strike_indicator in font_name
-        for strike_indicator in ["strike", "delete", "removed"]
-    ):
-        return True
-
-    # Check for unusual character spacing or positioning
-    if index > 0 and index < len(line_chars) - 1:
-        prev_char = line_chars[index - 1]
-        next_char = line_chars[index + 1]
-
-        # Look for gaps in text that might indicate strikethrough
-        gap_before = char["x0"] - prev_char["x1"]
-        gap_after = next_char["x0"] - char["x1"]
-
-        if gap_before > 2 or gap_after > 2:  # Unusual spacing
-            return True
-
-    # Check for color differences (strikethrough text might be grayed out)
-    if "non_stroking_color" in char:
-        color = char["non_stroking_color"]
-        if isinstance(color, list) and len(color) >= 3:
-            # Check if text is grayed out (common for strikethrough)
-            r, g, b = color[:3]
-            if r == g == b and r < 0.8:  # Gray text
-                return True
+        print(f"   ⚠️ Visual markup check failed: {e}")
+        return False
 
     return False
 
 
-def debug_pdf_structure(url: str, download_with_retry_func) -> dict:
+def extract_pdf(url: str, download_with_retry_func) -> Optional[dict]:
     """
-    Debug function to analyze PDF structure and identify potential strikethrough text.
+    Download and extract a PDF bill document in one pass.
 
-    This function provides detailed information about the PDF's character layout,
-    fonts, colors, and other properties that might indicate strikethrough text.
+    Returns a dict with:
+      - raw_bytes: the genuine, unmodified PDF bytes as downloaded (for
+        storage, and for handing off to a vision-capable model later)
+      - text: plain extracted text (no section-splitting -- one clean read)
+      - has_visual_markup: cheap geometry-based signal for whether this
+        document likely contains redline (strikethrough/underline) markup
+        that plain text extraction can't faithfully represent
+
+    Returns None if the download or every extraction library fails.
     """
-    try:
-        response = download_with_retry_func(url, max_retries=3, delay=1.0)
-        if not response:
-            return {"error": "Failed to download PDF"}
+    response = download_with_retry_func(url, max_retries=3, delay=1.0)
+    if not response:
+        return None
 
-        import pdfplumber
-        import io
+    raw_bytes = response.content
+    text = _extract_pages_text(raw_bytes)
+    if not text:
+        print(f"   ⚠️ No PDF parsing libraries available or all failed")
+        return None
 
-        pdf_file = io.BytesIO(response.content)
-        with pdfplumber.open(pdf_file) as pdf:
-            debug_info = {
-                "pages": len(pdf.pages),
-                "fonts": set(),
-                "colors": set(),
-                "character_count": 0,
-                "potential_strikethroughs": [],
-            }
-
-            for page_num, page in enumerate(pdf.pages):
-                chars = page.chars
-                debug_info["character_count"] += len(chars)
-
-                for char in chars:
-                    # Collect font information
-                    font_name = char.get("fontname", "")
-                    debug_info["fonts"].add(font_name)
-
-                    # Collect color information
-                    if "non_stroking_color" in char:
-                        color = char["non_stroking_color"]
-                        debug_info["colors"].add(str(color))
-
-                    # Check for potential strikethrough indicators
-                    if is_likely_strikethrough(char, chars, chars.index(char)):
-                        debug_info["potential_strikethroughs"].append(
-                            {
-                                "page": page_num + 1,
-                                "text": char["text"],
-                                "font": char.get("fontname", ""),
-                                "color": char.get("non_stroking_color", ""),
-                                "position": (char["x0"], char["top"]),
-                            }
-                        )
-
-            return debug_info
-
-    except Exception as e:
-        return {"error": str(e)}
-
+    return {
+        "raw_bytes": raw_bytes,
+        "text": text,
+        "has_visual_markup": _has_visual_markup(raw_bytes),
+    }

--- a/actions/extract/utils/text_extraction.py
+++ b/actions/extract/utils/text_extraction.py
@@ -28,12 +28,7 @@ from .common import (
 # Import specialized extractors
 from .xml_extractor import extract_text_from_xml
 from .html_extractor import download_html_content, extract_text_from_html
-from .pdf_extractor import (
-    download_pdf_content,
-    extract_text_from_pdf,
-    extract_text_with_strikethroughs,
-    debug_pdf_structure,
-)
+from .pdf_extractor import extract_pdf
 
 
 def create_safe_filename(
@@ -303,7 +298,8 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
 
                 # Download content based on media type
                 content = None
-                strikethrough_info = None
+                is_binary_content = False
+                has_visual_markup = False
 
                 if "xml" in media_type.lower():
                     content = download_bill_text(url)
@@ -312,27 +308,17 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                         url, download_with_retry, download_congress_gov_content
                     )
                 elif "pdf" in media_type.lower():
-                    # Try enhanced strikethrough detection first
-                    strikethrough_result = extract_text_with_strikethroughs(
-                        url, download_with_retry
-                    )
-                    if strikethrough_result and strikethrough_result.get("raw_text"):
-                        content = strikethrough_result["raw_text"]
-                        strikethrough_info = {
-                            "has_strikethroughs": strikethrough_result.get(
-                                "has_strikethroughs", False
-                            ),
-                            "strikethrough_count": strikethrough_result.get(
-                                "strikethrough_count", 0
-                            ),
-                        }
-                        if strikethrough_info["has_strikethroughs"]:
+                    pdf_result = extract_pdf(url, download_with_retry)
+                    if pdf_result:
+                        content = pdf_result["raw_bytes"]
+                        is_binary_content = True
+                        has_visual_markup = pdf_result["has_visual_markup"]
+                        if has_visual_markup:
                             print(
-                                f"   🔍 Detected {strikethrough_info['strikethrough_count']} strikethrough sections"
+                                f"   🔍 Detected likely redline/strikethrough markup -- "
+                                f"flagged for full-fidelity review"
                             )
-                    else:
-                        # Fallback to regular PDF extraction
-                        content = download_pdf_content(url, download_with_retry)
+                        extracted_text = pdf_result["text"]
                 else:
                     print(f"   ⚠️ Unsupported media type: {media_type}")
                     continue
@@ -356,22 +342,31 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                     )
                     continue
 
-                print(f"   📄 Downloaded {len(content)} characters")
+                print(f"   📄 Downloaded {len(content)} {'bytes' if is_binary_content else 'characters'}")
 
-                # Extract text based on content type
+                # Extract text based on content type. One clean read per
+                # document -- no section-splitting, since arbitrary
+                # formatting-based splits don't reliably capture anything
+                # meaningful across 56 states' differing bill formats, and
+                # duplicating the full text under both a "sections" and a
+                # "raw text" view was actively confusing for anything
+                # reading the output (human or AI).
                 extracted_data = None
                 if "xml" in media_type.lower():
                     extracted_data = extract_text_from_xml(content)
                 elif "html" in media_type.lower():
                     extracted_data = extract_text_from_html(content)
                 elif "pdf" in media_type.lower():
-                    extracted_data = extract_text_from_pdf(content)
+                    extracted_data = {
+                        "title": "",
+                        "official_title": "",
+                        "raw_text": extracted_text,
+                    }
                 else:
                     extracted_data = {
                         "raw_text": content,
                         "title": "",
                         "official_title": "",
-                        "sections": [],
                     }
 
                 if "error" in extracted_data:
@@ -389,17 +384,24 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                     )
                     continue
 
-                # Save original content
+                # Save original content -- genuine bytes for PDFs (needed to
+                # hand off the real document later, e.g. to a vision-capable
+                # model for redline-heavy bills), plain text for XML/HTML.
                 print(f"   💾 Saving {file_extension.upper()} to: {content_file}")
                 try:
-                    with open(content_file, "w", encoding="utf-8") as f:
-                        f.write(content)
+                    if is_binary_content:
+                        with open(content_file, "wb") as f:
+                            f.write(content)
+                    else:
+                        with open(content_file, "w", encoding="utf-8") as f:
+                            f.write(content)
                     print(f"   ✅ {file_extension.upper()} saved successfully")
                 except Exception as e:
                     print(f"   ❌ Error saving {file_extension.upper()}: {e}")
                     continue
 
-                # Save extracted text
+                # Save extracted text -- a single clean read, no artificial
+                # section-splitting.
                 print(f"   💾 Saving extracted text to: {text_file}")
                 try:
                     with open(text_file, "w", encoding="utf-8") as f:
@@ -407,26 +409,16 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                         f.write(
                             f"Official Title: {extracted_data.get('official_title', 'N/A')}\n"
                         )
-                        f.write(
-                            f"Number of Sections: {len(extracted_data.get('sections', []))}\n"
-                        )
                         f.write(f"Source: {array_name} - {item_note}\n")
                         f.write(f"Media Type: {media_type}\n")
-                        if strikethrough_info and strikethrough_info.get(
-                            "has_strikethroughs"
-                        ):
+                        if has_visual_markup:
                             f.write(
-                                f"Strikethrough Detection: {strikethrough_info['strikethrough_count']} sections found\n"
+                                "Visual Markup Detected: true -- this document likely "
+                                "contains redline (strikethrough/underline) formatting; "
+                                "plain text extraction may not faithfully represent what "
+                                "the bill changes. See the saved original file.\n"
                             )
                         f.write("\n" + "=" * 80 + "\n\n")
-
-                        for i, section in enumerate(
-                            extracted_data.get("sections", []), 1
-                        ):
-                            f.write(f"Section {i}:\n{section}\n\n")
-
-                        f.write("\n" + "=" * 80 + "\n\n")
-                        f.write("Raw Text:\n")
                         f.write(extracted_data.get("raw_text", ""))
                     print(f"   ✅ Text saved successfully")
                 except Exception as e:


### PR DESCRIPTION
## Summary

Three fixes to \`actions/extract\`'s PDF handling, all surfaced while investigating why a bill's extracted text was duplicated (ID H0493):

1. **Raw PDF storage bug**: the "original content" file (e.g. \`H0493_Bill_Text.pdf\`) was never actually the real PDF -- it was the already-extracted text, re-saved under a \`.pdf\`-looking filename, written in text mode. \`extract_pdf()\` now returns the genuine \`raw_bytes\` alongside the extracted text, written in binary mode. This matters for the plan to hand real PDFs to a vision-capable model for redline-heavy bills.
2. **Duplicated output**: every extracted \`.txt\` wrote the same content twice, once as a "Section N:" breakdown and once as "Raw Text:". Section-splitting rarely produced more than one section for real bills (the PDF regex broke on any state that numbers every line, i.e. most of them), so the whole document became "Section 1" and then got printed again as the raw dump. Dropped section-splitting entirely (across XML/HTML/PDF) in favor of one clean read.
3. **Strikethrough detection replaced with a geometry-based visual-markup flag**. The old heuristic guessed off font name/character spacing/color and produced unreadable garbage even when it fired. Replaced with a check for actual drawn line/rect objects (pdfplumber \`page.lines\`/\`page.rects\`) overlapping a character's vertical span -- catches both strikethrough and underline, which matter equally as a signal that a document needs full-fidelity (e.g. vision-LLM) handling rather than plain text extraction. This is a routing signal (\`has_visual_markup\`), not an attempt to reconstruct the marked text.

## Test plan
- [x] Verified against ID H0493 (real redline bill): raw bytes start with genuine \`%PDF-\` magic bytes, text is a single clean 2545-char read with no duplication, \`has_visual_markup\` correctly \`True\`
- [x] Verified \`has_visual_markup\` is \`False\` on a synthetic clean PDF with no drawn marks
- [x] No remaining references to removed functions (\`extract_text_from_pdf\`, \`download_pdf_content\`, \`extract_text_with_strikethroughs\`, \`debug_pdf_structure\`, \`is_likely_strikethrough\`)
- [x] No new dependencies -- pdfplumber/PyPDF2/PyMuPDF already in Pipfile
- [ ] Live run against a real state's extract-text workflow to confirm end-to-end

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>