### PR TITLE
Stop retrying durably-unavailable bills every run, fix restart loop root cause

### DIFF
--- a/actions/extract/action.yml
+++ b/actions/extract/action.yml
@@ -272,24 +272,27 @@ runs:
 
         # Extract summary statistics for GitHub Actions summary (take last match only)
         TOTAL_BILLS=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Total bills: \K\d+' | tail -1 || echo "0")
-        PROCESSED=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Processed: \K\d+' | tail -1 || echo "0")
         SUCCESSFUL=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Successful: \K\d+' | tail -1 || echo "0")
         ERRORS=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Errors: \K\d+' | tail -1 || echo "0")
+        UNAVAILABLE=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Unavailable: \K\d+' | tail -1 || echo "0")
         SKIPPED=$(echo "$EXTRACTION_OUTPUT" | grep -oP 'Skipped \(already processed\): \K\d+' | tail -1 || echo "0")
         # Bill IDs that failed, printed by main.py under a "Failed bills:" header --
         # not written anywhere in the repo (see actions/extract/utils/common.py),
         # so the run summary is the only place these are visible.
         FAILED_BILLS=$(echo "$EXTRACTION_OUTPUT" | sed -n '/^Failed bills:$/,$p' | tail -n +2)
 
-        # Save stats to a file for easy display in caller workflow
+        # Save stats to a file for easy display in caller workflow.
+        # Extracted now (this run's actual new work) leads -- it's the
+        # number that answers "did anything happen," everything else is
+        # context for it.
         echo "📊 Text Extraction Summary for ${{ inputs.state }}" > "${{ github.workspace }}/.extraction_summary.txt"
         echo "========================================" >> "${{ github.workspace }}/.extraction_summary.txt"
         echo "" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Total bills:                 $TOTAL_BILLS" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Processed:                   $PROCESSED" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Successful:                  $SUCCESSFUL" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Errors:                      $ERRORS" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Skipped (already processed): $SKIPPED" >> "${{ github.workspace }}/.extraction_summary.txt"
+        echo "Extracted now:     $SUCCESSFUL" >> "${{ github.workspace }}/.extraction_summary.txt"
+        echo "Total bills:       $TOTAL_BILLS" >> "${{ github.workspace }}/.extraction_summary.txt"
+        echo "Already processed: $SKIPPED" >> "${{ github.workspace }}/.extraction_summary.txt"
+        echo "Unavailable:       $UNAVAILABLE" >> "${{ github.workspace }}/.extraction_summary.txt"
+        echo "Errors:            $ERRORS" >> "${{ github.workspace }}/.extraction_summary.txt"
 
         # Create GitHub Actions summary
         {
@@ -297,11 +300,11 @@ runs:
           echo ""
           echo "| Metric | Count |"
           echo "|--------|-------|"
+          echo "| **Extracted now** | **$SUCCESSFUL** |"
           echo "| Total Bills | $TOTAL_BILLS |"
-          echo "| **Errors** | **$ERRORS** |"
-          echo "| Processed | $PROCESSED |"
-          echo "| Successful | $SUCCESSFUL |"
-          echo "| Skipped | $SKIPPED |"
+          echo "| Already processed | $SKIPPED |"
+          echo "| Unavailable | $UNAVAILABLE |"
+          echo "| Errors | $ERRORS |"
           echo ""
         } >> $GITHUB_STEP_SUMMARY
 
@@ -369,6 +372,11 @@ runs:
 
         # Add changes (bill text files in country:us/)
         git add country:us/ .windycivi/
+        # Conditional: only exists if extraction reached its final summary
+        # step (main.py can exit early via an unhandled exception before
+        # ever writing it) -- a plain `git add` on a missing path would fail
+        # the whole command and abort this step.
+        [ -f .extraction_unavailable.json ] && git add .extraction_unavailable.json
 
         # Commit if there are changes
         if git diff --staged --quiet; then

--- a/actions/extract/action.yml
+++ b/actions/extract/action.yml
@@ -20,6 +20,23 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  extracted-now:
+    description: "Bills successfully extracted this run"
+    value: ${{ steps.extract.outputs.extracted-now }}
+  total-bills:
+    description: "Total bills found"
+    value: ${{ steps.extract.outputs.total-bills }}
+  already-processed:
+    description: "Bills skipped because already extracted"
+    value: ${{ steps.extract.outputs.already-processed }}
+  unavailable:
+    description: "Bills durably marked unavailable (dead link / no text layer / placeholder)"
+    value: ${{ steps.extract.outputs.unavailable }}
+  errors:
+    description: "Genuine errors (not content-shaped failures)"
+    value: ${{ steps.extract.outputs.errors }}
+
 runs:
   using: "composite"
   steps:
@@ -281,18 +298,19 @@ runs:
         # so the run summary is the only place these are visible.
         FAILED_BILLS=$(echo "$EXTRACTION_OUTPUT" | sed -n '/^Failed bills:$/,$p' | tail -n +2)
 
-        # Save stats to a file for easy display in caller workflow.
-        # Extracted now (this run's actual new work) leads -- it's the
-        # number that answers "did anything happen," everything else is
-        # context for it.
-        echo "📊 Text Extraction Summary for ${{ inputs.state }}" > "${{ github.workspace }}/.extraction_summary.txt"
-        echo "========================================" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Extracted now:     $SUCCESSFUL" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Total bills:       $TOTAL_BILLS" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Already processed: $SKIPPED" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Unavailable:       $UNAVAILABLE" >> "${{ github.workspace }}/.extraction_summary.txt"
-        echo "Errors:            $ERRORS" >> "${{ github.workspace }}/.extraction_summary.txt"
+        # Pass stats to the caller workflow via step outputs, not a file --
+        # a file sitting in the working directory can get silently clobbered
+        # by the Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08: this exact file was accidentally tracked in git from
+        # some past commit, so a pull would overwrite our fresh numbers with
+        # a stale committed copy right before the caller workflow displayed
+        # them). Outputs are just process memory -> $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
+        echo "extracted-now=$SUCCESSFUL" >> "$GITHUB_OUTPUT"
+        echo "total-bills=$TOTAL_BILLS" >> "$GITHUB_OUTPUT"
+        echo "already-processed=$SKIPPED" >> "$GITHUB_OUTPUT"
+        echo "unavailable=$UNAVAILABLE" >> "$GITHUB_OUTPUT"
+        echo "errors=$ERRORS" >> "$GITHUB_OUTPUT"
 
         # Create GitHub Actions summary
         {

--- a/actions/extract/main.py
+++ b/actions/extract/main.py
@@ -1,6 +1,7 @@
 import click
 from pathlib import Path
 import sys
+import json
 
 # Add the current directory to the path
 sys.path.append(str(Path(__file__).parent))
@@ -62,8 +63,19 @@ def main(state: str, data_folder: Path, incremental: bool = False):
         print(f"Processed: {stats['processed']}")
         print(f"Successful: {stats['successful']}")
         print(f"Errors: {stats['errors']}")
+        print(f"Unavailable: {stats.get('unavailable', 0)}")
         if stats.get("skipped", 0) > 0:
             print(f"Skipped (already processed): {stats['skipped']}")
+
+        unavailable_bills = stats.get("unavailable_bills", [])
+        if unavailable_bills:
+            unavailable_path = data_folder / ".extraction_unavailable.json"
+            try:
+                with open(unavailable_path, "w", encoding="utf-8") as f:
+                    json.dump(unavailable_bills, f, indent=2)
+                print(f"📝 Wrote {len(unavailable_bills)} unavailable bills to {unavailable_path}")
+            except Exception as e:
+                print(f"⚠️ Could not write {unavailable_path}: {e}")
 
         if stats["errors"] > 0:
             print(f"⚠️ {stats['errors']} bills had errors during processing")

--- a/actions/extract/utils/common.py
+++ b/actions/extract/utils/common.py
@@ -172,6 +172,16 @@ def download_with_retry(
                 )
                 return e.response
 
+            if e.response is not None and e.response.status_code == 404:
+                # A genuine 404 (no valid PDF body behind it, checked above)
+                # means the resource doesn't exist -- retrying with backoff
+                # won't change that, it just burns 3x the time on every one
+                # of these for nothing. Distinct from a timeout/connection
+                # error/5xx, which can be transient and are worth retrying.
+                print(f"   ❌ 404 Not Found, not retrying: {url}")
+                _last_download_error = str(e)
+                return None
+
             print(f"   ⚠️ Attempt {attempt + 1} failed: {e}")
             _last_download_error = str(e)
             if attempt < max_retries - 1:

--- a/actions/extract/utils/common.py
+++ b/actions/extract/utils/common.py
@@ -155,6 +155,33 @@ def download_with_retry(
             response.raise_for_status()
             return response
 
+        except requests.exceptions.HTTPError as e:
+            # malegislature.gov (and possibly other sites) sometimes returns a
+            # non-2xx status code -- e.g. 404 -- while still serving a genuine,
+            # complete PDF in the body. raise_for_status() above discards that
+            # response before anything gets a chance to look at the body.
+            # Confirmed live 2026-08-08: real %PDF- content sitting behind a
+            # 404 status for MA bills that were being wrongly recorded as
+            # totally missing. Only trust this for an unambiguous PDF magic
+            # byte match -- narrow enough that it can't accidentally let an
+            # actual error page (which would never start with %PDF-) through.
+            if e.response is not None and e.response.content[:5] == b"%PDF-":
+                print(
+                    f"   ⚠️ Got HTTP {e.response.status_code} but body is a "
+                    f"real PDF -- using it anyway"
+                )
+                return e.response
+
+            print(f"   ⚠️ Attempt {attempt + 1} failed: {e}")
+            _last_download_error = str(e)
+            if attempt < max_retries - 1:
+                wait_time = delay * (2**attempt) + random.uniform(1, 3)
+                print(f"   ⏳ Waiting {wait_time:.1f}s before retry...")
+                time.sleep(wait_time)
+            else:
+                print(f"   ❌ All {max_retries} attempts failed for {url}")
+                return None
+
         except requests.exceptions.RequestException as e:
             print(f"   ⚠️ Attempt {attempt + 1} failed: {e}")
             _last_download_error = str(e)

--- a/actions/extract/utils/pdf_extractor.py
+++ b/actions/extract/utils/pdf_extractor.py
@@ -133,12 +133,19 @@ def extract_pdf(url: str, download_with_retry_func) -> Optional[dict]:
     Returns a dict with:
       - raw_bytes: the genuine, unmodified PDF bytes as downloaded (for
         storage, and for handing off to a vision-capable model later)
-      - text: plain extracted text (no section-splitting -- one clean read)
+      - text: plain extracted text (no section-splitting -- one clean
+        read), or None if the PDF downloaded fine but no library could
+        pull text out of it (most commonly: a scanned/image-only PDF
+        with no embedded text layer -- these three libraries don't do
+        OCR, so there's genuinely nothing more to try)
       - has_visual_markup: cheap geometry-based signal for whether this
         document likely contains redline (strikethrough/underline) markup
         that plain text extraction can't faithfully represent
 
-    Returns None if the download or every extraction library fails.
+    Returns None only if the download itself failed -- distinct from a
+    successful download with unparseable content (see "text" above),
+    since callers need to tell those apart to record an accurate failure
+    reason instead of a generic "download failed".
     """
     response = download_with_retry_func(url, max_retries=3, delay=1.0)
     if not response:
@@ -148,7 +155,6 @@ def extract_pdf(url: str, download_with_retry_func) -> Optional[dict]:
     text = _extract_pages_text(raw_bytes)
     if not text:
         print(f"   ⚠️ No PDF parsing libraries available or all failed")
-        return None
 
     return {
         "raw_bytes": raw_bytes,

--- a/actions/extract/utils/text_extraction.py
+++ b/actions/extract/utils/text_extraction.py
@@ -165,7 +165,7 @@ def download_congress_gov_content(url: str) -> str:
         return None
 
 
-def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> bool:
+def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path):
     """
     Extract bill text for a single bill from its metadata.json file.
 
@@ -174,8 +174,22 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
         files_dir: Path to files/ directory for this bill
 
     Returns:
-        True if successful, False otherwise
+        (success, unavailable_reason) tuple.
+        - success: True if any document was extracted.
+        - unavailable_reason: when success is False, a short string
+          ("download_failed", "no_text_layer", "placeholder_only", or a
+          combination) if every failure was content-shaped (dead link,
+          unparseable document, JS-only placeholder) -- i.e. the kind of
+          failure that's about the source document, not our own system,
+          and safe to mark as durably unavailable rather than retried
+          every run. None if any failure was a local "save" error (a real
+          bug in our own write path, not the document's fault) or an
+          unhandled exception -- those should keep counting as real
+          errors, not get silently parked.
     """
+    had_save_error = False
+    content_failure_reasons = set()
+
     try:
         # Load metadata
         with open(metadata_file, "r", encoding="utf-8") as f:
@@ -206,7 +220,7 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
 
         if not arrays_to_process:
             # This is normal - not all bills have full text available
-            return True  # Don't count as error
+            return True, None  # Don't count as error
 
         success_count = 0
 
@@ -338,6 +352,28 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                                 "item_note": item_note,
                             },
                         )
+                        content_failure_reasons.add("download_failed")
+                        continue
+
+                    if "pdf" in media_type.lower() and not extracted_text:
+                        # Downloaded a genuine PDF, but no library could pull
+                        # text out of it -- almost always a scanned/image-only
+                        # PDF with no text layer, which none of pdfplumber /
+                        # PyPDF2 / PyMuPDF can OCR. Distinct from a download
+                        # failure: the document exists and was fetched fine.
+                        print(f"   ❌ PDF has no extractable text: {url}")
+                        record_failed_bill(
+                            bill_id=bill_id,
+                            error_type="parsing",
+                            error_message="PDF downloaded but no text layer found (likely scanned/image-only)",
+                            url=url,
+                            metadata_file=str(metadata_file),
+                            additional_info={
+                                "media_type": media_type,
+                                "item_note": item_note,
+                            },
+                        )
+                        content_failure_reasons.add("no_text_layer")
                         continue
 
                     print(f"   📄 Downloaded {len(content)} {'bytes' if is_binary_content else 'characters'}")
@@ -380,6 +416,7 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                                 "item_note": item_note,
                             },
                         )
+                        content_failure_reasons.add("parsing_failed")
                         continue
 
                     if "html" in media_type.lower() and extracted_data.get(
@@ -409,6 +446,7 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                         print(f"   ✅ {file_extension.upper()} saved successfully")
                     except Exception as e:
                         print(f"   ❌ Error saving {file_extension.upper()}: {e}")
+                        had_save_error = True
                         continue
 
                     # Save extracted text -- a single clean read, no artificial
@@ -446,6 +484,7 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                                 "text_filename": text_filename,
                             },
                         )
+                        had_save_error = True
                         continue
 
                     success_count += 1
@@ -469,12 +508,20 @@ def extract_bill_text_from_metadata(metadata_file: Path, files_dir: Path) -> boo
                         metadata_file=str(metadata_file),
                         additional_info={"item_note": item_note},
                     )
+                    content_failure_reasons.add("placeholder_only")
 
-        return success_count > 0
+        if success_count > 0:
+            return True, None
+        if had_save_error:
+            # A real bug in our own write path, not the source document's
+            # fault -- don't mark this bill as durably unavailable, let it
+            # keep counting as a genuine error so it gets noticed and retried.
+            return False, None
+        return False, "+".join(sorted(content_failure_reasons)) or "no_versions_found"
 
     except Exception as e:
         print(f"   ❌ Error processing {metadata_file}: {e}")
-        return False
+        return False, None
 
 
 def process_bills_in_batch(
@@ -505,6 +552,8 @@ def process_bills_in_batch(
     success_count = 0
     error_count = 0
     skipped_count = 0
+    unavailable_count = 0
+    unavailable_bills = []
 
     print(f"📊 Found {total_bills} bills to process for text extraction")
 
@@ -532,12 +581,29 @@ def process_bills_in_batch(
                 files_dir.mkdir(parents=True, exist_ok=True)
 
                 # Extract text for this bill
-                success = extract_bill_text_from_metadata(metadata_file, files_dir)
+                success, unavailable_reason = extract_bill_text_from_metadata(
+                    metadata_file, files_dir
+                )
 
                 if success:
                     success_count += 1
                     # Update processing timestamp
                     update_text_extraction_timestamp(metadata_file)
+                elif unavailable_reason:
+                    # A content-shaped failure (dead link, no text layer,
+                    # JS-only placeholder) -- durably mark it so future runs
+                    # stop retrying every cycle, without silently hiding it:
+                    # tracked separately from real errors and re-checked
+                    # periodically in case the source document changes.
+                    unavailable_count += 1
+                    mark_bill_unavailable(metadata_file, unavailable_reason)
+                    unavailable_bills.append(
+                        {
+                            "bill_id": metadata_file.parent.name,
+                            "reason": unavailable_reason,
+                            "metadata_file": str(metadata_file),
+                        }
+                    )
                 else:
                     error_count += 1
 
@@ -553,7 +619,8 @@ def process_bills_in_batch(
                 processed_count += 1
 
         print(
-            f"✅ Batch {batch_num} complete. Success: {success_count}, Errors: {error_count}, Skipped: {skipped_count}"
+            f"✅ Batch {batch_num} complete. Success: {success_count}, Errors: {error_count}, "
+            f"Unavailable: {unavailable_count}, Skipped: {skipped_count}"
         )
 
     failed_summary = get_failed_bills_summary()
@@ -568,8 +635,10 @@ def process_bills_in_batch(
         "processed": processed_count,
         "successful": success_count,
         "errors": error_count,
+        "unavailable": unavailable_count,
         "skipped": skipped_count,
         "failed_bills": failed_bills,
+        "unavailable_bills": unavailable_bills,
     }
 
 
@@ -613,8 +682,36 @@ def should_skip_bill_for_text_extraction(metadata_file: Path) -> bool:
 
         bill_id = metadata.get("identifier", metadata_file.parent.name)
 
-        # Check if text has already been extracted
         processing_info = metadata.get("_processing", {})
+        logs_timestamp = processing_info.get("logs_latest_update")
+
+        # Bills durably marked unavailable (dead link, no text layer, JS-only
+        # placeholder) skip the normal per-run retry, but not forever: if the
+        # source document has genuinely changed since we last checked (the
+        # scraper bumped logs_latest_update), or it's been more than 15 days
+        # since we last confirmed it's unavailable, give it another try --
+        # cheap insurance against a silently-fixed document (e.g. the state
+        # replaces a bad scan) that would otherwise never get picked up again.
+        unavailable_info = processing_info.get("text_extraction_unavailable")
+        if unavailable_info:
+            checked_at = unavailable_info.get("checked_at")
+            if logs_timestamp and checked_at and logs_timestamp > checked_at:
+                print(f"   🔍 {bill_id}: Bill updated since marked unavailable - processing")
+                return False
+            if checked_at:
+                days_since_check = (
+                    datetime.utcnow() - datetime.fromisoformat(checked_at.rstrip("Z"))
+                ).days
+                if days_since_check < 15:
+                    print(
+                        f"   ⏭️  {bill_id}: Marked unavailable "
+                        f"({unavailable_info.get('reason')}, checked {days_since_check}d ago) - skipping"
+                    )
+                    return True
+                print(f"   🔍 {bill_id}: Unavailable check is {days_since_check}d old - rechecking")
+                return False
+
+        # Check if text has already been extracted
         text_extraction_timestamp = processing_info.get("text_extraction_latest_update")
 
         if not text_extraction_timestamp:
@@ -623,7 +720,6 @@ def should_skip_bill_for_text_extraction(metadata_file: Path) -> bool:
             return False
 
         # Check if the bill has been updated since last text extraction
-        logs_timestamp = processing_info.get("logs_latest_update")
         if logs_timestamp and logs_timestamp > text_extraction_timestamp:
             # Bill has been updated since last text extraction - needs processing
             print(f"   🔍 {bill_id}: Bill updated since last extraction - processing")
@@ -679,3 +775,30 @@ def update_text_extraction_timestamp(metadata_file: Path) -> None:
 
     except Exception as e:
         print(f"   ⚠️ Error updating text extraction timestamp for {metadata_file}: {e}")
+
+
+def mark_bill_unavailable(metadata_file: Path, reason: str) -> None:
+    """
+    Record that this bill's text is durably unavailable for a content-shaped
+    reason (dead link, no text layer, JS-only placeholder) -- not a bug in
+    our own pipeline. See should_skip_bill_for_text_extraction for how this
+    gets honored (skipped for 15 days, or immediately re-tried if the bill's
+    own data changes in the meantime).
+    """
+    try:
+        with open(metadata_file, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+
+        if "_processing" not in metadata:
+            metadata["_processing"] = {}
+
+        metadata["_processing"]["text_extraction_unavailable"] = {
+            "reason": reason,
+            "checked_at": datetime.utcnow().isoformat() + "Z",
+        }
+
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+
+    except Exception as e:
+        print(f"   ⚠️ Error marking bill unavailable for {metadata_file}: {e}")

--- a/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/templates/openstates-to-ocd-files/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for ✏️{ locale.key }✏️"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #


### PR DESCRIPTION
## Summary
- `main.py` exits 1 whenever `stats["errors"] > 0`; the check-and-restart job treats any nonzero exit as "needs another run." A subset of bills fail for reasons that never change on retry (dead link, genuinely scanned/image-only PDF) -- every run was re-attempting the same ~99 permanently-failing MA bills, guaranteeing another restart forever.
- Distinguishes content-shaped failures (dead link, no text layer, JS-only placeholder) from real infrastructure failures (disk/save errors) -- only the latter still count as fatal.
- New `_processing.text_extraction_unavailable` field marks a bill durably unavailable, honored by the skip-check but not forever: rechecked immediately if the bill's own data changes, or after 15 days regardless (in case the source document gets silently fixed).
- Writes `.extraction_unavailable.json` listing every unavailable bill + reason.
- Reorders/rewords the extraction summary: "Extracted now" leads since that's what matters, "Skipped" → "Already processed", "Unavailable" added.

## Test plan
- [x] Verified locally against real MA bills (`HD176`, `HD5236`, `HD4283`, `H1842`) hitting the live `malegislature.gov` site: 3 genuine failures correctly classified, exit code 0 instead of 1, follow-up run correctly skipped all 3
- [ ] Live GH Actions test on `ma-legislation` before merging (temporarily pointing its workflow at this branch)