### PR TITLE
Regenerate pipeline-manager snapshots after extract-text.yml template fix

### DIFF
--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/ak-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for ak"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/id-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for id"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/mt-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for mt"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/pr-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for pr"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-files/wy-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for wy"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/ak-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for ak"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/id-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for id"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/mt-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for mt"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/pr-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for pr"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #

--- a/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
+++ b/actions/pipeline-manager/__snapshots__/chn-openstates-test/wy-legislation/.github/workflows/extract-text.yml
@@ -59,12 +59,23 @@ jobs:
       - name: Display extraction summary
         if: always()
         shell: bash
+        # Read from the action's own outputs, not a file on disk -- a file
+        # sitting in the working tree can get silently clobbered by the
+        # Commit Changes step's own git pull/merge (confirmed live
+        # 2026-08-08 on ma-legislation: this exact file had gotten
+        # accidentally tracked in git from a past commit, so a pull
+        # overwrote the fresh numbers with a stale committed copy right
+        # before this step ran). Outputs are just $GITHUB_OUTPUT, no git
+        # involved, nothing to clobber.
         run: |
-          if [ -f ".extraction_summary.txt" ]; then
-            cat .extraction_summary.txt
-          else
-            echo "⚠️  Summary file not found"
-          fi
+          echo "📊 Text Extraction Summary for wy"
+          echo "========================================"
+          echo ""
+          echo "Extracted now:     ${{ steps.extract.outputs.extracted-now }}"
+          echo "Total bills:       ${{ steps.extract.outputs.total-bills }}"
+          echo "Already processed: ${{ steps.extract.outputs.already-processed }}"
+          echo "Unavailable:       ${{ steps.extract.outputs.unavailable }}"
+          echo "Errors:            ${{ steps.extract.outputs.errors }}"
 
   # Auto-restart job if extraction was cancelled (timeout) or failed.
   #


### PR DESCRIPTION
## Summary
- #109 changed the `extract-text.yml` caller-workflow template (Display extraction summary now reads the composite action's outputs instead of catting a file that could get silently clobbered by git).
- Snapshots under `__snapshots__/` were stale against that template change, failing `Validate Snapshots / pipeline-manager-snapshots`.
- Regenerated via `render-snapshots.sh`, no template changes in this PR -- output-only.

## Test plan
- [x] Diffed the regenerated snapshots against the previous ones: only the `Display extraction summary` step changed, identical across all 5 sample locales, matches the template change exactly