### PR TITLE
docs: PDF visual-markup audit across the 28 PDF-only states

### DIFF
--- a/actions/extract/docs/2026-07-21-pdf-visual-markup-audit.md
+++ b/actions/extract/docs/2026-07-21-pdf-visual-markup-audit.md
@@ -1,0 +1,73 @@
+# PDF Visual-Markup Audit
+
+Audits how often bill PDFs from each "PDF-only" state (no HTML/XML alternative,
+per `actions/scrape/docs/bill-format-audit.md`) show detectable redline
+(strikethrough/underline) markup — the signal that decides whether a document
+needs full-fidelity handling (e.g. handing the raw PDF to a vision-capable
+model) versus plain-text extraction being trustworthy on its own.
+
+Run with `actions/extract/scripts/audit_pdf_visual_markup.py`, which samples
+up to 10 bills per state from the most recent session in `govbot-data`,
+downloads each bill's earliest and latest available PDF version directly from
+its original government source, and checks for real drawn line/rect objects
+overlapping text (the same `has_visual_markup` check used in production
+extraction — see `actions/extract/utils/pdf_extractor.py`).
+
+## Results (394 documents checked across 27 of 28 PDF-only states)
+
+| State | Checked | Markup | % | Notes |
+|---|--:|--:|--:|---|
+| AL | 16 | 16 | 100 | |
+| CO | 20 | 13 | 65 | |
+| CT | 14 | 14 | 100 | |
+| DC | 18 | 3 | 17 | |
+| FL | 9 | 9 | 100 | |
+| GA | 20 | 0 | 0 | |
+| GU | 10 | 10 | 100 | |
+| IA | 10 | 3 | 30 | |
+| ID | 11 | 11 | 100 | |
+| IN | 15 | 0 | 0 | |
+| KY | 12 | 11 | 92 | |
+| LA | 19 | 0 | 0 | |
+| MA | 10 | 1 | 10 | |
+| MD | 15 | 14 | 93 | |
+| ME | 8 | 0 | 0 | |
+| MO | 11 | 4 | 36 | |
+| MP | 12 | 1 | 8 | 1 error |
+| NC | 20 | 18 | 90 | |
+| ND | 20 | 20 | 100 | |
+| NE | 14 | 12 | 86 | |
+| NV | 20 | 16 | 80 | |
+| OK | 17 | 16 | 94 | |
+| OR | 14 | 13 | 93 | |
+| RI | 10 | 10 | 100 | |
+| TN | 17 | 9 | 53 | |
+| VT | 14 | 14 | 100 | |
+| WY | 18 | 11 | 61 | |
+| VI | 0 | — | — | Connection timeout to a non-standard port (8082); URL pattern (`/preview/Bill%2F...`) looks like it may not even be a direct PDF link. Not investigated further — one small territory, not worth blocking on. |
+| **TOTAL** | **394** | **249** | **63** | |
+
+## Reading
+
+- **Consistently high (~85-100%)**: AL, CT, FL, GU, ID, MD, ND, NE, NC, OK, OR, RI, VT, KY. These states' PDF generators appear to always draw redline-style marks, even on "as introduced"/"filed" versions that haven't been amended yet -- possibly a house style (e.g. always underlining new/added statutory language on first introduction), not just amendment tracking. Full-fidelity handling should be the default for these, not the exception.
+- **Consistently zero**: GA, IN, LA, ME (0% across 8-20 samples each). Plain text extraction is likely trustworthy for these without special handling.
+- **Mixed**: CO, DC, IA, MA, MO, MP, TN, WY, NV -- markup detected on a meaningful minority to majority of documents. These likely need the geometry check run per-document (which production already does) rather than a static per-state assumption either way.
+
+## Caveats
+
+- Sample is skewed toward each state's *most recent* session only, and mostly toward whatever version types happened to be available (many states only had one PDF version per bill this early in getting government scraped, so "earliest vs. latest version" comparison wasn't always possible).
+- This doesn't distinguish *why* markup is detected -- a states with a "100%" rate could be drawing lines for something other than redline (underlining bill numbers, etc.), though spot-checks against ID (H0493) and the synthetic clean-PDF test suggest the detector is behaving correctly, not over-firing on unrelated marks.
+- VI is an open gap (see above).
+
+## Related finding, not part of this audit
+
+While digging into a separate reported issue, found that **SD's HTML bill
+pages are JS-rendered loading shells** (a Vue.js SPA) -- `text/html` versions
+return "please enable JavaScript" boilerplate, not real bill text. SD also
+serves working PDFs for the same bills, but production's format preference
+(`text/xml > text/html > application/pdf`) picks the broken HTML over the
+working PDF, since nothing currently detects the HTML is a placeholder.
+Spot-checked MN and WV (the two states listed as HTML-only, no PDF fallback,
+in `bill-format-audit.md`) and both show genuine real content -- this appears
+specific to SD's site, not a systemic HTML-only-states problem. Not fixed as
+part of this audit; tracked separately.

--- a/actions/extract/scripts/audit_pdf_visual_markup.py
+++ b/actions/extract/scripts/audit_pdf_visual_markup.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+One-time audit: how prevalent is redline (strikethrough/underline) markup
+in each state's bill PDFs?
+
+Samples up to SAMPLE_SIZE bills per state from govbot-data's most recent
+session, downloads each bill's earliest and latest available PDF version
+directly from its original government source URL, and runs the same
+geometry-based visual-markup check used in production extraction
+(actions/extract/utils/pdf_extractor.py's _has_visual_markup).
+
+Not part of the recurring pipeline -- this is research to decide which
+states can safely stay on cheap plain-text extraction versus which need
+full-fidelity (e.g. vision-LLM) handling by default.
+
+Usage:
+    python3 audit_pdf_visual_markup.py [--sample-size N] [--states al,ak,...]
+
+Writes incremental results to audit_pdf_visual_markup_results.jsonl (one
+JSON object per checked document) so progress survives a crash/interrupt,
+and prints a per-state summary at the end (or run with --summarize-only
+to just re-summarize an existing results file).
+"""
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils.pdf_extractor import _has_visual_markup  # noqa: E402
+
+RESULTS_FILE = Path(__file__).parent / "audit_pdf_visual_markup_results.jsonl"
+
+# Production already prefers text/xml > text/html > application/pdf > text/plain
+# (see MEDIA_TYPE_PREFERENCE in utils/text_extraction.py), so states offering an
+# HTML/XML/msword alternative never actually hit the PDF path in practice --
+# auditing PDF markup for them is moot. This is the "PDF only" list from
+# actions/scrape/docs/bill-format-audit.md (2026-07-02); update if that audit
+# is refreshed and a state's format mix changes.
+PDF_ONLY_STATES = [
+    "al", "co", "ct", "dc", "fl", "ga", "gu", "ia", "id", "in", "ky", "la",
+    "ma", "md", "me", "mo", "mp", "nc", "nd", "ne", "nv", "ok", "or", "ri",
+    "tn", "vi", "vt", "wy",
+]
+
+GH_TOKEN = subprocess.run(
+    ["gh", "auth", "token"], capture_output=True, text=True, check=True
+).stdout.strip()
+GH_HEADERS = {"Authorization": f"token {GH_TOKEN}", "Accept": "application/vnd.github+json"}
+
+
+def gh_api(path: str):
+    r = requests.get(f"https://api.github.com/{path}", headers=GH_HEADERS, timeout=30)
+    if r.status_code != 200:
+        return None
+    return r.json()
+
+
+def get_all_states() -> list:
+    repos = gh_api("orgs/govbot-data/repos?per_page=100")
+    if not repos:
+        return []
+    return sorted(r["name"][: -len("-legislation")] for r in repos if r["name"].endswith("-legislation"))
+
+
+def list_sample_bills(state: str, limit: int) -> list:
+    """Return [(session, bill_dir), ...] from the most recent-looking session."""
+    repo = f"govbot-data/{state}-legislation"
+    sessions_dir = gh_api(f"repos/{repo}/contents/country:us/state:{state}/sessions")
+    if not sessions_dir:
+        return []
+    sessions = sorted(d["name"] for d in sessions_dir if d["type"] == "dir")
+    if not sessions:
+        return []
+    session = sessions[-1]  # most recent-looking (lexicographic, e.g. "2026" or "20252026")
+    bills_dir = gh_api(f"repos/{repo}/contents/country:us/state:{state}/sessions/{session}/bills")
+    if not bills_dir:
+        return []
+    bill_names = [d["name"] for d in bills_dir if d["type"] == "dir"][:limit]
+    return [(session, b) for b in bill_names]
+
+
+def get_metadata(state: str, session: str, bill: str) -> dict:
+    repo = f"govbot-data/{state}-legislation"
+    path = f"country:us/state:{state}/sessions/{session}/bills/{bill}/metadata.json"
+    data = gh_api(f"repos/{repo}/contents/{path}")
+    if not data or "content" not in data:
+        return None
+    try:
+        return json.loads(base64.b64decode(data["content"]))
+    except Exception:
+        return None
+
+
+def pick_pdf_versions(metadata: dict) -> list:
+    """Return up to 2 (note, url) pairs: earliest and latest PDF versions available."""
+    pdf_versions = []
+    for v in metadata.get("versions", []):
+        for link in v.get("links", []):
+            if "pdf" in link.get("media_type", "").lower():
+                pdf_versions.append((v.get("note", "") or v.get("date", ""), link["url"]))
+                break
+    if len(pdf_versions) <= 2:
+        return pdf_versions
+    return [pdf_versions[0], pdf_versions[-1]]
+
+
+def download_and_check(url: str):
+    """Returns True/False for visual markup detected, or None on download/parse failure."""
+    try:
+        # verify=False matches actions/extract/utils/common.py's own
+        # download_with_retry() -- several state legislature sites (e.g.
+        # cga.ct.gov, legislature.vermont.gov) serve an incomplete cert
+        # chain that strict clients reject even with an up-to-date trust
+        # bundle; production already made this tradeoff deliberately.
+        resp = requests.get(
+            url,
+            timeout=30,
+            headers={"User-Agent": "Mozilla/5.0 (govbot-audit-script)"},
+            verify=False,
+        )
+        if resp.status_code != 200 or not resp.content:
+            return None
+        return _has_visual_markup(resp.content)
+    except Exception:
+        return None
+
+
+def append_result(record: dict):
+    with open(RESULTS_FILE, "a") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def already_checked() -> set:
+    """Set of (state, bill, note) already recorded, for resuming a partial run."""
+    if not RESULTS_FILE.exists():
+        return set()
+    seen = set()
+    with open(RESULTS_FILE) as f:
+        for line in f:
+            try:
+                r = json.loads(line)
+                seen.add((r["state"], r["bill"], r["note"]))
+            except Exception:
+                continue
+    return seen
+
+
+def summarize():
+    if not RESULTS_FILE.exists():
+        print("No results file yet.")
+        return
+    by_state = defaultdict(list)
+    errors = defaultdict(int)
+    with open(RESULTS_FILE) as f:
+        for line in f:
+            r = json.loads(line)
+            if r["has_visual_markup"] is None:
+                errors[r["state"]] += 1
+                continue
+            by_state[r["state"]].append(r["has_visual_markup"])
+
+    print(f"\n{'State':<6}{'Checked':<10}{'Markup':<10}{'%':<8}{'Errors'}")
+    print("-" * 45)
+    total_checked, total_markup = 0, 0
+    for state in sorted(by_state):
+        vals = by_state[state]
+        n_markup = sum(vals)
+        pct = 100 * n_markup / len(vals) if vals else 0
+        total_checked += len(vals)
+        total_markup += n_markup
+        print(f"{state:<6}{len(vals):<10}{n_markup:<10}{pct:<7.0f}{errors.get(state, 0)}")
+    print("-" * 45)
+    overall_pct = 100 * total_markup / total_checked if total_checked else 0
+    print(f"{'TOTAL':<6}{total_checked:<10}{total_markup:<10}{overall_pct:<7.0f}{sum(errors.values())}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sample-size", type=int, default=10)
+    parser.add_argument(
+        "--states",
+        default=None,
+        help="Comma-separated state codes; default: the 28 PDF-only states "
+        "(others already use HTML/XML in production, see bill-format-audit.md)",
+    )
+    parser.add_argument(
+        "--all-states", action="store_true", help="Audit all 56 states, not just PDF-only ones"
+    )
+    parser.add_argument("--summarize-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.summarize_only:
+        summarize()
+        return
+
+    if args.states:
+        states = args.states.split(",")
+    elif args.all_states:
+        states = get_all_states()
+    else:
+        states = PDF_ONLY_STATES
+    print(f"Auditing {len(states)} states, up to {args.sample_size} bills each")
+
+    seen = already_checked()
+
+    for state in states:
+        bills = list_sample_bills(state, args.sample_size)
+        print(f"=== {state}: {len(bills)} bills sampled ===")
+        for session, bill in bills:
+            metadata = get_metadata(state, session, bill)
+            if not metadata:
+                continue
+            for note, url in pick_pdf_versions(metadata):
+                if (state, bill, note) in seen:
+                    continue
+                markup = download_and_check(url)
+                print(f"   {bill} [{note}]: has_visual_markup={markup}")
+                append_result(
+                    {
+                        "state": state,
+                        "bill": bill,
+                        "note": note,
+                        "url": url,
+                        "has_visual_markup": markup,
+                    }
+                )
+                time.sleep(0.3)  # be polite to state government servers
+
+    summarize()
+
+
+if __name__ == "__main__":
+    main()

--- a/actions/extract/scripts/audit_pdf_visual_markup_results.jsonl
+++ b/actions/extract/scripts/audit_pdf_visual_markup_results.jsonl
@@ -1,0 +1,406 @@
+{"state": "al", "bill": "HB1", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB1-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB1", "note": "Motion to Adopt - Adopted Roll Call 224", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/JP8ATFN-1.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB10", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB10-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB100", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB100-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB100", "note": "Reported Out Committee House of Origin-- Committee Amendment", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/84IXKH2-1.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB101", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB101-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB101", "note": "Reported Out of Committee House of Origin", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/CX3HXQQ-1.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB102", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB102-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB102", "note": "Motion to Adopt - Adopted Roll Call 851", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/MSQVA1W-1.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB103", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB103-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB104", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB104-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB104", "note": "Albritton motion to Adopt - Adopted Roll Call 767", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/BYKDLQJ-1.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB105", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB105-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB106", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB106-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB107", "note": "Introduced", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB107-int.pdf", "has_visual_markup": true}
+{"state": "al", "bill": "HB107", "note": "Motion to Adopt - Adopted Roll Call 340", "url": "https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/4UXNS3R-1.pdf", "has_visual_markup": true}
+{"state": "co", "bill": "HB1001", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/113728/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1001", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110668/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1002", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/115302/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1002", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110657/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1003", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116849/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1003", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110670/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1004", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116791/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1004", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110672/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1005", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/117241/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1005", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110674/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1006", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116970/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1006", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110676/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1007", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116074/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1007", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110678/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1008", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116751/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1008", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110680/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1009", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/117051/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1009", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110682/download", "has_visual_markup": true}
+{"state": "co", "bill": "HB1010", "note": "Signed Act", "url": "https://leg.colorado.gov/bill_files/116975/download", "has_visual_markup": false}
+{"state": "co", "bill": "HB1010", "note": "Introduced", "url": "https://leg.colorado.gov/bill_files/110684/download", "has_visual_markup": true}
+{"state": "dc", "bill": "B26-0001", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56820/Introduction/B26-0001-Introduction.pdf?Id=203761", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0001", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56820/Meeting1/Enrollment/B26-0001-Enrollment1.pdf?Id=204336", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0002", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56824/Introduction/B26-0002-Introduction.pdf?Id=203787", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0002", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56824/Meeting1/Enrollment/B26-0002-Enrollment1.pdf?Id=206500", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0003", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56822/Introduction/B26-0003-Introduction.pdf?Id=203780", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0003", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56822/Meeting2/Enrollment/B26-0003-Enrollment1.pdf?Id=205874", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0004", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56826/Introduction/B26-0004-Introduction.pdf?Id=203795", "has_visual_markup": true}
+{"state": "dc", "bill": "B26-0004", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56826/Meeting1/Enrollment/B26-0004-Enrollment1.pdf?Id=204337", "has_visual_markup": true}
+{"state": "dc", "bill": "B26-0005", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56829/Introduction/B26-0005-Introduction.pdf?Id=203830", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0005", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56829/Meeting1/Enrollment/B26-0005-Enrollment1.pdf?Id=204339", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0006", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56832/Introduction/B26-0006-Introduction.pdf?Id=203846", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0006", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56832/Meeting1/Enrollment/B26-0006-Enrollment2.pdf?Id=204340", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0007", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56833/Introduction/B26-0007-Introduction.pdf?Id=203851", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0007", "note": "Engrossment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56833/Meeting1/Engrossment/B26-0007-Engrossment1.pdf?Id=204345", "has_visual_markup": true}
+{"state": "dc", "bill": "B26-0008", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56834/Introduction/B26-0008-Introduction.pdf?Id=203865", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0009", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56835/Introduction/B26-0009-Introduction.pdf?Id=203870", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0010", "note": "Introduction", "url": "https://lims.dccouncil.gov/downloads/LIMS/56836/Introduction/B26-0010-Introduction.pdf?Id=203874", "has_visual_markup": false}
+{"state": "dc", "bill": "B26-0010", "note": "Enrollment", "url": "https://lims.dccouncil.gov/downloads/LIMS/56836/Meeting2/Enrollment/B26-0010-Enrollment1.pdf?Id=227211", "has_visual_markup": false}
+{"state": "fl", "bill": "HB3F", "note": "H 3F Filed", "url": "https://flsenate.gov/Session/Bill/2026F/3F/BillText/Filed/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "HB3F", "note": "H 3F c1", "url": "https://flsenate.gov/Session/Bill/2026F/3F/BillText/c1/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "HJR11F", "note": "H 11F Filed", "url": "https://flsenate.gov/Session/Bill/2026F/11F/BillText/Filed/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "HJR1F", "note": "H 1F Filed", "url": "https://flsenate.gov/Session/Bill/2026F/1F/BillText/Filed/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "HJR1F", "note": "H 1F er", "url": "https://flsenate.gov/Session/Bill/2026F/1F/BillText/er/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "SB4F", "note": "S 4F Filed", "url": "https://flsenate.gov/Session/Bill/2026F/4F/BillText/Filed/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "SB4F", "note": "S 4F er", "url": "https://flsenate.gov/Session/Bill/2026F/4F/BillText/er/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "SJR2F", "note": "S 2F Filed", "url": "https://flsenate.gov/Session/Bill/2026F/2F/BillText/Filed/PDF", "has_visual_markup": true}
+{"state": "fl", "bill": "SJR2F", "note": "S 2F c1", "url": "https://flsenate.gov/Session/Bill/2026F/2F/BillText/c1/PDF", "has_visual_markup": true}
+{"state": "ga", "bill": "HB1", "note": "LC 46 1571/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249298", "has_visual_markup": false}
+{"state": "ga", "bill": "HB1", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249505", "has_visual_markup": false}
+{"state": "ga", "bill": "HB10", "note": "LC 44 3587/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249310", "has_visual_markup": false}
+{"state": "ga", "bill": "HB10", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249514", "has_visual_markup": false}
+{"state": "ga", "bill": "HB11", "note": "LC 47 4345/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249312", "has_visual_markup": false}
+{"state": "ga", "bill": "HB11", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249515", "has_visual_markup": false}
+{"state": "ga", "bill": "HB12", "note": "LC 47 4388/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249313", "has_visual_markup": false}
+{"state": "ga", "bill": "HB12", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249516", "has_visual_markup": false}
+{"state": "ga", "bill": "HB13", "note": "LC 44 3588/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249314", "has_visual_markup": false}
+{"state": "ga", "bill": "HB13", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249517", "has_visual_markup": false}
+{"state": "ga", "bill": "HB14", "note": "LC 62 0535/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249315", "has_visual_markup": false}
+{"state": "ga", "bill": "HB14", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249518", "has_visual_markup": false}
+{"state": "ga", "bill": "HB15", "note": "LC 62 0565/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249316", "has_visual_markup": false}
+{"state": "ga", "bill": "HB15", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249519", "has_visual_markup": false}
+{"state": "ga", "bill": "HB16", "note": "LC 62 0564/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249317", "has_visual_markup": false}
+{"state": "ga", "bill": "HB16", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249520", "has_visual_markup": false}
+{"state": "ga", "bill": "HB17", "note": "LC 47 4375/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249318", "has_visual_markup": false}
+{"state": "ga", "bill": "HB17", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249521", "has_visual_markup": false}
+{"state": "ga", "bill": "HB18", "note": "LC 62 0548/a", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249319", "has_visual_markup": false}
+{"state": "ga", "bill": "HB18", "note": "Local Ad", "url": "https://www.legis.ga.gov/api/legislation/document/2026EX/249522", "has_visual_markup": false}
+{"state": "gu", "bill": "B1-38", "note": "Bill No. 1-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 1-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B10-38", "note": "Bill No. 10-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 10-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B100-38", "note": "Bill No. 100-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 100-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B101-38", "note": "Bill No. 101-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 101-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B102-38", "note": "Bill No. 102-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 102-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B103-38", "note": "Bill No. 103-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 103-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B104-38", "note": "Bill No. 104-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 104-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B105-38", "note": "Bill No. 105-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 105-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B106-38", "note": "Bill No. 106-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 106-38 (COR).pdf", "has_visual_markup": true}
+{"state": "gu", "bill": "B107-38", "note": "Bill No. 107-38 (COR)", "url": "http://guamlegislature.gov/38th_Guam_Legislature/Bill_History_38th/STATUS Bill No. 107-38 (COR).pdf", "has_visual_markup": true}
+{"state": "ia", "bill": "5302XD", "note": "Prefiled", "url": "https://www.legis.iowa.gov/docs/publications/BP/1544404.pdf", "has_visual_markup": true}
+{"state": "ia", "bill": "5304XD", "note": "Prefiled", "url": "https://www.legis.iowa.gov/docs/publications/BP/1544391.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "5354XD", "note": "Prefiled", "url": "https://www.legis.iowa.gov/docs/publications/BP/1544366.pdf", "has_visual_markup": true}
+{"state": "ia", "bill": "5393XD", "note": "Prefiled", "url": "https://www.legis.iowa.gov/docs/publications/BP/1544398.pdf", "has_visual_markup": true}
+{"state": "ia", "bill": "HCR1", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR1.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "HCR101", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR101.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "HCR102", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR102.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "HCR103", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR103.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "HCR104", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR104.pdf", "has_visual_markup": false}
+{"state": "ia", "bill": "HCR2", "note": "Introduced", "url": "https://www.legis.iowa.gov/docs/publications/LGI/91/HCR2.pdf", "has_visual_markup": false}
+{"state": "id", "bill": "H0489", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0489.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0490", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0490.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0491", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0491.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0492", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0492.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0493", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0493.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0494", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0494.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0494", "note": "Engrossment 1", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0494E1.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0495", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0495.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0496", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0496.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0497", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0497.pdf", "has_visual_markup": true}
+{"state": "id", "bill": "H0498", "note": "Bill Text", "url": "https://legislature.idaho.gov/wp-content/uploads/sessioninfo/2026/legislation/H0498.pdf", "has_visual_markup": true}
+{"state": "in", "bill": "HB1001", "note": "Enrolled House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1001/HB1001.06.ENRS.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1001", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1001/HB1001.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1002", "note": "Enrolled House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1002/HB1002.06.ENRS.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1002", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1002/HB1002.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1003", "note": "Enrolled House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1003/HB1003.07.ENRS.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1003", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1003/HB1003.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1004", "note": "Enrolled House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1004/HB1004.07.ENRS.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1004", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1004/HB1004.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1011", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1011/HB1011.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1012", "note": "House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1012/HB1012.02.COMH.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1012", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1012/HB1012.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1013", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1013/HB1013.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1014", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1014/HB1014.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1015", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1015/HB1015.01.INTR.pdf", "has_visual_markup": false}
+{"state": "in", "bill": "HB1016", "note": "Introduced House Bill (H)", "url": "https://iga.in.gov/pdf-documents/124/2026/house/bills/HB1016/HB1016.01.INTR.pdf", "has_visual_markup": false}
+{"state": "ky", "bill": "HB1", "note": "Acts Chapter 4", "url": "https://apps.legislature.ky.gov/law/acts/26RS/documents/0004.pdf", "has_visual_markup": false}
+{"state": "ky", "bill": "HB1", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb1/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB10", "note": "Acts Chapter 178", "url": "https://apps.legislature.ky.gov/law/acts/26RS/documents/0178.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB10", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb10/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB100", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb100/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB101", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb101/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB102", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb102/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB103", "note": "Current/Final", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb103/bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB103", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb103/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB104", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb104/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB106", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb106/orig_bill.pdf", "has_visual_markup": true}
+{"state": "ky", "bill": "HB107", "note": "Introduced", "url": "https://apps.legislature.ky.gov/recorddocuments/bill/26RS/hb107/orig_bill.pdf", "has_visual_markup": true}
+{"state": "la", "bill": "HB1", "note": "HB1 Act 3", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1481824", "has_visual_markup": false}
+{"state": "la", "bill": "HB1", "note": "House Committee Amendment, #3574, APP, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1461126", "has_visual_markup": false}
+{"state": "la", "bill": "HB10", "note": "HB10 Act", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1473851", "has_visual_markup": false}
+{"state": "la", "bill": "HB10", "note": "HB10 Original", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1434366", "has_visual_markup": false}
+{"state": "la", "bill": "HB100", "note": "HB100 Original", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1437540", "has_visual_markup": false}
+{"state": "la", "bill": "HB100", "note": "House Committee Amendment, #2020, ACRJ, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1452658", "has_visual_markup": false}
+{"state": "la", "bill": "HB1000", "note": "HB1000 Act 449", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1480299", "has_visual_markup": false}
+{"state": "la", "bill": "HB1000", "note": "House Committee Amendment, #4009, THPW, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1463602", "has_visual_markup": false}
+{"state": "la", "bill": "HB1001", "note": "HB1001 Act 686", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1480639", "has_visual_markup": false}
+{"state": "la", "bill": "HB1001", "note": "HB1001 Original", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1453229", "has_visual_markup": false}
+{"state": "la", "bill": "HB1002", "note": "HB1002 Original", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1453244", "has_visual_markup": false}
+{"state": "la", "bill": "HB1003", "note": "HB1003 Act 687", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1480640", "has_visual_markup": false}
+{"state": "la", "bill": "HB1003", "note": "House Committee Amendment, #3104, EDUC, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1458940", "has_visual_markup": false}
+{"state": "la", "bill": "HB1004", "note": "HB1004 Original", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1453273", "has_visual_markup": false}
+{"state": "la", "bill": "HB1004", "note": "House Committee Amendment, #2701, JUD, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1455216", "has_visual_markup": false}
+{"state": "la", "bill": "HB1005", "note": "HB1005 Act 862", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1481493", "has_visual_markup": false}
+{"state": "la", "bill": "HB1005", "note": "House Committee Amendment, #2448, ACRJ, Draft", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1453949", "has_visual_markup": false}
+{"state": "la", "bill": "HB1006", "note": "HB1006 Reengrossed", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1462453", "has_visual_markup": false}
+{"state": "la", "bill": "HB1006", "note": "House Floor Amendment, #3758, Carter, Wilford, Adopted", "url": "https://www.legis.la.gov/Legis/ViewDocument.aspx?d=1462053", "has_visual_markup": false}
+{"state": "ma", "bill": "H1", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1.pdf", "has_visual_markup": true}
+{"state": "ma", "bill": "H10", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H10.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H100", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H100.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1000", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1000.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1001", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1001.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1002", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1002.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1003", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1003.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1004", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1004.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1005", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1005.pdf", "has_visual_markup": false}
+{"state": "ma", "bill": "H1006", "note": "Bill Text", "url": "https://malegislature.gov/Bills/194/H1006.pdf", "has_visual_markup": false}
+{"state": "md", "bill": "HB0001", "note": "First - Investor-Owned Electric, Gas, and Gas and Electric Companies - Cost Recovery - Limitations", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0001f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0001", "note": "Third - Investor-Owned Electric, Gas, and Gas and Electric Companies - Cost Recovery - Limitations", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0001t.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0002", "note": "First - Subtraction Modification - Public Safety Retirement Income", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0002f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0003", "note": "First - Higher Education - Nonresident Tuition - Exemption for Dependents of State or Local Public Safety Employees (Maryland Fallen Heroes Tuition Benefits Act)", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0003f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0003", "note": "Chapter - Higher Education - Student Financial Assistance - Dependents of State or Local Public Safety Employees (Maryland Fallen Heroes Tuition Benefits Act)", "url": "http://mgaleg.maryland.gov/2026RS/Chapters_noln/CH_798_hb0003e.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0004", "note": "First - Vehicle Laws \u2013 Historic Motor Vehicles \u2013 Minimum Age", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0004f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0005", "note": "First - Community Development - Maryland New Markets Development Program - Establishment", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0005f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0006", "note": "First - Public Institutions of Higher Education - Pregnant and Parenting Students - Plan and Reporting", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0006f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0006", "note": "Chapter - Public Institutions of Higher Education - Pregnant and Parenting Students - Plan and Reporting", "url": "http://mgaleg.maryland.gov/2026RS/Chapters_noln/CH_735_hb0006e.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0007", "note": "First - State Board of Examiners for Audiologists, Hearing Aid Dispensers, Speech-Language Pathologists, and Music Therapists - Authority to Issue Limited Licenses to Practice Music Therapy", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0007f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0007", "note": "Chapter - State Board of Examiners for Audiologists, Hearing Aid Dispensers, Speech-Language Pathologists, and Music Therapists - Authority to Issue Limited Licenses to Practice Music Therapy", "url": "http://mgaleg.maryland.gov/2026RS/Chapters_noln/CH_30_hb0007t.pdf", "has_visual_markup": false}
+{"state": "md", "bill": "HB0008", "note": "First - Vehicle Laws - Dangerous Driver Abatement Program - Establishment (Dangerous Driver Accountability Act)", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0008f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0009", "note": "First - 3-1-1 Systems - Expansion Program and Oversight Board - Establishment", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0009f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0010", "note": "First - Legal Advertisement or Legal Notice - Publication in Newspaper or Newspaper in General Circulation - Digital Newspapers", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0010f.pdf", "has_visual_markup": true}
+{"state": "md", "bill": "HB0010", "note": "Third - Legal Advertisement or Legal Notice - Publication in Newspaper or Newspaper in General Circulation - Digital Newspapers", "url": "http://mgaleg.maryland.gov/2026RS/bills/hb/hb0010t.pdf", "has_visual_markup": true}
+{"state": "me", "bill": "HP1", "note": "LD 0 HP 1", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP0001&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1001", "note": "LD 0 HP 1001", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1001&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1155", "note": "LD 0 HP 1155", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1155&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1181", "note": "LD 0 HP 1181", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1181&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1185", "note": "LD 0 HP 1185", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1185&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1206", "note": "LD 0 HP 1206", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1206&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1241", "note": "LD 0 HP 1241", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1241&item=1&snum=132", "has_visual_markup": false}
+{"state": "me", "bill": "HP1242", "note": "LD 0 HP 1242", "url": "http://www.mainelegislature.org/legis/bills/getPDF.asp?paper=HP1242&item=1&snum=132", "has_visual_markup": false}
+{"state": "mo", "bill": "HB10", "note": "Truly Agreed and Finally Passed", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/0010H.06T.pdf", "has_visual_markup": true}
+{"state": "mo", "bill": "HB11", "note": "Truly Agreed and Finally Passed", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/0011H.06T.pdf", "has_visual_markup": true}
+{"state": "mo", "bill": "HB12", "note": "Truly Agreed and Finally Passed", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/0012H.06T.pdf", "has_visual_markup": true}
+{"state": "mo", "bill": "HB13", "note": "Truly Agreed and Finally Passed", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/0013H.04T.pdf", "has_visual_markup": true}
+{"state": "mo", "bill": "HB1607", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5106H.01I.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1608", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5076H.01I.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1609", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5109H.01I.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1610", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5052H.01I.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1611", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5100H.01I.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1611", "note": "House Committee Substitute", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5100H.02C.pdf", "has_visual_markup": false}
+{"state": "mo", "bill": "HB1612", "note": "Introduced", "url": "https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/5110H.01I.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-1", "note": "HB 24-1", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-1.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-1", "note": "P.L. 24-08", "url": "https://cnmileg.net/documents/files/24TH%20UPDATE/PL24-08.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-2", "note": "HB 24-2", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-2.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-2", "note": "P.L. 24-09", "url": "https://cnmileg.net/documents/files/24TH%20UPDATE/PL%2024-09%20(HB%2024-2%20To%20rename%20the%20%E2%80%9CCNMI%20Scholarship%20Office%E2%80%9D%20to%20the%20%E2%80%9CCNMI%20Scholarship%20and%20Financial%20Assistance%20Office.%E2%80%9D%E2%80%9D).pdf", "has_visual_markup": null}
+{"state": "mp", "bill": "HB24-3", "note": "HB 24-3", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-3.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-4", "note": "HB 24-4", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-4.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-5", "note": "HB 24-5", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-5.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HB24-6", "note": "HB 24-6", "url": "https://cnmileg.net/documents/house/hse_bills/24/HB24-6.pdf", "has_visual_markup": true}
+{"state": "mp", "bill": "HB24-6", "note": "P.L. 24-01", "url": "https://cnmileg.net/documents/files/23rd%20update/PL%2024-01%20(HB%2024-6%20HD1%20FY%202025%20REVISED%20BUDGET%20ACT).pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HCR24-1", "note": "HCR 24-1", "url": "https://cnmileg.net/documents/house/hse_conres/24/HCR24-1.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HCR24-2", "note": "HCR 24-2", "url": "https://cnmileg.net/documents/house/hse_conres/24/HCR24-2.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HCR24-3", "note": "HCR 24-3", "url": "https://cnmileg.net/documents/house/hse_conres/24/HCR24-3.pdf", "has_visual_markup": false}
+{"state": "mp", "bill": "HCommRes24-1", "note": "HCommRes 24-1", "url": "https://cnmileg.net/documents/house/hse_comres/24/HCommRes24-1.pdf", "has_visual_markup": false}
+{"state": "nc", "bill": "HB10", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H10v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB10", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H10v1.pdf", "has_visual_markup": false}
+{"state": "nc", "bill": "HB100", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H100v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB100", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H100v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1000", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1000v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1000", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1000v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1001", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1001v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1001", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1001v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1002", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1002v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1002", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1002v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1003", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1003v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1003", "note": "A1: ACC-8-V-2", "url": "https://webservices.ncleg.gov/ViewBillDocument/2025/5627/0/H1003-ACC-8-V-2", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1004", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1004v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1004", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1004v1.pdf", "has_visual_markup": false}
+{"state": "nc", "bill": "HB1005", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1005v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1005", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1005v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1006", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1006v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1006", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1006v1.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1008", "note": "Filed", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1008v0.pdf", "has_visual_markup": true}
+{"state": "nc", "bill": "HB1008", "note": "Edition 1", "url": "https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H1008v1.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1001", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0145-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1001", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0145-04000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1002", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0146-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1002", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0146-03000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1003", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0147-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1003", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0147-06000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1004", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0148-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1004", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0148-04000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1005", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0149-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1005", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0149-04000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1006", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0150-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1006", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0150-05000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1007", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0151-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1007", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0151-03000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1008", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0152-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1008", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0152-04000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1009", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0153-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1009", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0153-06000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1010", "note": "INTRODUCED", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0154-01000.pdf", "has_visual_markup": true}
+{"state": "nd", "bill": "HB1010", "note": "Enrollment", "url": "https://ndlegis.gov/assembly/69-2025/regular/documents/25-0154-05000.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1", "note": "Slip Law", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Slip/LB1.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB10", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB10.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB10", "note": "Enrollment and Review ER3", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/AM/ER3.pdf", "has_visual_markup": false}
+{"state": "ne", "bill": "LB100", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB100.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1000", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1000.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1001", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1001.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1001", "note": "Hansen AM2320", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/AM/AM2320.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1001A", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1001A.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1001A", "note": "Enrollment and Review ER130", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/AM/ER130.pdf", "has_visual_markup": false}
+{"state": "ne", "bill": "LB1002", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1002.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1003", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1003.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1004", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1004.pdf", "has_visual_markup": true}
+{"state": "ne", "bill": "LB1005", "note": "Introduced", "url": "https://nebraskalegislature.gov/FloorDocs/109/PDF/Intro/LB1005.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB1", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB1.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB1", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB1_EN.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB2", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB2.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB2", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB2_EN.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB3", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB3.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB3", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB3_EN.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB4", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB4.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB4", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB4_EN.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB5", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB5.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB5", "note": "Reprint 2", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB5_R2.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB6", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB6.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "AB6", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/AB/AB6_EN.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "ACR1", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR1.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "ACR1", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR1_EN.pdf", "has_visual_markup": false}
+{"state": "nv", "bill": "ACR2", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR2.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "ACR2", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR2_EN.pdf", "has_visual_markup": false}
+{"state": "nv", "bill": "ACR3", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR3.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "ACR3", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR3_EN.pdf", "has_visual_markup": false}
+{"state": "nv", "bill": "ACR4", "note": "As Introduced", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR4.pdf", "has_visual_markup": true}
+{"state": "nv", "bill": "ACR4", "note": "As Enrolled", "url": "https://www.leg.state.nv.us/Session/36th2025Special/Bills/ACR/ACR4_EN.pdf", "has_visual_markup": false}
+{"state": "ok", "bill": "HB1001", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1001 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1001", "note": "HB1001 (4-29-25) (THOMPSON) RT FA1.PDF", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 FLOOR AMENDMENTS/Senate/HB1001 (4-29-25) (THOMPSON) RT FA1.PDF", "has_visual_markup": false}
+{"state": "ok", "bill": "HB1002", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1002 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1002", "note": "Policy Committee Recommendation", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 COMMITTEE SUBS/HCS/HB1002 POLREC.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1003", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1003 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1003", "note": "Committee Amendment", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 COMMITTEE AMENDMENTS/Senate/HB1003 PCS.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1004", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1004 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1005", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1005 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1005", "note": "2 Floor Amendment by OLSEN (UNTIMELY FILED)", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 FLOOR AMENDMENTS/House/HB1005 FA2 OLSENJI-MJ(UNTIMELY FILED).PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1006", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1006 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1007", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1007 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1007", "note": "Floor (House)", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 FLR/HFLR/HB1007 HFLR.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1008", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1008 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1008", "note": "Floor (House)", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 FLR/HFLR/HB1008 HFLR.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1009", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1009 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1010", "note": "Introduced", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 INT/hB/HB1010 INT.PDF", "has_visual_markup": true}
+{"state": "ok", "bill": "HB1010", "note": "Sub Committee Recommendation", "url": "https://www.oklegislature.gov/cf_pdf/2025-26 COMMITTEE SUBS/HCS/HB1010 SUBREC.PDF", "has_visual_markup": true}
+{"state": "or", "bill": "HB4001", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4001/Introduced", "has_visual_markup": true}
+{"state": "or", "bill": "HB4002", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4002/Introduced", "has_visual_markup": true}
+{"state": "or", "bill": "HB4003", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4003/Introduced", "has_visual_markup": true}
+{"state": "or", "bill": "HB4004", "note": "A-Engrossed", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4004/A-Engrossed", "has_visual_markup": true}
+{"state": "or", "bill": "HB4004", "note": "HREV Amendment -A17", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/ProposedAmendment/30588", "has_visual_markup": false}
+{"state": "or", "bill": "HB4005", "note": "A-Engrossed", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4005/A-Engrossed", "has_visual_markup": true}
+{"state": "or", "bill": "HB4005", "note": "HALNRW Amendment -1", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/ProposedAmendment/29893", "has_visual_markup": true}
+{"state": "or", "bill": "HB4006", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4006/Introduced", "has_visual_markup": true}
+{"state": "or", "bill": "HB4007", "note": "A-Engrossed", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4007/A-Engrossed", "has_visual_markup": true}
+{"state": "or", "bill": "HB4007", "note": "HCT Amendment -13", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/ProposedAmendment/30491", "has_visual_markup": true}
+{"state": "or", "bill": "HB4008", "note": "A-Engrossed", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4008/A-Engrossed", "has_visual_markup": true}
+{"state": "or", "bill": "HB4008", "note": "HCT Amendment -5", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/ProposedAmendment/30494", "has_visual_markup": true}
+{"state": "or", "bill": "HB4009", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4009/Introduced", "has_visual_markup": true}
+{"state": "or", "bill": "HB4010", "note": "Introduced", "url": "https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/HB4010/Introduced", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7002", "note": "7002", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7002.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7003", "note": "7003", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7003.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7004", "note": "7004", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7004.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7005", "note": "7005", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7005.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7006", "note": "7006", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7006.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7007", "note": "7007\u00a0\u00a0as amended", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7007aa.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7008", "note": "7008\u00a0 SUB A", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7008A.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7010", "note": "7010", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7010.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7020", "note": "7020", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7020.pdf", "has_visual_markup": true}
+{"state": "ri", "bill": "HB7021", "note": "7021", "url": "http://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7021.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6001", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6001.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6001", "note": "Amendment SA6012", "url": "https://capitol.tn.gov/Bills/114/Amend/SA6012.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6002", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6002.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6003", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6003.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6003", "note": "Amendment HA6037", "url": "https://capitol.tn.gov/Bills/114/Amend/HA6037.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6004", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6004.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6004", "note": "Amendment SA6014", "url": "https://capitol.tn.gov/Bills/114/Amend/SA6014.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6005", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6005.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6005", "note": "Amendment SA6015", "url": "https://capitol.tn.gov/Bills/114/Amend/SA6015.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HB6006", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6006.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6007", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HB6007.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "HB6007", "note": "Amendment SA6008", "url": "https://capitol.tn.gov/Bills/114/Amend/SA6008.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "HJR6001", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/HJR6001.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "SB6001", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/SB6001.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "SB6001", "note": "Amendment HA6044", "url": "https://capitol.tn.gov/Bills/114/Amend/HA6044.pdf", "has_visual_markup": true}
+{"state": "tn", "bill": "SB6002", "note": "Current Version", "url": "https://capitol.tn.gov/Bills/114/Bill/SB6002.pdf", "has_visual_markup": false}
+{"state": "tn", "bill": "SB6002", "note": "Amendment HA6051", "url": "https://capitol.tn.gov/Bills/114/Amend/HA6051.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0001", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0001.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0001", "note": "Amendment HB0001SS001 (Standing Committee) - Senate Appropriations Committee (Reported)", "url": "https://wyoleg.gov/2026/Amends/HB0001SS001.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0002", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0002.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0002", "note": "Amendment HB0002HS001 (Standing Committee) - House Minerals, Business and Economic Development  (Adopted)", "url": "https://wyoleg.gov/2026/Amends/HB0002HS001.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0003", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0003.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0003", "note": "Amendment HB0003SW001 (Committee of the Whole) - Senator Scott (Ruled Out of Order)", "url": "https://wyoleg.gov/2026/Amends/HB0003SW001.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0004", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0004.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0004", "note": "Enrolled", "url": "https://wyoleg.gov/2026/Enroll/HB0004.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0005", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0005.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0005", "note": "Enrolled", "url": "https://wyoleg.gov/2026/Enroll/HB0005.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0006", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0006.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0007", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0007.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0008", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0008.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0008", "note": "Enrolled", "url": "https://wyoleg.gov/2026/Enroll/HB0008.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0009", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0009.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0009", "note": "Amendment HB0009SS001 (Standing Committee) - Senate Judiciary Committee (Adopted)", "url": "https://wyoleg.gov/2026/Amends/HB0009SS001.pdf", "has_visual_markup": false}
+{"state": "wy", "bill": "HB0010", "note": "Introduced", "url": "https://wyoleg.gov/2026/Introduced/HB0010.pdf", "has_visual_markup": true}
+{"state": "wy", "bill": "HB0010", "note": "Amendment HB0010SW005 (Committee of the Whole)", "url": "https://wyoleg.gov/2026/Amends/HB0010SW005.pdf", "has_visual_markup": false}
+{"state": "ct", "bill": "HB05001", "note": "Public Act No. 26-42", "url": "https://www.cga.ct.gov/2026/ACT/PA/PDF/2026PA-00042-R00HB-05001-PA.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05001", "note": "Raised Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05001-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05002", "note": "APP Joint Favorable", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05002-R02-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05002", "note": "Raised Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05002-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05003", "note": "Public Act No. 26-12", "url": "https://www.cga.ct.gov/2026/ACT/PA/PDF/2026PA-00012-R00HB-05003-PA.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05003", "note": "Raised Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05003-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05004", "note": "Public Act No. 26-26", "url": "https://www.cga.ct.gov/2026/ACT/PA/PDF/2026PA-00026-R00HB-05004-PA.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05004", "note": "Raised Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05004-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05005", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05005-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05006", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05006-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05007", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05007-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05008", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05008-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05009", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05009-R00-HB.PDF", "has_visual_markup": true}
+{"state": "ct", "bill": "HB05010", "note": "Proposed Bill", "url": "https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05010-R00-HB.PDF", "has_visual_markup": true}
+{"state": "vi", "bill": "36-0001", "note": "Bill 36-0001", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0001", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0002", "note": "Bill 36-0002", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0002", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0003", "note": "Bill 36-0003", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0003", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0004", "note": "Bill 36-0004", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0004", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0005", "note": "Bill 36-0005", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0005", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0005", "note": "Act 8986", "url": "https://billtracking.legvi.org:8082/preview/Act%2F8986", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0006", "note": "Bill 36-0006", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0006", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0007", "note": "Bill 36-0007", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0007", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0008", "note": "Bill 36-0008", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0008", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0009", "note": "Bill 36-0009", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0009", "has_visual_markup": null}
+{"state": "vi", "bill": "36-0010", "note": "Bill 36-0010", "url": "https://billtracking.legvi.org:8082/preview/Bill%2F36-0010", "has_visual_markup": null}
+{"state": "vt", "bill": "H1", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0001/H-0001%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H1", "note": "Act Summary", "url": "https://legislature.vermont.gov/Documents/2026/Docs/ACTS/ACT044/ACT044%20Act%20Summary.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H10", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0010/H-0010%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H10", "note": "Act Summary", "url": "https://legislature.vermont.gov/Documents/2026/Docs/ACTS/ACTM001/ACTM001%20Act%20Summary.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H100", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0100/H-0100%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H101", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0101/H-0101%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H102", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0102/H-0102%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H103", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0103/H-0103%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H104", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0104/H-0104%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H105", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0105/H-0105%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H105", "note": "Act Summary", "url": "https://legislature.vermont.gov/Documents/2026/Docs/ACTS/ACT045/ACT045%20Act%20Summary.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H106", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0106/H-0106%20As%20Introduced.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H106", "note": "Act Summary", "url": "https://legislature.vermont.gov/Documents/2026/Docs/ACTS/ACT052/ACT052%20Act%20Summary.pdf", "has_visual_markup": true}
+{"state": "vt", "bill": "H107", "note": "As Introduced", "url": "https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0107/H-0107%20As%20Introduced.pdf", "has_visual_markup": true}


### PR DESCRIPTION
## Summary

Runs the audit we discussed: samples up to 10 bills per state (earliest + latest available PDF version each) from the 28 states with no HTML/XML alternative, checks each for redline markup using the same geometry-based detector production extraction uses.

**394 documents checked across 27/28 states** (VI unreachable -- non-standard port 8082 connection timeout, tracked as an open gap rather than blocking on it).

## Key findings

- **Consistently high (~85-100%)**: AL, CT, FL, GU, ID, MD, ND, NE, NC, OK, OR, RI, VT, KY -- markup detected even on unamended "as introduced" versions, suggesting this may be house style for these states (e.g. underlining new statutory language on first introduction) rather than only appearing on amendments. Full-fidelity handling should probably be the default for these, not the exception.
- **Consistently zero**: GA, IN, LA, ME (0% across 8-20 samples each) -- plain text extraction is likely trustworthy on its own for these.
- **Mixed**: the remaining ~9 states -- matches what production's existing per-document check already handles correctly.

Full per-state table and caveats in `actions/extract/docs/2026-07-21-pdf-visual-markup-audit.md`.

## Related finding (not fixed here, tracked separately)

While investigating a separately-reported issue, found that **SD's HTML bill pages are JS-rendered loading shells**, not real content -- but SD *also* serves working PDFs for the same bills that production's format preference (`xml > html > pdf`) currently ignores in favor of the broken HTML. Spot-checked MN and WV (the two states listed as HTML-only with no PDF fallback) and both are unaffected -- this looks specific to SD's site, not a systemic HTML-only-states problem.

## Test plan
- [x] Script runs cleanly, results committed as JSONL for reference
- [x] Spot-checked findings against known cases (ID/H0493 real redline, synthetic clean PDF false-negative-free)
- [ ] No production code changes in this PR -- audit/docs only

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>