### PR TITLE
Enable embedding-based bill tagging for the Pages dashboard

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,17 +32,49 @@ jobs:
         with:
           mdbook-version: 'latest'
 
-      # Fetch live legislation data and rebuild the dashboard's data.json
-      # before mdbook runs, so the fresh file is copied into the book.
-      # Failures fall back to the committed sample data instead of
-      # breaking the docs deploy.
+      # Install the govbot CLI so we can run the embedding tagger (`govbot tag`).
+      - name: Install govbot CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/chihacknight/govbot/main/actions/govbot/scripts/install-nightly.sh | bash
+          echo "$HOME/.govbot/bin" >> "$GITHUB_PATH"
+
+      # The ~90MB all-MiniLM-L6-v2 ONNX model is downloaded once and reused
+      # across runs. Stable key => downloaded on the first run, restored after.
+      - name: Cache embedding model
+        uses: actions/cache@v4
+        with:
+          path: /tmp/govbot-model
+          key: govbot-minilm-onnx-v1
+
+      # Per-repo incremental state: the seen-bills ledger + a snapshot of the
+      # produced tag files. Keyed on the taxonomy hash so editing the topic list
+      # busts the cache (forces a full re-tag); the run-id suffix + restore-keys
+      # prefix means each run saves a fresh snapshot and restores the latest one.
+      - name: Cache incremental tag state
+        uses: actions/cache@v4
+        with:
+          path: /tmp/govbot-cache
+          key: govbot-tags-${{ hashFiles('scripts/govbot-dashboard.yml') }}-${{ github.run_id }}
+          restore-keys: |
+            govbot-tags-${{ hashFiles('scripts/govbot-dashboard.yml') }}-
+
+      # Fetch live legislation data, tag it with govbot's embedding model, and
+      # rebuild the dashboard's data.json before mdbook runs. Every stage that
+      # touches the network or the tagger degrades to a warning + the keyword
+      # fallback (scripts/dashboard_tags.json) or, ultimately, the committed
+      # sample data, so the docs deploy never breaks.
       - name: Build dashboard data from legislation repos
         env:
           GH_TOKEN: ${{ github.token }}
           DATA_ORG: govbot-openstates-scrapers
+          GOVBOT_DATA: /tmp/govbot-data
+          MODEL_DIR: /tmp/govbot-model
+          CACHE_DIR: /tmp/govbot-cache
+          DASHBOARD_CONFIG: ${{ github.workspace }}/scripts/govbot-dashboard.yml
+          FILTER_SCRIPT: ${{ github.workspace }}/scripts/filter_new_bills.py
         run: |
           set -uo pipefail
-          mkdir -p /tmp/govbot-data/repos
+          mkdir -p /tmp/govbot-data/repos /tmp/govbot-model /tmp/govbot-cache
           repos=$(gh repo list "$DATA_ORG" --limit 200 --json name --jq '.[].name' | grep -- '-legislation$') || true
           if [ -z "${repos:-}" ]; then
             echo "::warning::no *-legislation repos found in $DATA_ORG; keeping committed sample data"
@@ -52,6 +84,20 @@ jobs:
               git clone --quiet --depth 1 "https://github.com/$DATA_ORG/$r.git" "/tmp/govbot-data/repos/$r" \
                 || echo "::warning::failed to clone $DATA_ORG/$r"
             done
+
+            # Warm up the model in a single process BEFORE fanning out, so the
+            # parallel workers below don't race to download it. Empty stdin is
+            # fine: govbot tag downloads the model before reading any lines.
+            mkdir -p /tmp/govbot-warmup
+            cp "$DASHBOARD_CONFIG" /tmp/govbot-warmup/govbot.yml
+            ( cd /tmp/govbot-warmup && : | govbot tag --govbot-dir "$MODEL_DIR" ) \
+              || echo "::warning::embedding model warm-up failed; tagging may use keyword fallback"
+
+            # Tag each repo incrementally, 4 at a time. Repos are independent.
+            find /tmp/govbot-data/repos -mindepth 1 -maxdepth 1 -type d -name '*-legislation' -print0 \
+              | xargs -0 -r -P4 -I{} bash scripts/tag_dashboard_repo.sh {}
+            echo "tag files produced: $(find /tmp/govbot-data/repos -path '*/tags/*.tag.json' | wc -l)"
+
             python3 scripts/build_dashboard_data.py \
               --govbot-dir /tmp/govbot-data \
               --tags-config scripts/dashboard_tags.json \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ Mock legislative data is available for offline development:
 - Contains: Wyoming (wy) and Guam (gu) sample data
 - Usage: `govbot logs --govbot-dir ./actions/govbot/mocks/govbot_data`
 
+## Pages Dashboard
+
+The GitHub Pages dashboard's topic taxonomy lives in `scripts/govbot-dashboard.yml`
+(the canonical `tags:` config the deploy workflow runs `govbot tag` against). Its topic
+names must stay in sync with the keyword fallback in `scripts/dashboard_tags.json`. See
+`docs/src/dashboard-guide.md` for the data flow; tagging in CI is incremental via
+`scripts/filter_new_bills.py` + `scripts/tag_dashboard_repo.sh`.
+
 ## govbot Development
 
 ```bash

--- a/docs/src/dashboard-guide.md
+++ b/docs/src/dashboard-guide.md
@@ -34,9 +34,21 @@ output (`_data/<locale>/bill_<uuid>.json`) — and joins topic tags from
 On every Pages deploy (and on a daily 8am UTC schedule), the workflow shallow-clones
 every `*-legislation` repo from the
 [govbot-openstates-scrapers](https://github.com/govbot-openstates-scrapers)
-organization and rebuilds `data.json` from all of them, so the published dashboard
-covers every tracked jurisdiction. If that step fails, the deploy falls back to the
-committed sample data rather than breaking the docs site.
+organization, tags the bills with govbot's embedding model, and rebuilds `data.json`
+from all of them, so the published dashboard covers every tracked jurisdiction. The
+topic taxonomy lives in
+[`scripts/govbot-dashboard.yml`](https://github.com/chihacknight/govbot/blob/main/scripts/govbot-dashboard.yml);
+`scripts/dashboard_tags.json` mirrors the same topic names as a keyword fallback for
+any bill the embedding tagger didn't reach.
+
+Tagging is **incremental**: after the first full pass, each run re-embeds only bills
+that are new or whose text changed, so the daily build stays fast. This is powered by
+two caches (a shared copy of the ~90MB embedding model, and a per-repo ledger +
+snapshot of the tag files) plus `scripts/filter_new_bills.py`, which drops unchanged
+bills before they reach the tagger. Editing `scripts/govbot-dashboard.yml` changes the
+cache key and triggers one full re-tag. Every stage degrades gracefully: a failed
+tagger falls back to keyword tags, and a failed data build falls back to the committed
+sample data rather than breaking the docs site.
 
 The committed sample data is built from the offline mocks
 (`actions/govbot/mocks/govbot_data` — Wyoming and Guam), with demo topics derived from
@@ -53,12 +65,18 @@ python3 scripts/build_dashboard_data.py \
 ## Regenerating locally with real data
 
 ```bash
-govbot clone all        # clone the dataset repos (~/govbot_data/repos)
-govbot tag              # optional: score bills against your govbot.yml tags
+govbot clone all                       # clone the dataset repos (~/govbot_data/repos)
+cp scripts/govbot-dashboard.yml govbot.yml   # tag definitions (govbot tag reads ./govbot.yml)
+govbot logs --join bill --limit none | govbot tag --overwrite   # score bills (embedding mode)
 python3 scripts/build_dashboard_data.py --output docs/src/dashboard/data.json
 ```
 
-When real `tags/*.tag.json` files exist for a session, they take precedence over
-the keyword fallback; a bill gets a tag when its `final_score` meets the tag's
-configured threshold. Commit the regenerated `data.json` and the Pages workflow
-publishes it with the rest of the docs.
+`govbot tag` downloads the embedding model (all-MiniLM-L6-v2) to `./govbot_data` on
+first use and writes `tags/*.tag.json` next to each session's `bills/`. When those
+files exist for a session they take precedence over the keyword fallback; a bill gets a
+tag when its `final_score` meets the tag's configured threshold. Commit the regenerated
+`data.json` and the Pages workflow publishes it with the rest of the docs.
+
+The Pages workflow does the same across all repos but per-repo (so tags land inside each
+clone) and incrementally — see `scripts/tag_dashboard_repo.sh` and
+`scripts/filter_new_bills.py`.

--- a/schemas/govbot.schema.json
+++ b/schemas/govbot.schema.json
@@ -81,11 +81,38 @@
           "type": "string"
         },
         "examples": {
-          "description": "Example bill descriptions that would match this tag",
+          "description": "Example bill descriptions that would match this tag. Embedded alongside the description in semantic (embedding) tagging mode.",
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "include_keywords": {
+          "description": "Keywords that boost a bill's score toward this tag (and drive keyword-only mode when the embedding model is unavailable).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude_keywords": {
+          "description": "Keywords that disqualify a bill from this tag when present.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "negative_examples": {
+          "description": "Example descriptions that should NOT match this tag; they subtract from the score in embedding mode.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "threshold": {
+          "description": "Minimum composite score for a bill to be assigned this tag (default 0.5).",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
         }
       },
       "required": ["description"]

--- a/scripts/dashboard_tags.json
+++ b/scripts/dashboard_tags.json
@@ -1,25 +1,57 @@
 {
-  "description": "Demo keyword tag definitions for the Pages dashboard sample data. Mirrors the shape of the `tags:` section in govbot.yml (keyword-only mode). Real deployments should run `govbot tag` and let build_dashboard_data.py read the resulting tags/*.tag.json files instead.",
+  "description": "Keyword tag definitions used as a fallback by build_dashboard_data.py for any bill that produced no `govbot tag` embedding output (tags/*.tag.json). Tag names MUST stay identical to the keys in scripts/govbot-dashboard.yml so descriptions and the embedding/keyword taxonomies line up. Real deployments run `govbot tag` (embedding mode) via .github/workflows/deploy-docs.yml; this keyword set covers repos/sessions the tagger did not reach and the committed offline sample data.",
   "tags": {
     "health care": {
-      "description": "Health care, public health, and insurance coverage",
-      "include_keywords": ["health", "medicaid", "medicare", "insurance", "birthing", "pregnancy", "hospital", "medical"]
+      "description": "Health care, public health, insurance coverage, Medicaid/Medicare, hospitals, and medical services",
+      "include_keywords": ["health", "medicaid", "medicare", "insurance", "hospital", "medical", "prescription", "clinic", "provider", "mental health", "birthing"]
     },
-    "budget & taxes": {
-      "description": "Appropriations, taxation, fees, and public funds",
-      "include_keywords": ["appropriation", "appropriations", "tax", "fees", "revenue", "bonding", "budget", "funds"]
-    },
-    "environment & wildlife": {
-      "description": "Natural resources, wildlife, hunting, fishing, and energy",
-      "include_keywords": ["animal", "animals", "hunting", "fishing", "wildlife", "oil and gas", "snowmobile", "water", "energy", "environment"]
+    "housing": {
+      "description": "Housing affordability, tenants and landlords, evictions, homelessness, and zoning",
+      "include_keywords": ["housing", "rent", "rental", "tenant", "landlord", "eviction", "homeless", "zoning", "mortgage", "affordable housing"]
     },
     "education": {
-      "description": "Schools, universities, and education policy",
-      "include_keywords": ["education", "school", "schools", "university", "student", "teacher"]
+      "description": "Schools, universities, curriculum, teachers, students, and education policy",
+      "include_keywords": ["education", "school", "schools", "university", "college", "student", "teacher", "curriculum", "tuition", "classroom"]
+    },
+    "environment & climate": {
+      "description": "Environment, climate, clean energy, natural resources, water, wildlife, and pollution",
+      "include_keywords": ["environment", "climate", "emissions", "energy", "pollution", "wildlife", "water", "conservation", "renewable", "oil and gas", "hunting", "fishing"]
+    },
+    "labor & workers": {
+      "description": "Wages, workplace safety, unions, paid leave, unemployment, and employment protections",
+      "include_keywords": ["labor", "worker", "employee", "wage", "minimum wage", "union", "overtime", "paid leave", "unemployment", "workplace"]
+    },
+    "immigration": {
+      "description": "Immigration, refugees and asylum, citizenship, enforcement, and immigrant services",
+      "include_keywords": ["immigration", "immigrant", "refugee", "asylum", "citizenship", "deportation", "undocumented", "migrant", "visa"]
+    },
+    "criminal justice": {
+      "description": "Criminal law, sentencing, policing, prisons, bail, parole, and justice reform",
+      "include_keywords": ["criminal", "police", "policing", "prison", "incarceration", "sentencing", "bail", "parole", "probation", "felony"]
+    },
+    "elections & voting": {
+      "description": "Elections, voting rights, registration, ballots, redistricting, and campaign finance",
+      "include_keywords": ["election", "elections", "voting", "voter", "ballot", "registration", "redistricting", "campaign finance", "polling place"]
+    },
+    "budget & taxes": {
+      "description": "Appropriations, taxation, tax credits, fees, revenue, bonding, and public funds",
+      "include_keywords": ["appropriation", "appropriations", "tax", "taxes", "tax credit", "fees", "revenue", "bonding", "budget", "funds"]
+    },
+    "transportation": {
+      "description": "Roads, highways, transit, rail, vehicles, traffic safety, and infrastructure",
+      "include_keywords": ["transportation", "highway", "road", "transit", "rail", "vehicle", "traffic", "bridge", "driver license", "infrastructure", "snowmobile"]
+    },
+    "reproductive rights": {
+      "description": "Abortion, contraception, reproductive health care, pregnancy, and family planning",
+      "include_keywords": ["abortion", "reproductive", "contraception", "family planning", "pregnancy", "reproductive health", "fetal"]
+    },
+    "lgbtq": {
+      "description": "Rights and policies affecting LGBTQ people, gender identity, and sexual orientation",
+      "include_keywords": ["lgbtq", "transgender", "gender identity", "sexual orientation", "gender-affirming", "same-sex", "nonbinary"]
     },
     "government operations": {
-      "description": "Permitting, licensing, elections, and agency administration",
-      "include_keywords": ["permit", "permits", "license", "licenses", "registration", "election", "agency", "department"]
+      "description": "Permitting, licensing, agency administration, public records, procurement, and ethics",
+      "include_keywords": ["permit", "permits", "license", "licenses", "agency", "department", "public records", "procurement", "ethics", "administration"]
     }
   }
 }

--- a/scripts/filter_new_bills.py
+++ b/scripts/filter_new_bills.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Incremental filter for the `govbot logs | govbot tag` dashboard pipeline.
+
+`govbot tag` runs one embedding forward pass per bill it receives on stdin, so
+tagging every bill on every daily dashboard build is slow (~1-2h at ~140k bills).
+This filter sits between `govbot logs` and `govbot tag` and passes through only
+bills that are **new or whose tag-relevant text changed** since the last run,
+based on a small per-repo ledger. After the first full pass, each run only
+re-tags what actually changed, keeping the nightly build to minutes.
+
+Why a ledger is needed rather than relying on cached tag files: `govbot tag`
+records a bill only when it matches at least one tag (see run_tag_command in
+actions/govbot/src/main.rs), so bills that match no topic leave no trace and
+would be re-embedded every run. The ledger records **every** bill it sees
+(matched or not), so unchanged bills are skipped regardless of whether they tag.
+
+Pipeline usage (see .github/workflows/deploy-docs.yml):
+
+    govbot logs --repos <loc> --govbot-dir <D> --join bill --limit none --filter none \
+      | python3 scripts/filter_new_bills.py --ledger <cache>/<repo>/ledger.json \
+      | ( cd <repo> && govbot tag --govbot-dir <model-dir> --overwrite )
+
+Notes:
+* Use `--join bill` (not the default `bill,tags`): the `tags` join would inject a
+  bill's own tags into the line after the first run, churning the content hash.
+* Pair with `govbot tag --overwrite` so a **changed** bill actually re-tags — the
+  tagger's own fast path skips a bill by id presence alone and would otherwise
+  keep stale tags for amended bills.
+* The ledger is per-repo so parallel workers never touch the same file.
+
+Only the Python standard library is used.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def content_hash(entry):
+    """Stable hash of the tag-relevant content of one `govbot logs` line.
+
+    Hashes the bill metadata plus this line's action — a superset of the text
+    `govbot tag` embeds (see ocd_files_select_default in
+    actions/govbot/src/selectors.rs). Deliberately excludes volatile top-level
+    fields (`id`, `sources`, `timestamp`) so an unchanged bill hashes the same
+    across runs. Falls back to the whole entry (minus those fields) if the line
+    is not shaped as expected.
+    """
+    bill = entry.get("bill")
+    if bill is not None:
+        material = {"bill": bill, "action": (entry.get("log") or {}).get("action")}
+    else:
+        material = {k: v for k, v in entry.items()
+                    if k not in ("id", "sources", "timestamp")}
+    blob = json.dumps(material, sort_keys=True, ensure_ascii=False,
+                      separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def load_ledger(path):
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError) as err:
+        print(f"filter_new_bills: ignoring unreadable ledger {path}: {err}",
+              file=sys.stderr)
+        return {}
+
+
+def save_ledger(path, ledger):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(ledger, sort_keys=True, separators=(",", ":")))
+    os.replace(tmp, path)  # atomic
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--ledger", required=True,
+                        help="Path to this repo's ledger JSON (bill_id -> content hash)")
+    args = parser.parse_args()
+
+    ledger_path = Path(args.ledger)
+    previous = load_ledger(ledger_path)
+    current = {}  # every bill seen this run -> its current hash (the next ledger)
+
+    read = emitted = 0
+    for line in sys.stdin:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        read += 1
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            # Not JSON we understand; pass it through untouched rather than drop.
+            sys.stdout.write(line)
+            emitted += 1
+            continue
+
+        bill_id = entry.get("id")
+        if not isinstance(bill_id, str):
+            # No stable id to dedup on; let the tagger handle it.
+            sys.stdout.write(line)
+            emitted += 1
+            continue
+
+        if bill_id in current:
+            # Another log line for a bill already decided this run (govbot logs
+            # emits one line per action). The first, most-recent line wins.
+            continue
+
+        h = content_hash(entry)
+        current[bill_id] = h
+        if previous.get(bill_id) != h:  # new bill or changed content
+            sys.stdout.write(line)
+            emitted += 1
+
+    save_ledger(ledger_path, current)
+    print(f"filter_new_bills: {len(current)} bills, {emitted} new/changed "
+          f"emitted, {len(current) - emitted} unchanged skipped "
+          f"(read {read} lines)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/govbot-dashboard.yml
+++ b/scripts/govbot-dashboard.yml
@@ -1,0 +1,173 @@
+# Canonical topic taxonomy for the GitHub Pages dashboard.
+#
+# The deploy workflow (.github/workflows/deploy-docs.yml) copies this file into
+# each cloned legislation repo as `govbot.yml` and runs `govbot tag`, which reads
+# these definitions and writes tags/*.tag.json next to each session's bills/.
+# `scripts/build_dashboard_data.py` then reads those tag files to power the
+# "Topics" filter and chart on the dashboard.
+#
+# IMPORTANT: the tag names (the keys under `tags:`) MUST stay identical to the
+# keys in `scripts/dashboard_tags.json`. build_dashboard_data.py sources each
+# topic's dashboard description from that JSON keyed by name, and falls back to
+# its keyword matching for any bill that produced no embedding tag. Mismatched
+# names would split the taxonomy and blank out descriptions.
+#
+# Each tag drives govbot's embedding tagger (all-MiniLM-L6-v2):
+#   description       - what the topic covers (embedded as the tag's meaning)
+#   examples          - sample bill summaries that should match (also embedded)
+#   include_keywords  - a keyword hit boosts the score / forces keyword-only mode
+#   threshold         - a bill is tagged when its composite score >= threshold
+#
+# Threshold note: govbot's composite embedding score runs high (a generic
+# "legislative" baseline lands ~0.6 for any bill/topic pair), so the default of
+# 0.5 would tag every bill with every topic. 0.72 keeps only confident matches;
+# bills below it fall back to keyword tags in build_dashboard_data.py. Tune this
+# against real dashboard output — the mock data is too sparse to calibrate on.
+$schema: https://raw.githubusercontent.com/chihacknight/govbot/main/schemas/govbot.schema.json
+
+repos:
+  - all
+
+tags:
+  health care:
+    description: |
+      Health care, public health, insurance coverage, Medicaid and Medicare,
+      hospitals, clinics, providers, prescription drugs, and medical services.
+    examples:
+      - "Expands Medicaid eligibility and postpartum coverage"
+      - "Regulates hospital billing and health insurance networks"
+      - "Caps insulin copays and prescription drug prices"
+    include_keywords: [health, medicaid, medicare, insurance, hospital, medical, prescription, clinic, provider, mental health]
+    threshold: 0.72
+
+  housing:
+    description: |
+      Housing affordability, rental and tenant protections, evictions,
+      homelessness, zoning and land use, home ownership, and construction.
+    examples:
+      - "Caps annual rent increases and strengthens tenant protections"
+      - "Funds affordable housing construction and homelessness services"
+      - "Reforms zoning to allow more multifamily housing"
+    include_keywords: [housing, rent, rental, tenant, landlord, eviction, homeless, zoning, mortgage, affordable housing]
+    threshold: 0.72
+
+  education:
+    description: |
+      Schools, school funding, curriculum, teachers, universities and colleges,
+      student aid, and education policy from pre-K through higher education.
+    examples:
+      - "Increases per-pupil funding and teacher salaries"
+      - "Establishes charter school authorization standards"
+      - "Expands college tuition assistance and student loan relief"
+    include_keywords: [education, school, schools, university, college, student, teacher, curriculum, tuition, classroom]
+    threshold: 0.72
+
+  environment & climate:
+    description: |
+      Environmental protection, climate change, clean energy, emissions,
+      natural resources, water, wildlife, pollution, and conservation.
+    examples:
+      - "Sets clean energy targets and reduces carbon emissions"
+      - "Protects wetlands and regulates industrial pollution"
+      - "Manages wildlife, water rights, and public lands"
+    include_keywords: [environment, climate, emissions, energy, pollution, wildlife, water, conservation, renewable, "oil and gas"]
+    threshold: 0.72
+
+  labor & workers:
+    description: |
+      Wages, workplace safety, unions and collective bargaining, paid leave,
+      unemployment, worker classification, and employment protections.
+    examples:
+      - "Raises the minimum wage and guarantees paid sick leave"
+      - "Protects the right to organize and bargain collectively"
+      - "Sets workplace safety standards and overtime rules"
+    include_keywords: [labor, worker, employee, wage, minimum wage, union, overtime, "paid leave", unemployment, workplace]
+    threshold: 0.72
+
+  immigration:
+    description: |
+      Immigration, refugees and asylum, citizenship, immigration enforcement,
+      and services or protections for immigrant communities.
+    examples:
+      - "Provides legal services and protections for immigrants"
+      - "Restricts state cooperation with federal immigration enforcement"
+      - "Expands access to driver licenses regardless of status"
+    include_keywords: [immigration, immigrant, refugee, asylum, citizenship, deportation, undocumented, migrant, visa]
+    threshold: 0.72
+
+  criminal justice:
+    description: |
+      Criminal law and sentencing, policing, prisons and incarceration,
+      bail and pretrial, parole and probation, and criminal justice reform.
+    examples:
+      - "Reforms cash bail and reduces pretrial detention"
+      - "Sets policing standards and use-of-force limits"
+      - "Revises sentencing guidelines and expands parole eligibility"
+    include_keywords: [criminal, police, policing, prison, incarceration, sentencing, bail, parole, probation, felony]
+    threshold: 0.72
+
+  elections & voting:
+    description: |
+      Elections, voting rights and access, voter registration, ballots,
+      redistricting, campaign finance, and election administration.
+    examples:
+      - "Expands early voting and mail-in ballot access"
+      - "Sets voter registration and voter ID requirements"
+      - "Reforms redistricting and campaign finance disclosure"
+    include_keywords: [election, elections, voting, voter, ballot, registration, redistricting, "campaign finance", "polling place"]
+    threshold: 0.72
+
+  budget & taxes:
+    description: |
+      State budgets and appropriations, taxation, tax credits, fees,
+      revenue, bonding, and public funds.
+    examples:
+      - "Appropriates general funds for the biennial budget"
+      - "Adjusts income tax rates and creates a new tax credit"
+      - "Authorizes bonding and allocates public revenue"
+    include_keywords: [appropriation, appropriations, tax, taxes, "tax credit", fees, revenue, bonding, budget, funds]
+    threshold: 0.72
+
+  transportation:
+    description: |
+      Roads and highways, transit and rail, bridges, drivers and vehicles,
+      traffic safety, and transportation infrastructure and funding.
+    examples:
+      - "Funds highway repair and public transit expansion"
+      - "Sets traffic safety rules and vehicle registration fees"
+      - "Invests in bridges, rail, and road infrastructure"
+    include_keywords: [transportation, highway, road, transit, rail, vehicle, traffic, bridge, "driver license", infrastructure]
+    threshold: 0.72
+
+  reproductive rights:
+    description: |
+      Abortion, contraception, reproductive health care access, pregnancy,
+      and family planning services and restrictions.
+    examples:
+      - "Protects access to abortion and reproductive health care"
+      - "Restricts abortion after a set number of weeks"
+      - "Expands contraception coverage and family planning services"
+    include_keywords: [abortion, reproductive, contraception, "family planning", pregnancy, "reproductive health", fetal]
+    threshold: 0.72
+
+  lgbtq:
+    description: |
+      Rights, protections, and policies affecting LGBTQ people, including
+      gender identity, sexual orientation, and anti-discrimination measures.
+    examples:
+      - "Prohibits discrimination based on sexual orientation and gender identity"
+      - "Protects access to gender-affirming care"
+      - "Addresses transgender participation and recognition"
+    include_keywords: [lgbtq, transgender, "gender identity", "sexual orientation", "gender-affirming", "same-sex", nonbinary]
+    threshold: 0.72
+
+  government operations:
+    description: |
+      Permitting and licensing, agency administration, public records,
+      procurement, ethics, and the general operation of government.
+    examples:
+      - "Modernizes professional licensing and permit processing"
+      - "Strengthens public records and government ethics rules"
+      - "Reforms state procurement and agency administration"
+    include_keywords: [permit, permits, license, licenses, agency, department, "public records", procurement, ethics, administration]
+    threshold: 0.72

--- a/scripts/tag_dashboard_repo.sh
+++ b/scripts/tag_dashboard_repo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Incrementally tag one cloned legislation repo for the Pages dashboard.
+#
+# Steps, per repo:
+#   1. Copy the canonical taxonomy in as the repo's govbot.yml (govbot tag forces
+#      its output to the directory containing govbot.yml).
+#   2. Restore tag files produced on previous runs (so unchanged bills keep tags).
+#   3. Stream `govbot logs` -> filter_new_bills.py (only new/changed bills) ->
+#      `govbot tag --overwrite` (embedding mode). Only changed bills get embedded.
+#   4. Save the produced tag files + ledger back to the cache for the next run.
+#
+# Designed to be run in parallel across repos (e.g. xargs -P4); all state is
+# per-repo so workers never contend. Failures are downgraded to warnings so the
+# dashboard build proceeds to its keyword fallback for this repo.
+#
+# Inputs: repo dir as $1; the rest via environment so the call site stays simple:
+#   GOVBOT_DATA       dir containing repos/ (passed to `govbot logs --govbot-dir`)
+#   MODEL_DIR         shared ONNX model cache (passed to `govbot tag --govbot-dir`)
+#   CACHE_DIR         root for per-repo incremental state (ledger + tag snapshot)
+#   DASHBOARD_CONFIG  path to scripts/govbot-dashboard.yml
+#   FILTER_SCRIPT     path to scripts/filter_new_bills.py
+#
+set -uo pipefail
+
+repo_dir=${1:?usage: tag_dashboard_repo.sh <repo_dir>}
+: "${GOVBOT_DATA:?}" "${MODEL_DIR:?}" "${CACHE_DIR:?}" "${DASHBOARD_CONFIG:?}" "${FILTER_SCRIPT:?}"
+
+[ -d "$repo_dir" ] || exit 0
+name=$(basename "$repo_dir")
+locale=${name%-legislation}
+repo_cache="$CACHE_DIR/$name"
+mkdir -p "$repo_cache"
+
+warn() { echo "::warning::$*"; }
+
+# 1. govbot tag reads tag definitions from ./govbot.yml and writes tags/ beside it.
+cp "$DASHBOARD_CONFIG" "$repo_dir/govbot.yml"
+
+# 2. Restore previously-produced tag files into the fresh clone.
+if [ -f "$repo_cache/tags.tgz" ]; then
+  tar -xzf "$repo_cache/tags.tgz" -C "$repo_dir" 2>/dev/null \
+    || warn "could not restore cached tags for $name (will re-tag)"
+fi
+
+# 3. Tag only new/changed bills. --limit none: all bills; --filter none: don't
+# drop entries; --join bill: stable content (no self-injected tags); --overwrite:
+# actually re-tag a changed bill (the tagger otherwise skips by id presence).
+govbot logs --repos "$locale" --govbot-dir "$GOVBOT_DATA" \
+    --join bill --limit none --filter none \
+  | python3 "$FILTER_SCRIPT" --ledger "$repo_cache/ledger.json" \
+  | ( cd "$repo_dir" && govbot tag --govbot-dir "$MODEL_DIR" --overwrite )
+status=${PIPESTATUS[2]}
+
+# 4. Persist produced tag files for next run's cache.
+filelist="$repo_cache/filelist.txt"
+( cd "$repo_dir" && find . -path '*/tags/*.tag.json' -print > "$filelist" ) 2>/dev/null || true
+if [ -s "$filelist" ]; then
+  tar -czf "$repo_cache/tags.tgz" -C "$repo_dir" -T "$filelist" 2>/dev/null \
+    || warn "could not save tag cache for $name"
+fi
+rm -f "$filelist"
+
+if [ "${status:-1}" -ne 0 ]; then
+  warn "govbot tag pipeline failed for $name (keyword fallback applies)"
+fi
+exit 0


### PR DESCRIPTION
## Summary

The dashboard's "Topics" were produced by a small keyword demo fallback (`scripts/dashboard_tags.json`). govbot's real embedding tagger (`govbot tag` — all-MiniLM-L6-v2 via ONNX, composite scoring, keyword boosts) already existed but was **never run in CI**: there was no `govbot.yml` with topic definitions and the deploy workflow never invoked it, so zero `tags/*.tag.json` files existed. This PR turns the existing tagger on, feeds it a topic taxonomy, and runs it incrementally on each dashboard build. The keyword config is kept as a graceful fallback.

The Rust tagger itself is **unchanged** — this is purely configuration + pipeline wiring.

## Changes

- **`scripts/govbot-dashboard.yml`** (new): canonical 13-topic taxonomy the deploy workflow copies into each cloned repo as `govbot.yml`. `threshold: 0.72` — govbot's composite score runs high, so the default 0.5 tags every bill with every topic. Topic names kept in sync with `dashboard_tags.json`.
- **`scripts/dashboard_tags.json`**: expanded from 5 to the same 13 topic names so the keyword fallback and dashboard descriptions line up.
- **`scripts/filter_new_bills.py`** (new): incremental filter. Tracks every seen bill in a per-repo ledger and passes only new/changed bills to the tagger, so after the first full pass each run re-embeds only what changed.
- **`scripts/tag_dashboard_repo.sh`** (new): per-repo restore → filter → `govbot tag --overwrite` → save; safe to run in parallel.
- **`.github/workflows/deploy-docs.yml`**: install the CLI, cache the ONNX model and the incremental state (keyed on the taxonomy hash), warm up the model before fanning out, tag repos 4-at-a-time, then build `data.json`. Every stage degrades to keyword / committed-sample-data fallback so the deploy never breaks.
- **`scripts/build_dashboard_data.py`**: unchanged — it already prefers `tags/*.tag.json` and only falls back to keywords when none exist.
- **`schemas/govbot.schema.json`**: document the optional tag fields (`include_keywords`, `exclude_keywords`, `negative_examples`, `threshold`).
- **docs + `CLAUDE.md`**: describe the new pipeline.

## Performance

Tagging is incremental: the first run is a full pass (~1–2h on the full dataset, unattended), and every run after re-embeds only new/changed bills (minutes). Two caches back this — a shared copy of the ~90MB model and a per-repo ledger + tag snapshot. Editing `scripts/govbot-dashboard.yml` bumps the cache key and triggers one full re-tag.

## Verification (Wyoming mock data)

- Embedding mode runs and is deterministic; each bill maps to the correct topic at threshold 0.72 (e.g. "Birthing centers–Medicaid coverage" → health care; "Fast Track Permits Act" → government operations).
- A second pass re-tags nothing (incrementality confirmed).
- `build_dashboard_data.py` consumes the tag files, with keyword fallback for bills that have no activity logs.

## Note

The 0.72 threshold was calibrated on sparse mock data and will likely need tuning against real dashboard output; it's a one-line change per topic and can be monitored via the dashboard's "% tagged" tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXDEo22QUAsogDfmBBVQHr)_