### PR TITLE
fix: replace broken PAT restart trigger with GitHub App token

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"

--- a/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
@@ -104,13 +104,28 @@ jobs:
             echo "needs_restart=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token for workflow restart
+        id: app-token
+        if: steps.check.outputs.needs_restart == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Trigger workflow restart
         if: steps.check.outputs.needs_restart == 'true'
         env:
-          # Note: GITHUB_TOKEN cannot trigger workflows due to GitHub security restrictions
-          # You must create a Personal Access Token (PAT) with 'workflow' scope and add it as a secret
-          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER }}
+          # GITHUB_TOKEN structurally cannot trigger new workflow runs (GitHub
+          # security restriction, to prevent runaway recursive workflow
+          # triggering). A long-lived PAT in a repo/org secret was the original
+          # fix here, but that needs admin:org access to provision and is one
+          # more long-lived credential to rotate/leak. Reuse the GitHub App
+          # token approach the scrape -> format cross-org dispatch already
+          # relies on instead (see openstates-scrape.yml) -- short-lived,
+          # scoped to just this repo, no second PAT to manage.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "⚠️ Previous run was cancelled/failed. Restarting to continue extraction..."
           echo "   (Incremental processing will skip already-completed bills)"


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` structurally cannot trigger new workflow runs, so extract-text's auto-restart step (meant to continue extraction after a large state times out) needed a real credential
- The original fix (a PAT in `secrets.PAT_WORKFLOW_TRIGGER`) needed `admin:org` access to provision and was never actually set up -- confirmed live on NH 2026-07-21, and again tonight on MT, where every long-running extraction just timed out with the restart step failing on an empty `GH_TOKEN` every single time
- Swaps it for the GitHub App token approach already proven on the scrape -> format cross-org dispatch (see `openstates-scrape.yml`): a short-lived token scoped to just this repo, no second long-lived PAT to provision or rotate

## Test plan
- [x] Applied to `govbot-data/mt-legislation` via `apply.py` and confirmed the live workflow file has the fix
- [x] Cancelled MT's in-flight (pre-fix) extraction run and re-triggered a fresh one to pick up the new definition
- [ ] Confirm the restart step actually fires successfully next time MT's extraction hits its ~5.9h timeout
- [ ] Roll out to the rest of `govbot-data` once confirmed stable on MT