### PR TITLE
fix: validate merge-conflict resolution before committing scraped data

### DIFF
--- a/actions/scrape/action.yml
+++ b/actions/scrape/action.yml
@@ -527,7 +527,26 @@ runs:
             # In case of conflicts, keep our scraped files
             git checkout --ours "_data/${{ inputs.state }}/" 2>/dev/null || true
             git add "_data/${{ inputs.state }}/"
-            git commit --no-edit -m "🔄 Auto-merge: kept scraped data" || true
+
+            # git checkout --ours can silently no-op instead of resolving (see
+            # tamara-notes/scraper-status/critical-merge-conflict-corruption.md --
+            # this exact gap let GA commit 352 files full of literal, unresolved
+            # conflict markers for 5 days as if they were clean data). Verify the
+            # merge actually resolved and every bill JSON file still parses before
+            # committing; abort loudly instead of silently committing garbage.
+            UNMERGED=$(git diff --name-only --diff-filter=U)
+            BAD_JSON=$(find "_data/${{ inputs.state }}/" -type f -name '*.json' -print0 2>/dev/null \
+              | xargs -0 -I{} sh -c 'jq empty "$1" >/dev/null 2>&1 || echo "$1"' _ {})
+
+            if [ -n "$UNMERGED" ] || [ -n "$BAD_JSON" ]; then
+              echo "❌ Conflict resolution failed, aborting commit:" >&2
+              [ -n "$UNMERGED" ] && echo "Unmerged paths: $UNMERGED" >&2
+              [ -n "$BAD_JSON" ] && echo "Invalid JSON after resolution: $BAD_JSON" >&2
+              git merge --abort 2>/dev/null || true
+              exit 1
+            fi
+
+            git commit --no-edit -m "🔄 Auto-merge: kept scraped data"
           fi
 
           # Push with retries

--- a/actions/scrape/scrape.sh
+++ b/actions/scrape/scrape.sh
@@ -95,6 +95,12 @@ touch "$AUTOSAVE_FLAG"
             echo "✅ Auto-saved progress (attempt $i)"
             break
           fi
+          # A failed pull can leave conflict markers sitting in the working
+          # tree (unmerged, uncommitted) -- left alone, the final "Commit and
+          # push scraped files" step's `git add` would silently pick those up.
+          # Abort the merge so the working tree is clean for the next attempt
+          # or the final commit step, instead of leaving corrupted files behind.
+          git merge --abort 2>/dev/null || true
           echo "⚠️ Auto-save push failed (attempt $i), retrying..."
           sleep 5
         done


### PR DESCRIPTION
## Summary
- `git checkout --ours` in the "Commit and push scraped files" step could silently no-op instead of resolving a real conflict, letting files with literal, unresolved conflict markers get committed as if they were clean data — this is exactly what happened to GA (352 `bill_*.json` files with raw conflict markers, undetected for 5 days). See `tamara-notes/scraper-status/critical-merge-conflict-corruption.md`.
- `action.yml`'s conflict-resolution block now verifies no unmerged paths remain **and** every bill JSON file still parses before committing; aborts the merge and fails loudly (exit 1) instead of silently committing corrupted content.
- `scrape.sh`'s autosave loop now runs `git merge --abort` on a failed pull instead of retrying blind, so it can't leave marker-laden files in the working tree for the final commit step to pick up.

## Test plan
- [x] Reproduced a real modify/modify git conflict locally — confirmed the new validation doesn't regress the normal resolve-and-commit path (exit 0, clean commit).
- [x] Reproduced GA's actual failure signature (conflict markers staged with a clean index — i.e. `checkout --ours` no-op) — confirmed the new JSON validation catches it and aborts (exit 1), where the unmerged-paths check alone would have missed it.
- [x] Ran the **old** code against the identical corrupted state and confirmed it would have committed the marker-laden garbage silently, unconditionally — proving the vulnerability and the fix.
- [x] `bash -n` syntax check on `scrape.sh` and the extracted `action.yml` script block.
- [ ] Live GitHub Actions verification (force a real two-run race) — not yet done, flagged as still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)