### PR TITLE
feat: route scrape timeout through per-locale config instead of a hand-edit

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/ak-legislation/.github/workflows/openstates-scrape.yml
@@ -52,6 +52,13 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('self-hosted' == 'self-hosted' && 'ubuntu-latest' || 'self-hosted') }}
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
     timeout-minutes: 720
     permissions:
       contents: write

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/id-legislation/.github/workflows/openstates-scrape.yml
@@ -52,6 +52,13 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
     timeout-minutes: 720
     permissions:
       contents: write

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/mt-legislation/.github/workflows/openstates-scrape.yml
@@ -52,6 +52,13 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
     timeout-minutes: 720
     permissions:
       contents: write

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/pr-legislation/.github/workflows/openstates-scrape.yml
@@ -52,6 +52,13 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
     timeout-minutes: 720
     permissions:
       contents: write

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-scrape/wy-legislation/.github/workflows/openstates-scrape.yml
@@ -52,6 +52,13 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('ubuntu-latest' == 'self-hosted' && 'ubuntu-latest' || 'ubuntu-latest') }}
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
     timeout-minutes: 720
     permissions:
       contents: write

--- a/actions/pipeline-manager/chn-openstates-scrape.yml
+++ b/actions/pipeline-manager/chn-openstates-scrape.yml
@@ -22,23 +22,27 @@ locales:
     template: openstates-scrape
     name: Alabama
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
   ak:
     template: openstates-scrape
     name: Alaska
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 8 * * *"  # Alaska
     runner: self-hosted
   az:
     template: openstates-scrape
     name: Arizona
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
     runner: self-hosted
   ar:
     template: openstates-scrape
     name: Arkansas
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
@@ -47,27 +51,32 @@ locales:
     template: openstates-scrape
     name: California
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 7 * * *"  # Pacific
   co:
     template: openstates-scrape
     name: Colorado
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
   ct:
     template: openstates-scrape
     name: Connecticut
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   dc:
     template: openstates-scrape
     name: District of Columbia
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
   de:
     template: openstates-scrape
     name: Delaware
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -75,6 +84,7 @@ locales:
     template: openstates-scrape
     name: Florida
     toolkit_branch: main
+    scrape_timeout_minutes: "2520"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -83,6 +93,7 @@ locales:
     template: openstates-scrape
     name: Georgia
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -90,17 +101,20 @@ locales:
     template: openstates-scrape
     name: Hawaii
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 10 * * *"  # Hawaii (no DST)
     runner: self-hosted
   id:
     template: openstates-scrape
     name: Idaho
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
   il:
     template: openstates-scrape
     name: Illinois
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
@@ -109,12 +123,14 @@ locales:
     template: openstates-scrape
     name: Indiana
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   ia:
     template: openstates-scrape
     name: Iowa
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -122,6 +138,7 @@ locales:
     template: openstates-scrape
     name: Kansas
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -129,6 +146,7 @@ locales:
     template: openstates-scrape
     name: Kentucky
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -136,6 +154,7 @@ locales:
     template: openstates-scrape
     name: Louisiana
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -143,28 +162,33 @@ locales:
     template: openstates-scrape
     name: Maine
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
   md:
     template: openstates-scrape
     name: Maryland
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
   ma:
     template: openstates-scrape
     name: Massachusetts
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   mi:
     template: openstates-scrape
     name: Michigan
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   mn:
     template: openstates-scrape
     name: Minnesota
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -172,11 +196,13 @@ locales:
     template: openstates-scrape
     name: Mississippi
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
   mo:
     template: openstates-scrape
     name: Missouri
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -184,6 +210,7 @@ locales:
     template: openstates-scrape
     name: Montana
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
@@ -191,6 +218,7 @@ locales:
     template: openstates-scrape
     name: Nebraska
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
@@ -199,6 +227,7 @@ locales:
     template: openstates-scrape
     name: Nevada
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 7 * * *"  # Pacific
     runner: self-hosted
     labels:
@@ -207,6 +236,7 @@ locales:
     template: openstates-scrape
     name: New Hampshire
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -214,6 +244,7 @@ locales:
     template: openstates-scrape
     name: New Jersey
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -221,6 +252,7 @@ locales:
     template: openstates-scrape
     name: New Mexico
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
     runner: self-hosted
     labels:
@@ -229,12 +261,14 @@ locales:
     template: openstates-scrape
     name: New York
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   nc:
     template: openstates-scrape
     name: North Carolina
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -243,6 +277,7 @@ locales:
     template: openstates-scrape
     name: North Dakota
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -250,12 +285,14 @@ locales:
     template: openstates-scrape
     name: Ohio
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   ok:
     template: openstates-scrape
     name: Oklahoma
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -263,6 +300,7 @@ locales:
     template: openstates-scrape
     name: Oregon
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 7 * * *"  # Pacific
     labels:
     - working
@@ -270,6 +308,7 @@ locales:
     template: openstates-scrape
     name: Pennsylvania
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -278,6 +317,7 @@ locales:
     template: openstates-scrape
     name: Rhode Island
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     labels:
     - working
@@ -285,6 +325,7 @@ locales:
     template: openstates-scrape
     name: South Carolina
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -293,11 +334,13 @@ locales:
     template: openstates-scrape
     name: South Dakota
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
   tn:
     template: openstates-scrape
     name: Tennessee
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     runner: self-hosted
     labels:
@@ -306,6 +349,7 @@ locales:
     template: openstates-scrape
     name: Texas
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -313,6 +357,7 @@ locales:
     template: openstates-scrape
     name: Utah
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
@@ -320,6 +365,7 @@ locales:
     template: openstates-scrape
     name: Vermont
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -328,12 +374,14 @@ locales:
     template: openstates-scrape
     name: Virginia
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
   wa:
     template: openstates-scrape
     name: Washington
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 7 * * *"  # Pacific
     labels:
     - working
@@ -341,6 +389,7 @@ locales:
     template: openstates-scrape
     name: West Virginia
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:
@@ -349,6 +398,7 @@ locales:
     template: openstates-scrape
     name: Wisconsin
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 5 * * *"  # Central
     labels:
     - working
@@ -356,6 +406,7 @@ locales:
     template: openstates-scrape
     name: Wyoming
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 6 * * *"  # Mountain
     labels:
     - working
@@ -363,6 +414,7 @@ locales:
     template: openstates-scrape
     name: Puerto Rico
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Atlantic (PR/VI, no DST)
     labels:
     - working
@@ -370,6 +422,7 @@ locales:
     template: openstates-scrape
     name: Northern Mariana Islands
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 14 * * *"  # Chamorro (GU/MP, UTC+10)
     labels:
     - working
@@ -377,6 +430,7 @@ locales:
     template: openstates-scrape
     name: U.S. Virgin Islands
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Atlantic (PR/VI, no DST)
     runner: self-hosted
     labels:
@@ -385,6 +439,7 @@ locales:
     template: openstates-scrape
     name: Guam
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 14 * * *"  # Chamorro (GU/MP, UTC+10)
     labels:
     - working
@@ -392,6 +447,7 @@ locales:
     template: openstates-scrape
     name: United States
     toolkit_branch: main
+    scrape_timeout_minutes: "720"
     scrape_cron: "0 4 * * *"  # Eastern
     runner: self-hosted
     labels:

--- a/actions/pipeline-manager/config.schema.json
+++ b/actions/pipeline-manager/config.schema.json
@@ -104,6 +104,10 @@
             "scrape_cron": {
               "type": "string",
               "description": "Cron schedule (UTC) for this locale's scrape workflow, staggered by the state capital's timezone so scrapes run shortly after each state's own legislative day ends rather than all firing at once. E.g. '0 4 * * *' for Eastern, '0 7 * * *' for Pacific. See openstates-scrape.yml template."
+            },
+            "scrape_timeout_minutes": {
+              "type": "string",
+              "description": "GitHub Actions timeout-minutes for this locale's scrape job. Defaults to 720 (12h); raised for slow states (e.g. FL, 2520 = 42h). Routed through config rather than hand-edited on the live workflow file so a template rollout (apply.py's fully_override_dirs) can't silently revert it."
             }
           },
           "additionalProperties": false

--- a/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
+++ b/actions/pipeline-manager/templates/openstates-scrape/.github/workflows/openstates-scrape.yml
@@ -52,7 +52,14 @@ jobs:
   scrape:
     name: "🕷️ Scrape Data"
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.use-self-hosted) && 'self-hosted' || ('✏️{ locale.runner }✏️' == 'self-hosted' && 'ubuntu-latest' || '✏️{ locale.runner }✏️') }}
-    timeout-minutes: 720
+    # Per-locale override (locale.scrape_timeout_minutes in
+    # chn-openstates-scrape.yml) -- this used to be a one-off hand-edit
+    # directly on FL's live workflow file (raised to 24h after its default
+    # 12h was hit mid-scrape), which meant it silently reverted back to the
+    # template default the next time apply.py's fully_override_dirs pushed
+    # the shared template out. Routing it through config instead means a
+    # rollout can't quietly undo it again.
+    timeout-minutes: ✏️{ locale.scrape_timeout_minutes }✏️
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

FL's timeout had been manually raised to 24h directly on its live workflow file after its default 12h was hit mid-scrape -- but since that was a one-off hand-edit outside the shared template, tonight's \`apply.py\` rollout (\`fully_override_dirs: .github\`) silently reverted it back to 720min/12h, which then contributed to FL's scrape getting caught mid-run tonight.

Adds \`locale.scrape_timeout_minutes\` (default 720, FL raised to **2520 = 42h** given the original 21h cutoff and wanting real headroom), same pattern as \`scrape_cron\` and \`runner\`. Routing it through config means a template rollout can't quietly undo it again.

## Test plan
- [x] Config valid, all 56 locales have the field set
- [x] Snapshots regenerated -- FL not in the default 5-state snapshot sample, but WY confirmed still showing the 720 default correctly
- [ ] Deploy via apply.py and confirm FL's live workflow shows timeout-minutes: 2520

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>