### PR TITLE
fix: skip --fastmode for NH, restore SCRAPELIB_RPM throttling

### DIFF
--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -130,6 +130,19 @@ fi
 echo "🕷️ Scraping ${STATE} (with retries + DNS override)..."
 exit_code=1
 
+# --fastmode sets requests_per_minute=0 (unlimited) in openstates-core's
+# Scraper.__init__, unconditionally overriding any per-state SCRAPELIB_RPM
+# setting -- confirmed via a local test run (2026-07-24) that NH's server
+# (gc.nh.gov) starts dropping connections under fastmode's unthrottled burst
+# pattern even with SCRAPELIB_RPM set in scrapers/nh/__init__.py, because
+# fastmode ignores it entirely. Dropping --fastmode for NH restores the
+# framework default of 60 RPM (1 req/sec), which a per-state RPM setting can
+# then actually take effect on top of.
+FASTMODE_FLAG="--fastmode"
+if [ "${STATE}" = "nh" ]; then
+  FASTMODE_FLAG=""
+fi
+
 if [ "${STATE}" = "va" ]; then
   # Virginia uses csv_bills scraper for two sessions; run each independently with retries
   va_regular_exit=1
@@ -180,7 +193,7 @@ else
         -v "$(pwd)/_working/_cache":/opt/openstates/openstates/_cache \
         "${DOCKER_ENV_FLAGS[@]+"${DOCKER_ENV_FLAGS[@]}"}" \
         ${DOCKER_IMAGE} \
-        ${STATE} bills --scrape --fastmode 2>&1 | tee -a "$SCRAPE_LOG"
+        ${STATE} bills --scrape ${FASTMODE_FLAG} 2>&1 | tee -a "$SCRAPE_LOG"
     then
       exit_code=0
       break


### PR DESCRIPTION
## Summary
- `actions/scrape/scrape.sh` unconditionally passes `--fastmode`, which sets `requests_per_minute=0` (unlimited) in openstates-core's `Scraper.__init__`, silently overriding any per-state `SCRAPELIB_RPM` setting.
- Confirmed via local docker test runs (2026-07-24) that `gc.nh.gov` starts dropping connections under this unthrottled burst pattern — a live scheduled run got 1,084 requests in before degrading (`RemoteDisconnected`, escalating retry backoff, eventual connect timeout); a local unthrottled test burst 89 requests in 11 seconds before failing the same way.
- Drops `--fastmode` specifically for NH (state-conditional, same pattern as the existing VA special-case in this script) so the framework default of 60 RPM applies. Pairs with a `SCRAPELIB_RPM=20` setting on `scrapers/nh/__init__.py` (`fix/nh-rate-limit` branch on the `tamara-builds/openstates-scrapers` fork, not yet a PR).

## Caveat
A same-day test during NH's known 6am-9pm ET block window failed instantly on the very first request — a different, harder failure than the gradual degradation this fix targets, suggesting a separate time-based block is also real. This fix addresses the unthrottled-burst degradation only; it's not yet confirmed to resolve NH end-to-end. Full details in `project_docs/scraper-status/pending-branches.md` and `not-working.md` (both gitignored, not in this diff).

## Test plan
- [ ] Re-test NH outside the 6am-9pm ET block window (after 9pm ET or before 6am ET) to confirm this fix alone resolves the degradation
- [ ] Confirm no regression for other states (change is state-conditional, `${STATE} = "nh"` only)