### PR TITLE
fix: prevent scrape data loss from cancelled/short-lived runs overwriting good data

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: ak
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: id
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: mt
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: pr
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: wy
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape-paused/.github/workflows/openstates-scrape.yml
@@ -12,6 +12,11 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# See the active (non-paused) template for the full explanation.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: ✏️{ locale.key }✏️
   # See the active (non-paused) template for the full explanation -- same

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -19,6 +19,17 @@ on:
         description: "Force self-hosted for this manual run instead of the default tinyproxy + GitHub-hosted path (only meaningful for locales configured runner: self-hosted; e.g. to test without the proxy)"
         default: false
 
+# A scrape can take hours (FL up to 24h). Without this, a new trigger
+# (schedule, manual dispatch, or a delayed cron catching up) cancels an
+# in-progress run outright rather than queuing behind it -- confirmed
+# happening for real: FL's schedule firing hours late cancelled a 6-hour-old
+# manual run, and the fresh replacement "succeeded" with a fraction of the
+# data, overwriting what the cancelled run had already saved. Same pattern
+# already used in format.yml/extract-text.yml.
+concurrency:
+  group: scrape
+  cancel-in-progress: false
+
 env:
   STATE_CODE: ✏️{ locale.key }✏️
   # locale.runner is a render-time literal ("self-hosted" or "ubuntu-latest"),

--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -215,7 +215,36 @@ else
   COUNT_JSON=0
 fi
 echo "Found ${COUNT_JSON} JSON files in $JSON_DIR"
-if [ "$exit_code" -eq 0 ] && [ "$COUNT_JSON" -gt 0 ]; then
+
+# exit_code == 0 only means the docker scraper itself didn't crash -- it does
+# NOT mean this run produced a complete dataset. A run that gets cut short
+# (e.g. cancelled by a newer trigger and replaced by a fresh, short-lived one;
+# or a retry attempt within this same run that returns less than an earlier
+# attempt already did) can still exit 0 with a handful of real files, which
+# used to be enough to trigger the wipe below and silently replace a larger,
+# good dataset with a smaller one -- confirmed happening for real on IL (a
+# single run's last retry produced ~4k files after auto-save had already
+# captured ~19k earlier in that same run) and FL (a fresh run, started after
+# an in-progress 6-hour run got cancelled, "succeeded" with a fraction of a
+# full scrape and overwrote the larger dataset the cancelled run had already
+# saved). Comparing against what's already committed catches both: within a
+# single run there's no legitimate reason a later retry has fewer real bills
+# than an earlier one already did today, and across runs the existing count
+# already reflects this run's own auto-saves, not stale history -- so a
+# shrink here is always suspicious, never normal session growth (which only
+# ever adds bills over time).
+EXISTING_DIR="${OUTPUT_DIR}/_data/${STATE}"
+if [ -d "$EXISTING_DIR" ]; then
+  EXISTING_COUNT=$(find "$EXISTING_DIR" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+else
+  EXISTING_COUNT=0
+fi
+
+if [ "$exit_code" -eq 0 ] && [ "$COUNT_JSON" -gt 0 ] && [ "$COUNT_JSON" -lt "$EXISTING_COUNT" ]; then
+  echo "⚠️ Fresh scrape produced ${COUNT_JSON} files, fewer than the ${EXISTING_COUNT} already saved -- refusing to overwrite. Leaving existing data in place; this run's output is not being committed." >&2
+  FAILURE_TYPE_OVERRIDE="P1_SHRINKING_OUTPUT"
+  COUNT_JSON=0  # so the summary/downstream logic reports this as "nothing new," not a success
+elif [ "$exit_code" -eq 0 ] && [ "$COUNT_JSON" -gt 0 ]; then
   # Copy files directly to workspace _data directory
   # Clean the directory first to avoid accumulating stale files with different UUIDs
   mkdir -p "${OUTPUT_DIR}/_data/${STATE}"
@@ -316,7 +345,9 @@ fi
 # Grep the log file directly — avoids broken-pipe errors from piping large variables through echo.
 IS_ACTIVE_BLOCK="false"
 
-if [ "$exit_code" -eq 0 ]; then
+if [ -n "${FAILURE_TYPE_OVERRIDE:-}" ]; then
+  FAILURE_TYPE="$FAILURE_TYPE_OVERRIDE"
+elif [ "$exit_code" -eq 0 ]; then
   FAILURE_TYPE="NONE"
 elif grep -qE "ConnectionRefusedError|Errno 111" "$SCRAPE_LOG" 2>/dev/null; then
   FAILURE_TYPE="N1_ACTIVE_BLOCK"


### PR DESCRIPTION
## Summary

Two real, confirmed data-loss incidents tonight prompted this:

- **IL**: a single run's last retry attempt produced far fewer files than an earlier retry in that same run had already captured via auto-save (9691 + 9287 files added across two auto-saves, then the final commit showed 3880 insertions vs 22850 deletions -- net **-18970 files**). The final wipe-and-rebuild step only checked \`exit_code == 0\` and file count > 0, with no comparison against what was already there.
- **FL**: a 6-hour-old in-progress manual scrape got cancelled when a new trigger (a \`schedule\` run, delayed hours by a GitHub Actions scheduler propagation quirk after tonight's cron-time change) fired for the same workflow -- no concurrency guard existed to queue it instead. The fresh replacement run "succeeded" after only ~5 hours (FL needs up to 24h) and its own wipe-and-rebuild overwrote the larger dataset the cancelled run had already auto-saved.

## Fixes

1. **\`scrape.sh\`**: before the destructive wipe+rebuild, compare the fresh file count against what's already committed in the output directory. If the fresh scrape would shrink the dataset, refuse to overwrite -- leave the existing (larger) data in place and surface it as a new failure type (\`P1_SHRINKING_OUTPUT\`) instead of silently reporting success. A later retry having fewer real bills than an earlier one already did today is never legitimate session growth (which only ever adds bills over time), so this check is safe in both the within-run and across-run case.
2. **\`openstates-scrape.yml\`** (+ paused variant): add a \`concurrency\` guard (\`group: scrape, cancel-in-progress: false\`), matching the pattern already used in \`format.yml\`/\`extract-text.yml\`, so a new trigger queues behind an in-progress scrape instead of cancelling it outright.

## Test plan
- [x] \`bash -n\` syntax check on scrape.sh
- [x] Snapshots regenerated for the concurrency-guard template change
- [ ] Live verification: next time a state's scrape overlaps with a new trigger, confirm it queues instead of cancelling, and that a shrinking result gets refused rather than committed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>