### PR TITLE
scrape: add backfill-prior-sessions.sh to restore archived sessions into govbot-data

### DIFF
--- a/actions/scrape/backfill-prior-sessions.sh
+++ b/actions/scrape/backfill-prior-sessions.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# backfill-prior-sessions.sh
+#
+# One-time (idempotent) backfill of INACTIVE / prior legislative sessions from
+# the archived data org into the maintained one.
+#
+#   FROM:  govbot-archive/<state>-legislation   (renamed from chn-openstates-files;
+#                                                 frozen, format workflows disabled,
+#                                                 but still holds older sessions)
+#   TO:    govbot-data/<state>-legislation      (the org `govbot clone` now reads;
+#                                                 kept fresh by the daily pipeline,
+#                                                 but only holds each state's ACTIVE
+#                                                 session)
+#
+# Why: the scraper only produces the session OpenStates marks `active`, so when a
+# state's repo was recreated under govbot-data it started with the current session
+# only. Older sessions live on solely in the archive. This script copies just the
+# session folders the archive has and govbot-data lacks -- so it NEVER touches the
+# active session (which govbot-data keeps fresh) and can be re-run safely.
+#
+# Usage:
+#   ./backfill-prior-sessions.sh nj              # one state
+#   ./backfill-prior-sessions.sh nj co ar        # several
+#   ./backfill-prior-sessions.sh all             # every jurisdiction govbot ships
+#   DRY_RUN=1 ./backfill-prior-sessions.sh all   # show what WOULD be copied, no push
+#
+# Requirements:
+#   * git + rsync
+#   * `gh auth login` (or a git credential) with PUSH access to the govbot-data
+#     repos. Run this from a machine/login that has that access -- the sandboxed
+#     cloud sessions do not.
+#
+# Caveat on extracted text: repos may store PDF/XML-extracted text via Git LFS.
+# This script clones with GIT_LFS_SKIP_SMUDGE=1 (the bill metadata + action logs,
+# which are plain JSON, copy fine), so any LFS-backed extracted-text files are
+# copied as pointer stubs, not real content. The core legislative data -- bills,
+# sponsors, actions, votes -- is complete; re-run the extract action against the
+# backfilled sessions later if you need their full text.
+
+set -uo pipefail
+
+ARCHIVE_ORG="govbot-archive"
+DATA_ORG="govbot-data"
+DRY_RUN="${DRY_RUN:-0}"
+
+# Every jurisdiction code govbot ships (mirror of WorkingLocale; excludes the
+# "all" keyword, which is not a repo). Update if the locale enum changes.
+ALL_STATES="ak al ar ca co de fl ga gu hi ia id il in ks ky la ma md me mi mn mo \
+mp ms mt nc nd ne nh nj nm nv ny oh ok or pa pr ri sc sd tn usa ut vi vt wa wi wv wy"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <state...|all>   (DRY_RUN=1 to preview)" >&2
+  exit 1
+fi
+if [ "$1" = "all" ]; then STATES="$ALL_STATES"; else STATES="$*"; fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# List the session folder names in a repo's HEAD (one per line), or nothing.
+list_sessions() { # <org> <state> <dir>
+  local org="$1" st="$2" dir="$3"
+  if ! git clone --filter=tree:0 --no-checkout --quiet \
+        "https://github.com/$org/$st-legislation.git" "$dir" 2>/dev/null; then
+    return 1
+  fi
+  git -C "$dir" ls-tree -d --name-only "HEAD:country:us/state:$st/sessions" 2>/dev/null | sort
+}
+
+overall=0
+for st in $STATES; do
+  echo "==== $st ===="
+  sp="country:us/state:$st/sessions"
+
+  data_sessions="$(list_sessions "$DATA_ORG" "$st" "$WORK/d_$st")" \
+    || { echo "  skip: no $DATA_ORG/$st-legislation repo"; continue; }
+  arch_sessions="$(list_sessions "$ARCHIVE_ORG" "$st" "$WORK/a_$st")" \
+    || { echo "  skip: no $ARCHIVE_ORG/$st-legislation repo"; continue; }
+
+  # Sessions to backfill = present in the archive, absent from govbot-data.
+  # comm needs sorted input (list_sessions already sorts). Newline-delimited so
+  # session names containing spaces (e.g. CA "... Special Session 1") survive.
+  missing="$(comm -23 <(printf '%s\n' "$arch_sessions") <(printf '%s\n' "$data_sessions"))"
+  missing="$(printf '%s\n' "$missing" | sed '/^$/d')"
+
+  if [ -z "$missing" ]; then
+    echo "  ✓ nothing to backfill (govbot-data already has: $(printf '%s ' $data_sessions))"
+    continue
+  fi
+  echo "  will backfill:"; printf '      - %s\n' "$missing"
+  if [ "$DRY_RUN" = "1" ]; then continue; fi
+
+  # Full checkout of govbot-data (need a working tree to add + push).
+  full="$WORK/full_$st"
+  GIT_LFS_SKIP_SMUDGE=1 git clone --quiet \
+      "https://github.com/$DATA_ORG/$st-legislation.git" "$full" \
+    || { echo "  ✗ clone $DATA_ORG/$st failed"; overall=1; continue; }
+  git -C "$full" config http.postBuffer 524288000   # some sessions are 10k+ files
+
+  # Sparse-clone ONLY the missing session folders from the archive.
+  arch="$WORK/arch_$st"
+  GIT_LFS_SKIP_SMUDGE=1 git clone --quiet --filter=blob:none --sparse \
+      "https://github.com/$ARCHIVE_ORG/$st-legislation.git" "$arch" \
+    || { echo "  ✗ clone $ARCHIVE_ORG/$st failed"; overall=1; continue; }
+
+  # Build the sparse path list (array to preserve spaces in session names).
+  declare -a paths=()
+  while IFS= read -r s; do [ -n "$s" ] && paths+=("$sp/$s"); done <<< "$missing"
+  git -C "$arch" sparse-checkout set "${paths[@]}" 2>/dev/null
+
+  # Copy each missing session folder across.
+  copied=0
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    src="$arch/$sp/$s"; dst="$full/$sp/$s"
+    if [ ! -d "$src" ]; then echo "  ! session '$s' not materialized (LFS-only?), skipping"; continue; fi
+    mkdir -p "$dst"; rsync -a "$src/" "$dst/"; copied=$((copied+1))
+  done <<< "$missing"
+  [ "$copied" -gt 0 ] || { echo "  ! nothing copied"; continue; }
+
+  # Commit + push to govbot-data.
+  git -C "$full" add "$sp"
+  if git -C "$full" diff --staged --quiet; then
+    echo "  ✓ already up to date after copy (no diff)"; continue
+  fi
+  msg="Backfill $copied prior session(s) from $ARCHIVE_ORG: $(printf '%s ' $missing)"
+  git -C "$full" -c user.email="action@github.com" -c user.name="govbot backfill" \
+      commit -q -m "$msg"
+  if git -C "$full" push origin HEAD 2>&1 | tail -2; then
+    echo "  ✅ pushed backfill for $st"
+  else
+    echo "  ❌ push failed for $st (need write access to $DATA_ORG/$st-legislation)"; overall=1
+  fi
+done
+
+echo "backfill run complete."
+exit "$overall"


### PR DESCRIPTION
## What

Adds `actions/scrape/backfill-prior-sessions.sh` — a one-time, idempotent operational script that copies inactive/prior legislative sessions from the archived data org into the maintained one:

- **from** `govbot-archive/<state>-legislation` (formerly `chn-openstates-files`; frozen, format workflows disabled, but still holds older sessions)
- **to** `govbot-data/<state>-legislation` (what `govbot clone` reads after #113; kept fresh daily, but holds only each state's active session)

## Why

After #113 pointed `govbot clone` at `govbot-data`, a sweep of all 51 jurisdictions found **22 missing exactly one prior session** there (`govbot-data` has only the OpenStates-`active` session; the scraper doesn't reproduce inactive ones). The prior-session data still exists in the archive and is static, so a one-time copy makes `govbot-data` a proper superset (fresh current + full history), with the daily pipeline continuing to keep the active session fresh.

Missing prior session by state: `ar 2025`, `co 2025B`, `fl 2026D`, `ga 2025_26`, `hi 2025`, `id 2025`, `ky 2025RS`, `la 2025s1`, `md 2025`, `mn 2025s1`, `mo 2025S2`, `ms 20251E`, `nh 2025`, `nj 221` (full 2024–2025 biennium, ~11,795 bills), `nm 2025S2`, `ok 2025`, `or 2025S1`, `ri 2025`, `sd 2025s`, `ut 2025S1`, `wv 2025`, `wy 2025`. (The other 29 states already have full coverage; 0 states lack a `govbot-data` repo.)

## How it works

For each state it lists the session folders in both orgs, computes `archive − govbot-data` (so it **only** copies what's missing and **never touches the active session**), sparse-checks-out just those folders from the archive, copies them into a `govbot-data` checkout, and commits + pushes. Handles session names with spaces (e.g. CA's), sets `http.postBuffer` for large pushes (NJ's 221 is ~12k files), and is safe to re-run.

```bash
DRY_RUN=1 ./actions/scrape/backfill-prior-sessions.sh all   # preview, no writes
./actions/scrape/backfill-prior-sessions.sh nj              # one state
./actions/scrape/backfill-prior-sessions.sh all             # all 22
```

## Notes / caveats

- Requires a login with **push access to `govbot-data`** (sandbox/CI runners without it can't push — it's an operator tool, sibling to `tx-backfill-runbook.md`).
- Bill metadata + action logs (plain JSON) copy fully; any **LFS-backed extracted text** copies as pointer stubs — re-run the extract action on the backfilled sessions if full text is needed.
- Dry-run verified: correctly identifies `nj` session `221` as the sole backfill target and copies nothing.
- Adds a standalone script only; no changes to existing code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kLH2Hqv3mRtcxRxWxBg9Z)_