### PR TITLE
Fix identifier-aware commit-summary label + 503/429 classifier false positives

### DIFF
--- a/actions/scrape/action.yml
+++ b/actions/scrape/action.yml
@@ -437,11 +437,34 @@ runs:
         # Every scrape run regenerates a fresh random UUID per bill/vote-event
         # file (that's how OpenStates names them), so a full delete-old/add-new
         # diff happens on every commit regardless of whether the underlying
-        # legislative content actually changed. Insertions == deletions is the
-        # signature of "same data, re-scraped" (e.g. an out-of-session state
-        # with nothing new to report) rather than real new activity -- surface
-        # that distinction in the job summary so it doesn't have to be
-        # reverse-engineered from commit stats after the fact.
+        # legislative content actually changed. Insertions/deletions are still
+        # shown below as raw stats, but labeling the result from them doesn't
+        # work -- this used to say "worth a look" on perfectly healthy commits
+        # that were simply cleaning out old duplicate-UUID cruft (confirmed on
+        # USA: three consecutive commits, bill count flat at 17,574 the whole
+        # time, but each one showed net deletions since old stale-duplicate
+        # files were being cleared without a 1:1 new file replacing them).
+        # Compare distinct bill identifiers instead, same fix already applied
+        # to the shrink-guard itself in scrape.sh.
+        count_distinct_identifiers() {
+          local dir="$1"
+          if [ -d "$dir" ]; then
+            find "$dir" -type f -name 'bill_*.json' -print0 2>/dev/null \
+              | xargs -0 jq -r '.identifier // empty' 2>/dev/null \
+              | sort -u | wc -l | tr -d ' '
+          else
+            echo 0
+          fi
+        }
+
+        OLD_SNAPSHOT=$(mktemp -d)
+        if git rev-parse --verify -q HEAD >/dev/null; then
+          git archive HEAD -- "_data/${{ inputs.state }}/" 2>/dev/null | tar -x -C "$OLD_SNAPSHOT" 2>/dev/null || true
+        fi
+        OLD_DISTINCT=$(count_distinct_identifiers "${OLD_SNAPSHOT}/_data/${{ inputs.state }}")
+        NEW_DISTINCT=$(count_distinct_identifiers "$DATA_DIR")
+        rm -rf "$OLD_SNAPSHOT"
+
         DIFF_STAT=$(git diff --staged --shortstat)
         INSERTIONS=$(echo "$DIFF_STAT" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
         DELETIONS=$(echo "$DIFF_STAT" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo 0)
@@ -450,12 +473,12 @@ runs:
 
         if [ "$INSERTIONS" -eq 0 ] && [ "$DELETIONS" -eq 0 ]; then
           CONTENT_CHANGE="⏸️ No changes (nothing staged)"
-        elif [ "$INSERTIONS" -eq "$DELETIONS" ]; then
-          CONTENT_CHANGE="🔁 Re-scraped, no net new content ($INSERTIONS files replaced with fresh UUIDs, same count) — likely an out-of-session or otherwise unchanged state"
-        elif [ "$INSERTIONS" -gt "$DELETIONS" ]; then
-          CONTENT_CHANGE="✨ Net new content (+$((INSERTIONS - DELETIONS)) files vs. last commit)"
+        elif [ "$NEW_DISTINCT" -lt "$OLD_DISTINCT" ]; then
+          CONTENT_CHANGE="⚠️ Distinct bills dropped ($OLD_DISTINCT → $NEW_DISTINCT) — worth a look"
+        elif [ "$NEW_DISTINCT" -gt "$OLD_DISTINCT" ]; then
+          CONTENT_CHANGE="✨ Net new content (+$((NEW_DISTINCT - OLD_DISTINCT)) distinct bills vs. last commit)"
         else
-          CONTENT_CHANGE="⚠️ Net fewer files than last commit (-$((DELETIONS - INSERTIONS)) files) — worth a look"
+          CONTENT_CHANGE="🔁 Re-scraped, no net new content ($NEW_DISTINCT distinct bills, same as last commit) — likely an out-of-session or otherwise unchanged state, or stale-duplicate cleanup"
         fi
 
         echo "$CONTENT_CHANGE"
@@ -466,6 +489,7 @@ runs:
           echo "| Metric | Value |"
           echo "|--------|-------|"
           echo "| Result | $CONTENT_CHANGE |"
+          echo "| Distinct bills (before → after) | $OLD_DISTINCT → $NEW_DISTINCT |"
           echo "| Insertions | $INSERTIONS |"
           echo "| Deletions | $DELETIONS |"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -463,11 +463,19 @@ elif grep -qE "403.*(Forbidden|forbidden)|Forbidden.*403" "$SCRAPE_LOG" 2>/dev/n
 elif grep -qE "Name or service not known|nodename nor servname provided|EAI_NONAME" "$SCRAPE_LOG" 2>/dev/null; then
   FAILURE_TYPE="N4_DNS_FAILURE"
   IS_ACTIVE_BLOCK="true"
-elif grep -qE "429|Too Many Requests" "$SCRAPE_LOG" 2>/dev/null; then
+elif grep -qE "(^|[^0-9])429([^0-9]|$)|Too Many Requests" "$SCRAPE_LOG" 2>/dev/null; then
   FAILURE_TYPE="H3_RATE_LIMITED"
 elif grep -qE "TimeoutError|ConnectTimeoutError|timed out|Errno 110|RemoteDisconnected|Connection aborted" "$SCRAPE_LOG" 2>/dev/null; then
   FAILURE_TYPE="N2_CONNECTIVITY"
-elif grep -qE "503|Service Unavailable" "$SCRAPE_LOG" 2>/dev/null; then
+elif grep -qE "(^|[^0-9])503([^0-9]|$)|Service Unavailable" "$SCRAPE_LOG" 2>/dev/null; then
+  # Bare "503"/"429" used to match as a substring of anything -- including cache-busting
+  # query params some scrapers append to every request URL (e.g. NH's `?x=<timestamp>`,
+  # which routinely contains "503" purely by digit coincidence). Confirmed on NH
+  # (2026-07-26 run 30184528088): every attempt actually failed with a plain
+  # `ScrapeError: no objects returned` (S1_OUT_OF_SESSION), but got misclassified as
+  # H4_SERVER_DOWN because the timestamp in every logged request URL happened to
+  # contain "503". Requiring non-digit boundaries keeps a real "503"/"429" (surrounded
+  # by spaces, punctuation, etc.) matching while rejecting digit-run coincidences.
   FAILURE_TYPE="H4_SERVER_DOWN"
 elif grep -qE "ScrapeValueError|validation.*failed|failed.*validation" "$SCRAPE_LOG" 2>/dev/null; then
   # Check before H2 — ScrapeValueError is a specific openstates schema failure, not an auth issue.


### PR DESCRIPTION
## Summary
- The job-summary "Commit Content" label used raw `git diff --shortstat` insertions/deletions to decide "worth a look" vs "no net new content" — same blind spot the shrink-guard used to have before its own identifier-aware fix. Confirmed on USA: distinct bill count flat at 17,574 across multiple commits, but each one flagged a false "⚠️ Net fewer files than last commit" because stale-duplicate cleanup deletes old files without a 1:1 new file replacing them. Now compares distinct bill identifiers instead, same approach as the shrink-guard.
- `scrape.sh`'s failure-type classifier did a bare substring match on `"503"`/`"429"`, which can match inside cache-busting query params some scrapers append to every request URL. Confirmed on NH: a plain `ScrapeError: no objects returned` (should classify as `S1_OUT_OF_SESSION`) got mislabeled `H4_SERVER_DOWN` because a request-URL timestamp coincidentally contained "503". Anchored both regexes to require non-digit boundaries.

## Test plan
- [x] MT: re-scraped, 4,495 distinct bills flat, correctly labeled "no net new content"
- [x] NH: correctly reported `S1_OUT_OF_SESSION` instead of `H4_SERVER_DOWN`, fell back to nightly as designed
- [x] USA: re-scraped, 17,574 distinct bills flat, correctly labeled "no net new content" despite 18,373 raw deletions vs 9,229 insertions
- [x] All three states' workflows reverted from the test branch back to `@main`