### PR TITLE
chore: gitignore local Claude Code tool config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,8 @@ target/
 
 sample_data/*
 
+# Claude Code local tool config (personal permission allowlists, not shared project config)
+.claude/
+
 
 


### PR DESCRIPTION
## Summary
- \`.claude/\` (settings.json, settings.local.json) is local Claude Code tool config — personal permission allowlists built up across sessions, not shared project config. Add it to \`.gitignore\` so it stops showing up as untracked noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)