### PR TITLE
fix: identifier-count crash on a single malformed bill_*.json

### DIFF
--- a/actions/scrape/action.yml
+++ b/actions/scrape/action.yml
@@ -449,8 +449,14 @@ runs:
         count_distinct_identifiers() {
           local dir="$1"
           if [ -d "$dir" ]; then
+            # One jq invocation per file (not a single batched xargs call) so a lone
+            # malformed/truncated bill_*.json can't take the whole count down with it --
+            # confirmed for real on GA (2026-07-26, run 30191180653): xargs propagates a
+            # single jq parse failure as exit 123, which under this step's
+            # `set -euo pipefail` silently aborted the entire commit step with zero
+            # output, blocking a perfectly good 460-bill commit.
             find "$dir" -type f -name 'bill_*.json' -print0 2>/dev/null \
-              | xargs -0 jq -r '.identifier // empty' 2>/dev/null \
+              | xargs -0 -I{} sh -c 'jq -r ".identifier // empty" "$1" 2>/dev/null || true' _ {} \
               | sort -u | wc -l | tr -d ' '
           else
             echo 0

--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -297,8 +297,13 @@ fi
 count_distinct_identifiers() {
   local dir="$1"
   if [ -d "$dir" ]; then
+    # One jq invocation per file (not a single batched xargs call) so a lone
+    # malformed/truncated bill_*.json can't take the whole count down with it --
+    # confirmed for real: xargs propagates a single jq parse failure as exit 123,
+    # which under this script's `set -euo pipefail` silently aborted the entire
+    # step (including this function's caller), blocking a perfectly good commit.
     find "$dir" -type f -name 'bill_*.json' -print0 2>/dev/null \
-      | xargs -0 jq -r '.identifier // empty' 2>/dev/null \
+      | xargs -0 -I{} sh -c 'jq -r ".identifier // empty" "$1" 2>/dev/null || true' _ {} \
       | sort -u | wc -l | tr -d ' '
   else
     echo 0


### PR DESCRIPTION
A batched `xargs -0 jq ...` call meant one bad JSON file (parse failure) made xargs exit 123, which under `set -euo pipefail` silently aborted the entire calling step -- including the commit step in action.yml, blocking a perfectly good commit with zero output or explanation.

Confirmed live in production: GA's 2026-07-26 06:30 scheduled run (30191180653) scraped 460 real bills cleanly, then the "Commit and push scraped files" step (added tonight in PR #97) crashed silently at OLD_DISTINCT=$(count_distinct_identifiers ...) with exit 123, losing that commit entirely. Reproduced exactly in a real ubuntu:24.04 + jq container: a single malformed bill_*.json in an otherwise-valid directory crashes the whole pipeline with zero output.

Fix: invoke jq once per file instead of one batched call, so a single bad file can't take down the others. Verified against the exact malformed-file repro, plus empty-directory and missing-directory edge cases -- all now return a correct count with exit 0.

Same bug existed in scrape.sh's original shrink-guard identifier check, fixed there too for consistency (lower risk there since it's only invoked when file count already shrank, but same fragility).