### PR TITLE
Fix Commit Changes step silently skipped on extraction failure

### DIFF
--- a/actions/extract/action.yml
+++ b/actions/extract/action.yml
@@ -341,6 +341,15 @@ runs:
         fi
 
     - name: Commit Changes
+      # Without this, a nonzero exit from the extraction step above (which
+      # happens on every run that hits even one permanently-failing bill --
+      # e.g. a dead PDF link or an unparseable scanned document -- see
+      # tamara-notes/scraper-status/not-working.md) skips this step entirely,
+      # silently discarding any progress that didn't make it into a periodic
+      # 30-min auto-save. Confirmed happening live 2026-08-08 on ma-legislation:
+      # a 14-minute run's entire output was lost this way, only caught and
+      # recovered by hand because someone was actively watching.
+      if: always()
       shell: bash
       run: |
         echo "📝 Committing extracted text files"


### PR DESCRIPTION
## Summary
- The end-of-job "Commit Changes" step in `actions/extract/action.yml` had no `if:` condition, so it was silently skipped by GitHub Actions' default behavior whenever the preceding extraction step exited nonzero.
- That happens on essentially every run, since permanently-failing bills (dead PDF links, unparseable scanned documents) guarantee `Errors > 0` and a nonzero exit — see the ongoing discussion in `tamara-notes/scraper-status/not-working.md`.
- Net effect: any extraction progress that hadn't already landed via the periodic 30-min auto-save was discarded outright, on top of the two issues already fixed in #105 and #106.
- Confirmed happening live 2026-08-08 on `ma-legislation` — a run's ~14 minutes of work was about to be lost this way, caught and manually recovered only because someone was actively watching the run.

## Fix
Add `if: always()` to the Commit Changes step so it runs regardless of the extraction step's outcome, matching how the caller workflow's own "Display extraction summary" step is already configured.

## Test plan
- [ ] Re-enable the workflow and confirm a run that hits a permanent per-bill failure still lands a final commit instead of losing that cycle's work