### PR TITLE
fix(format): avoid shell-glob copy that blows past the arg-length limit

### DIFF
--- a/actions/format/action.yml
+++ b/actions/format/action.yml
@@ -55,9 +55,18 @@ runs:
         TARGET_DIR="${RUNNER_TEMP}/scrape-snapshot-nightly/_data/${{ inputs.state }}"
         mkdir -p "$TARGET_DIR"
 
-        # Copy data
+        # Copy data. Use rsync (or cp's "/." form as a fallback) rather than a
+        # shell-glob "/*" -- that expands to one argument per file before cp
+        # even runs, and blows past the OS argument-length limit for large
+        # states (confirmed failing on USA at 54,228 files: "Argument list
+        # too long"). Both alternatives copy directory *contents* without the
+        # shell doing the expansion.
         echo "📦 Copying to: $TARGET_DIR"
-        cp -r "scraper-data/_data/${{ inputs.state }}"/* "$TARGET_DIR/"
+        if command -v rsync >/dev/null 2>&1; then
+          rsync -a "scraper-data/_data/${{ inputs.state }}/" "$TARGET_DIR/"
+        else
+          cp -r "scraper-data/_data/${{ inputs.state }}/." "$TARGET_DIR/"
+        fi
 
         FILE_COUNT=$(find "$TARGET_DIR" -type f -name "*.json" | wc -l)
         echo "📋 Files copied: $FILE_COUNT JSON files"


### PR DESCRIPTION
## Summary
- `actions/format/action.yml`'s data-copy step used `cp -r "dir"/* "target/"` — the shell expands `/*` into one argument per file *before* `cp` runs, blowing past the OS argument-length limit for large states.
- Confirmed failing today on USA's format run: `/usr/bin/cp: Argument list too long`, exit code 126, at 54,228 files (the pre-dedup-fix bloated dataset).
- Not USA-specific — NY is close behind at 35,882 files and would hit the same wall.
- Switched to `rsync -a` (falling back to `cp`'s `dir/.` form, which copies directory *contents* without shell expansion) — same pattern already used in `actions/scrape/scrape.sh` for the identical reason.

## Test plan
- [ ] Re-run format for USA once its clean, deduplicated scrape data lands — should copy without hitting the arg-length wall this time
- [ ] No existing test suite covers this action's shell script directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)