### PR TITLE
dashboard: add technology & AI topic and give each section a colored border

### DIFF
--- a/docs/src/dashboard/index.html
+++ b/docs/src/dashboard/index.html
@@ -195,12 +195,13 @@
   .card h2 { font-size: 14px; font-weight: 600; margin: 0 0 2px; }
   .card .sub { color: var(--text-muted); font-size: 12px; margin: 0 0 12px; }
 
-  /* Section accent: a colored left border marks each of the three main
-     sections with its own hue so they read as distinct at a glance. */
-  .card--accent { border-left-width: 3px; }
-  .card--jurisdiction { border-left-color: var(--series-1); }  /* blue   */
-  .card--topic        { border-left-color: var(--series-5); }  /* purple */
-  .card--bills        { border-left-color: var(--series-3); }  /* amber  */
+  /* Section accent: each main section carries its own colored border on all
+     four sides so the sections read as distinct blocks at a glance. */
+  .card--accent { border-width: 2px; }
+  .card--jurisdiction { border-color: var(--series-1); }  /* blue   */
+  .card--topic        { border-color: var(--series-5); }  /* purple */
+  .card--activity     { border-color: var(--series-2); }  /* green  */
+  .card--bills        { border-color: var(--series-3); }  /* amber  */
 
   .hbar-row {
     display: grid; grid-template-columns: 160px 1fr; gap: 10px;
@@ -370,7 +371,7 @@
     </div>
   </div>
 
-  <div class="card" id="activity-card">
+  <div class="card card--accent card--activity" id="activity-card">
     <h2>Activity by month</h2>
     <p class="sub" id="activity-sub">Bills with their most recent action in each month</p>
     <div id="chart-months"></div>

--- a/scripts/dashboard_tags.json
+++ b/scripts/dashboard_tags.json
@@ -52,6 +52,10 @@
     "government operations": {
       "description": "Permitting, licensing, agency administration, public records, procurement, and ethics",
       "include_keywords": ["permit", "permits", "license", "licenses", "agency", "department", "public records", "procurement", "ethics", "administration"]
+    },
+    "technology & AI": {
+      "description": "Artificial intelligence, data centers, cryptocurrency and blockchain, data privacy, cybersecurity, and broadband",
+      "include_keywords": ["artificial intelligence", "machine learning", "automated decision", "deepfake", "data center", "data centers", "cryptocurrency", "crypto", "blockchain", "digital asset", "digital assets", "bitcoin", "data privacy", "cybersecurity", "broadband"]
     }
   }
 }

--- a/scripts/govbot-dashboard.yml
+++ b/scripts/govbot-dashboard.yml
@@ -171,3 +171,15 @@ tags:
       - "Reforms state procurement and agency administration"
     include_keywords: [permit, permits, license, licenses, agency, department, "public records", procurement, ethics, administration]
     threshold: 0.72
+
+  technology & AI:
+    description: |
+      Artificial intelligence and automated decision systems, data centers,
+      cryptocurrency and blockchain, data privacy, cybersecurity, and
+      broadband and internet policy.
+    examples:
+      - "Regulates artificial intelligence and automated decision systems"
+      - "Sets siting, energy, and water use rules for data centers"
+      - "Governs cryptocurrency, digital assets, and blockchain"
+    include_keywords: ["artificial intelligence", "machine learning", "automated decision", deepfake, "data center", "data centers", cryptocurrency, crypto, blockchain, "digital asset", "digital assets", bitcoin, "data privacy", cybersecurity, broadband]
+    threshold: 0.72


### PR DESCRIPTION
## Summary

Two focused dashboard fixes:

1. **Missing topics** — adds a **`technology & AI`** topic covering artificial intelligence / automated decision systems, data centers, cryptocurrency & blockchain, data privacy, cybersecurity, and broadband. Added to both taxonomy sources so they stay in sync:
   - `scripts/govbot-dashboard.yml` — canonical embedding config (`govbot tag` in CI)
   - `scripts/dashboard_tags.json` — keyword fallback

   Takes effect on the live dashboard, which the deploy workflow rebuilds from real bill data daily. The committed sample `data.json` (WY/GU mocks) has no matching bills, so the topic won't appear in the offline demo — expected.

2. **Section borders** — changes the section accent from a single left stripe to a full **2px colored border on all four sides**, and extends it to the **Activity by month** card so all four content sections read as distinct blocks:
   - Bills by jurisdiction → blue
   - Bills by topic → purple
   - Activity by month → green (newly bordered)
   - Bills table → amber

   Borders use the theme's series-color variables, so they adapt in both light and dark mode.

## Verification

- Both taxonomy files validated and confirmed in sync (14 tags each, identical names).
- Sample `data.json` rebuild confirms mock data is unaffected (no tech-keyword matches in WY/GU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjmoBXsU2rZXpUmBdvGGLk)_