### PR TITLE
fix: check-and-restart job was silently skipping every time (implicit success())

### DIFF
--- a/actions/format/docs/for-caller-repos/example-caller-text-extraction.yml
+++ b/actions/format/docs/for-caller-repos/example-caller-text-extraction.yml
@@ -41,12 +41,17 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  # The `always() &&` is load-bearing: GitHub Actions implicitly ANDs a
+  # job's if: with success() unless the condition calls a status-check
+  # function (always/success/failure/cancelled) -- without it, this job
+  # silently skips every time, since the needed job having failed makes
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read

--- a/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
@@ -66,12 +66,20 @@ jobs:
             echo "⚠️  Summary file not found"
           fi
 
-  # Auto-restart job if extraction was cancelled (timeout) or failed
+  # Auto-restart job if extraction was cancelled (timeout) or failed.
+  #
+  # The `always() &&` is load-bearing, not decoration: GitHub Actions
+  # implicitly ANDs a job's `if:` with success() unless the condition
+  # explicitly calls a status-check function (always/success/failure/
+  # cancelled). Without it, this job silently skipped every single time --
+  # confirmed across every real failure/cancellation this repo has hit so
+  # far (it never once ran) -- because the needed job having failed made
+  # the implicit success() false regardless of the explicit check below.
   check-and-restart:
     name: Check Status & Restart if Needed
     needs: extract-text
     runs-on: ubuntu-latest
-    if: needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'
+    if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
## Summary

\`check-and-restart\` (the job meant to auto-retrigger \`extract-text.yml\` after a timeout/failure, since a run against a large state can hit the ~6h GitHub Actions ceiling) has **never once actually run**, on any state, since it was written.

Checked every real case govbot-data has hit so far:
- 3 \`failure\` conclusions on \`ky-legislation\`
- 1 \`cancelled\` conclusion on \`la-legislation\` that ran the full 5h55m before GitHub killed it -- exactly the scenario this job exists for

In all 4 cases, \`check-and-restart\`'s own conclusion was \`skipped\`, confirmed via the jobs API.

**Root cause**: GitHub Actions implicitly ANDs a job's \`if:\` condition with \`success()\` unless the condition explicitly calls a status-check function (\`always()\`/\`success()\`/\`failure()\`/\`cancelled()\`). The existing condition (\`needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure'\`) doesn't call one, so GitHub silently required the needed job to have *also* succeeded -- which by definition it hadn't, in exactly the cases this job is supposed to catch.

**Fix**: \`if: always() && (needs.extract-text.result == 'cancelled' || needs.extract-text.result == 'failure')\`

## One thing this doesn't fix

\`PAT_WORKFLOW_TRIGGER\` (needed for the "Trigger workflow restart" step's \`gh workflow run\` call) isn't set as a repo secret on at least \`govbot-data/sd-legislation\` (checked directly -- \`total_count: 0\`). Couldn't check org-level secrets without elevated \`gh\` auth scope. Even with this fix, the restart step itself will fail until that secret exists -- flagging as a separate follow-up, not addressed in this PR.

## Test plan
- [x] Confirmed via jobs API that all 4 historical failure/cancellation cases showed check-and-restart as skipped
- [x] Snapshots regenerated for the corrected \`if:\` condition
- [ ] Next real timeout/failure on any PDF-only state will confirm the job actually runs now (will still likely fail at the "Trigger workflow restart" step until PAT_WORKFLOW_TRIGGER is provisioned)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>