### PR TITLE
scrape: bound the download cache to one UTC day so bulk-file states can't freeze

### DIFF
--- a/actions/scrape/action.yml
+++ b/actions/scrape/action.yml
@@ -61,15 +61,38 @@ runs:
         mkdir -p "${RUNNER_TEMP}/scrape-snapshot-nightly"
         echo "Working root: ${RUNNER_TEMP}"
 
+    # A UTC day stamp so the scrape cache below can only be reused within the
+    # same calendar day (see the "Cache scrapes" step for the full rationale).
+    - name: Compute cache day stamp
+      id: cache-stamp
+      if: inputs.use-scrape-cache != 'true'
+      shell: bash
+      run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
     - name: Cache scrapes (best-effort)
       if: inputs.use-scrape-cache != 'true'
       uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/_working/_cache
-        key: cache-scrapes-${{ inputs.state }}-${{ github.sha }}
+        # This caches the scraper's HTTP download cache (openstates/scrapelib),
+        # which never revalidates -- once a URL is stored it is replayed verbatim
+        # on every later hit. States that pull a single static bulk file (the
+        # csv_bills scrapers: NJ, VA, ...) therefore get pinned to whatever that
+        # file said the first time it landed in the cache. NJ froze on a late-
+        # January 2026 snapshot for ~7 months exactly this way: every run restored
+        # the January cache through the old unbounded restore-keys
+        # (`cache-scrapes-<state>-`, then `cache-scrapes-`), replayed the stale bill
+        # file, and re-saved it forward -- so the daily scrape ran green while never
+        # seeing NJ's live data (which pub.njleg.state.nj.us rewrites daily).
+        #
+        # Scoping the key AND the restore-keys to a UTC day stamp means a run can
+        # only reuse a cache created earlier the *same* day (still a cheap win for
+        # within-day re-runs), while every new day starts cold and re-downloads the
+        # live file. Staleness is bounded to at most one day, and the scrape only
+        # runs daily anyway.
+        key: cache-scrapes-${{ inputs.state }}-${{ steps.cache-stamp.outputs.day }}-${{ github.sha }}
         restore-keys: |
-          cache-scrapes-${{ inputs.state }}-
-          cache-scrapes-
+          cache-scrapes-${{ inputs.state }}-${{ steps.cache-stamp.outputs.day }}-
 
     - name: Scrape data with Docker (resilient)
       if: inputs.use-scrape-cache != 'true'


### PR DESCRIPTION
## What

Scope the scrape action's download-cache key (and restore-keys) to a UTC day stamp, so a run can only reuse a cache created earlier the **same day**. Every new day starts cold and re-downloads the live source file. One file changed (`actions/scrape/action.yml`, +26/-3).

## Why

`actions/scrape/action.yml` restored the scraper's HTTP download cache (`_working/_cache`, the openstates/scrapelib cache) from **any** prior run via unbounded restore-keys:

```
restore-keys: |
  cache-scrapes-<state>-
  cache-scrapes-
```

scrapelib's cache never revalidates — once a URL is stored it's replayed verbatim. States that pull their **entire dataset as one static file** (the `csv_bills`/MDB scrapers: NJ, NM, NH, VA, CA) therefore get pinned to whatever that file said the first time it was cached.

**New Jersey froze on a late-January 2026 snapshot for ~7 months this way.** Every daily run restored the January cache, replayed the stale bill file, and re-saved it forward — so the scrape ran green while never seeing NJ's live data. Verified end-to-end:

- `govbot-data/nj-legislation` (formatted) newest action: **2026-01-28**; A796 had only its Jan 13 introduction.
- NJ's live source `pub.njleg.state.nj.us/leg-databases/2026data/DB2026_TEXT.zip` is **rewritten daily** (last-modified today, has an ETag), currently holds **10,712 bills** (Assembly up to A5438), and `BILLHIST.TXT` shows A796 with its full history through its **7/7/2026 approval**.
- A recent NJ scrape run logged `bills: {}` and "unknown bill A4029 in vote database" — its cached bill set predates bills NJ's live file already has.

So the data was current at the source the whole time; only the persisted cache was stale.

## The fix

Add a `date -u +%Y-%m-%d` day stamp step and use it in both the cache key and restore-keys:

```
key: cache-scrapes-<state>-<YYYY-MM-DD>-<sha>
restore-keys: |
  cache-scrapes-<state>-<YYYY-MM-DD>-
```

- Intra-day re-runs still reuse the cache (keeps the speed-up).
- Each new day starts cold and re-downloads the live file.
- Staleness is bounded to at most one day, and the scrape only runs daily anyway.
- State-agnostic — protects every bulk-file state (NM/NH/VA/CA), not just NJ.

## Rollout notes

- No manual cache clearing needed: the old poisoned caches use the old key format, so the new day-stamped restore-keys don't match them — they're orphaned automatically and the first post-merge run of each state starts cold.
- Side effect: every state re-downloads fresh at the start of each day instead of leaning on an old cache — the correct behavior for a nightly data pipeline, well within existing time limits, and it likely un-freezes other silently-stuck bulk-file states too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kLH2Hqv3mRtcxRxWxBg9Z)_