### PR TITLE
govbot: point clone default at the maintained govbot-data org

### DIFF
--- a/actions/govbot/src/git.rs
+++ b/actions/govbot/src/git.rs
@@ -17,8 +17,12 @@ use std::path::{Path, PathBuf};
 //
 // To use a custom URL template, set the environment variable:
 //   export GOVBOT_REPO_URL_TEMPLATE="https://gitlab.com/myorg/{locale}-data.git"
+// govbot-data is the maintained data org. The former org (chn-openstates-files,
+// since renamed to govbot-archive) has been archived and its format workflows
+// disabled, so it no longer receives fresh scraped data -- clone must not point
+// there. Override with GOVBOT_REPO_URL_TEMPLATE for a custom host/org.
 const DEFAULT_REPO_URL_TEMPLATE: &str =
-    "https://github.com/chn-openstates-files/{locale}-legislation.git";
+    "https://github.com/govbot-data/{locale}-legislation.git";
 
 /// Get the repository URL template from environment or use default
 fn get_repo_url_template() -> String {
@@ -69,8 +73,8 @@ fn extract_repo_org(template: &str) -> String {
             }
         }
     }
-    // Fallback: return default org
-    "chn-openstates-files".to_string()
+    // Fallback: return default org (matches DEFAULT_REPO_URL_TEMPLATE)
+    "govbot-data".to_string()
 }
 
 /// Build the repository name (used for local directory names)


### PR DESCRIPTION
## What

Repoint the `govbot clone` default template from `chn-openstates-files/{locale}-legislation` to `govbot-data/{locale}-legislation` (and update the `extract_repo_org` fallback to match). One file changed (`actions/govbot/src/git.rs`).

## Why

`govbot clone` was fetching every jurisdiction from **`chn-openstates-files`**, which has since been **renamed to `govbot-archive` and archived** — its format workflows are **disabled manually**, so those repos no longer receive fresh scraped data. Concretely, `chn-openstates-files/nj-legislation` is frozen at **2026-01-28** with its last commit on **2026-07-20**.

The maintained pipeline writes to **`govbot-data/{locale}-legislation`** instead. After the scraper cache fix (#112), `govbot-data/nj-legislation` un-froze to **2026-08-06** on the next run (A796 now carries its full history through its July 7 approval), while the archived org stayed frozen. So the CLI's default was pointing users at dead data.

This was the last disconnected hop: scraper → format(`govbot-data`) is healthy, but `govbot clone` read the old org. Repointing connects end users to the live pipeline.

## Safety

- **Coverage verified:** all **51** jurisdictions the CLI knows about have a repo under `govbot-data` (checked via `git ls-remote`); the only name without one is the `all` keyword, which isn't a repo.
- `GOVBOT_REPO_URL_TEMPLATE` still overrides for custom hosts/orgs.
- Existing local clones are unaffected until re-cloned.
- `cargo build` + full `cargo test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kLH2Hqv3mRtcxRxWxBg9Z)_