### PR TITLE
Fix: tag the dashboard against govbot's processed dataset (embeddings were inert)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -58,15 +58,16 @@ jobs:
           restore-keys: |
             govbot-tags-${{ hashFiles('scripts/govbot-dashboard.yml') }}-
 
-      # Fetch live legislation data, tag it with govbot's embedding model, and
-      # rebuild the dashboard's data.json before mdbook runs. Every stage that
-      # touches the network or the tagger degrades to a warning + the keyword
-      # fallback (scripts/dashboard_tags.json) or, ultimately, the committed
-      # sample data, so the docs deploy never breaks.
+      # Fetch govbot's processed legislation dataset, tag it with the embedding
+      # model, and rebuild the dashboard's data.json before mdbook runs. We clone
+      # via `govbot clone` (the chn-openstates-files dataset) rather than the raw
+      # openstates scraper repos, because `govbot logs`/`govbot tag` require
+      # govbot's OCD-files layout (country:/state:/sessions/.../logs). Every stage
+      # that touches the network or the tagger degrades to a warning + the keyword
+      # fallback (scripts/dashboard_tags.json) or, ultimately, the committed sample
+      # data, so the docs deploy never breaks.
       - name: Build dashboard data from legislation repos
         env:
-          GH_TOKEN: ${{ github.token }}
-          DATA_ORG: govbot-openstates-scrapers
           GOVBOT_DATA: /tmp/govbot-data
           MODEL_DIR: /tmp/govbot-model
           CACHE_DIR: /tmp/govbot-cache
@@ -74,16 +75,17 @@ jobs:
           FILTER_SCRIPT: ${{ github.workspace }}/scripts/filter_new_bills.py
         run: |
           set -uo pipefail
-          mkdir -p /tmp/govbot-data/repos /tmp/govbot-model /tmp/govbot-cache
-          repos=$(gh repo list "$DATA_ORG" --limit 200 --json name --jq '.[].name' | grep -- '-legislation$') || true
-          if [ -z "${repos:-}" ]; then
-            echo "::warning::no *-legislation repos found in $DATA_ORG; keeping committed sample data"
+          mkdir -p /tmp/govbot-data /tmp/govbot-model /tmp/govbot-cache
+
+          # Clone/pull the full supported dataset (depth-50 shallow, from
+          # chn-openstates-files) into /tmp/govbot-data/repos in govbot format.
+          govbot clone all --govbot-dir /tmp/govbot-data --parallel 8 \
+            || echo "::warning::govbot clone reported errors; proceeding with whatever cloned"
+
+          if [ -z "$(ls -A /tmp/govbot-data/repos 2>/dev/null)" ]; then
+            echo "::warning::no legislation data cloned; keeping committed sample data"
           else
-            echo "cloning $(echo "$repos" | wc -l) repos from $DATA_ORG"
-            for r in $repos; do
-              git clone --quiet --depth 1 "https://github.com/$DATA_ORG/$r.git" "/tmp/govbot-data/repos/$r" \
-                || echo "::warning::failed to clone $DATA_ORG/$r"
-            done
+            echo "cloned $(find /tmp/govbot-data/repos -mindepth 1 -maxdepth 1 -type d | wc -l) repos"
 
             # Warm up the model in a single process BEFORE fanning out, so the
             # parallel workers below don't race to download it. Empty stdin is
@@ -101,7 +103,7 @@ jobs:
             python3 scripts/build_dashboard_data.py \
               --govbot-dir /tmp/govbot-data \
               --tags-config scripts/dashboard_tags.json \
-              --source-label "github.com/$DATA_ORG" \
+              --source-label "github.com/chn-openstates-files" \
               --output docs/src/dashboard/data.json \
               || {
                 echo "::warning::dashboard data build failed; keeping committed sample data"

--- a/docs/src/dashboard-guide.md
+++ b/docs/src/dashboard-guide.md
@@ -31,12 +31,13 @@ OCD-files layout (`**/bills/<ID>/metadata.json`) or raw OpenStates scraper
 output (`_data/<locale>/bill_<uuid>.json`) — and joins topic tags from
 `govbot tag` output (`tags/*.tag.json`).
 
-On every Pages deploy (and on a daily 8am UTC schedule), the workflow shallow-clones
-every `*-legislation` repo from the
-[govbot-openstates-scrapers](https://github.com/govbot-openstates-scrapers)
-organization, tags the bills with govbot's embedding model, and rebuilds `data.json`
-from all of them, so the published dashboard covers every tracked jurisdiction. The
-topic taxonomy lives in
+On every Pages deploy (and on a daily 8am UTC schedule), the workflow runs
+`govbot clone all` to fetch govbot's processed dataset (the `chn-openstates-files`
+`*-legislation` repos, in govbot's OCD-files layout), tags the bills with govbot's
+embedding model, and rebuilds `data.json` from all of them, so the published
+dashboard covers every tracked jurisdiction. (The embedding tagger needs that
+layout — `govbot logs`/`govbot tag` read the per-bill `logs/` structure, which the
+raw OpenStates scraper repos don't have.) The topic taxonomy lives in
 [`scripts/govbot-dashboard.yml`](https://github.com/chihacknight/govbot/blob/main/scripts/govbot-dashboard.yml);
 `scripts/dashboard_tags.json` mirrors the same topic names as a keyword fallback for
 any bill the embedding tagger didn't reach.


### PR DESCRIPTION
## Summary

Follow-up to #99. That change wired up embedding tagging but it was **inert on production data**: the first deploy ran the tagger and produced **0 tags**, so the dashboard silently stayed on keyword tags.

**Root cause:** the workflow cloned the raw OpenStates scraper repos (`govbot-openstates-scrapers`, `bill_<uuid>.json` with no `logs/` layout). `govbot logs` / `govbot tag` require govbot's OCD-files layout, so `govbot logs` returned **0 lines for all 56 repos** → no bills reached the tagger. (Verified in run [30313334183](https://github.com/chihacknight/govbot/actions/runs/30313334183): "Using embedding mode" ×57, but every repo logged `read 0 lines` and `tag files produced: 0`.)

**Fix:** fetch the data with `govbot clone all` instead, which pulls govbot's processed dataset (`chn-openstates-files`) in the OCD-files layout the tagger needs — the same path the social-media pipeline uses in production daily, and the layout my mock verification already exercised end-to-end. The per-repo tag loop, incremental filter, and caches are unchanged.

## Changes

- `.github/workflows/deploy-docs.yml`: replace the `gh repo list` + `git clone` of the raw scrapers org with `govbot clone all --govbot-dir /tmp/govbot-data` (depth-50 shallow). Keeps the model/incremental caches, the parallel tag loop, and every graceful-fallback guard.
- `docs/src/dashboard-guide.md`: describe the corrected data source.

## Expectation after merge

The next deploy does the one-time full embedding pass (~1–2h, unattended), producing real `tags/*.tag.json`; subsequent runs are incremental. If tagging ever fails, the keyword fallback still applies, so the dashboard never breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXDEo22QUAsogDfmBBVQHr)_