### PR TITLE
Fix silent data loss in text extraction: git push failures on large commits

### DIFF
--- a/actions/extract/action.yml
+++ b/actions/extract/action.yml
@@ -76,6 +76,15 @@ runs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
+        # Large incremental pushes (many new PDFs/extracted text files per commit)
+        # can hit "fatal: the remote end hung up unexpectedly" with git's default
+        # 1MiB http.postBuffer, especially over HTTP/2. Seen repeatedly in practice
+        # on ma-legislation: periodic auto-commit pushes failing 3/3 retries and
+        # killing the job, discarding that run's extraction work on the next
+        # checkout's hard reset. Same fix that resolved it manually 2026-08-07.
+        git config --local http.postBuffer 524288000
+        git config --local http.version HTTP/1.1
+
         # Pull latest changes to ensure we have the most recent metadata with timestamps
         # This prevents race conditions where a previous run just committed updates
         echo "📥 Pulling latest changes to get updated metadata..."
@@ -320,6 +329,15 @@ runs:
         # Configure git
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+
+        # Large incremental pushes (many new PDFs/extracted text files per commit)
+        # can hit "fatal: the remote end hung up unexpectedly" with git's default
+        # 1MiB http.postBuffer, especially over HTTP/2. Seen repeatedly in practice
+        # on ma-legislation: periodic auto-commit pushes failing 3/3 retries and
+        # killing the job, discarding that run's extraction work on the next
+        # checkout's hard reset. Same fix that resolved it manually 2026-08-07.
+        git config --local http.postBuffer 524288000
+        git config --local http.version HTTP/1.1
 
         # Add changes (bill text files in country:us/)
         git add country:us/ .windycivi/


### PR DESCRIPTION
## Summary
- The auto-commit loop (periodic, every 30min) and end-of-job commit step in `actions/extract/action.yml` both push with git's default 1MiB `http.postBuffer`, which intermittently fails on large incremental pushes with `fatal: the remote end hung up unexpectedly`.
- When the periodic loop hits this 3x in a row, it kills the whole job (`pkill -P $$ python`). Since `actions/checkout` hard-resets on the next run, that run's extraction work is silently discarded.
- Observed live on `govbot-data/ma-legislation`: 6+ hours of ~47min restart cycles today (2026-08-07), each doing real extraction work but losing it on push failure.
- Fix: set `http.postBuffer 524288000` and `http.version HTTP/1.1` alongside the existing `git config` calls. Same combination already verified working manually for a large one-off push earlier this session.

## Test plan
- [ ] Merge and let `ma-legislation`'s next auto-restart pick up the fix
- [ ] Confirm a full auto-commit cycle (30min mark) pushes successfully instead of hitting the 3-retry failure
- [ ] Confirm `origin/main` on `ma-legislation` advances past the current 6-hour-stale commit