### PR TITLE
feat(fleet-monitor): orchestrator, hourly workflow + heartbeat (3/6)

### DIFF
--- a/.github/workflows/fleet-monitor.yml
+++ b/.github/workflows/fleet-monitor.yml
@@ -1,0 +1,62 @@
+# Hourly fleet sweep: poll every fleet repo's GitHub state and push metrics plus
+# a collector heartbeat to Grafana Cloud. Read-only on GitHub (the default token
+# covers all reads); the single secret is the Grafana Cloud write key. The push
+# endpoint and instance ID are non-secret per-fork config, supplied as repo
+# variables — see actions/fleet-monitor/README.md "Running the hourly workflow".
+name: Fleet Monitor
+
+on:
+  schedule:
+    - cron: "0 * * * *" # Hourly, on the hour (UTC)
+  workflow_dispatch: # Manual sweep (fork bring-up and one-off checks)
+
+# Read-only: the collector only reads GitHub and pushes to Grafana; it never
+# writes to the repo.
+permissions:
+  contents: read
+
+# One sweep at a time. A hung run is bounded by timeout-minutes well inside the
+# hour, and this group keeps a manual dispatch from overlapping a scheduled run;
+# cancel-in-progress is false so a running sweep is never killed mid-push.
+concurrency:
+  group: fleet-monitor
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: "📡 Sweep fleet, push metrics + heartbeat"
+    runs-on: ubuntu-latest
+    # A healthy sweep is a couple of minutes (~336 requests, 8 concurrent); this
+    # ceiling kills a hung run long before the next hour's schedule fires.
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout govbot
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        working-directory: actions/fleet-monitor
+        run: |
+          pip install pipenv
+          pipenv install --deploy
+
+      - name: Sweep the fleet and push metrics
+        working-directory: actions/fleet-monitor
+        env:
+          # GitHub's auto-provided default token (not a maintainer-set secret):
+          # public reads only, ~336 requests/sweep (limit 1000/hr). It is the only
+          # way to populate the GITHUB_TOKEN env the poller needs; the one secret a
+          # fork maintainer sets is GRAFANA_PUSH_KEY below.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Endpoint + instance ID are non-secret per-fork config (repo variables).
+          GRAFANA_PUSH_URL: ${{ vars.GRAFANA_PUSH_URL }}
+          GRAFANA_PUSH_USER: ${{ vars.GRAFANA_PUSH_USER }}
+          # The one secret: the Grafana Cloud metrics:write access-policy token.
+          GRAFANA_PUSH_KEY: ${{ secrets.GRAFANA_PUSH_KEY }}
+        run: |
+          pipenv run python main.py run --config-dir ../pipeline-manager

--- a/actions/fleet-monitor/README.md
+++ b/actions/fleet-monitor/README.md
@@ -53,7 +53,8 @@ steps, each its own module:
   Influx line-protocol payload Grafana Cloud ingests. Series produced:
   `fleet_workflow_run_status` (1 = latest run succeeded),
   `fleet_workflow_run_hours_since_success`, and `fleet_repo_data_commit_age_hours`.
-  Labels are capped at `state`/`org`/`workflow`/`paused`.
+  Labels are capped at `state`/`org`/`workflow`/`paused`. (The orchestrator adds one more,
+  untagged, series each sweep — `fleet_collector_heartbeat` — via `encode_heartbeat`; see below.)
 - **[metrics_push.py](metrics_push.py)** + **[http_util.py](http_util.py)** — POST with
   retry/backoff (429 honors Retry-After — as does a 403 that is really GitHub rate
   limiting — 5xx backs off, other 4xx fails fast; an exhausted quota with no
@@ -67,8 +68,9 @@ steps, each its own module:
   runs, latest success) + 1 per repo for the data-path commit. Current fleet: 112 repos × 1 workflow → **336
   requests per sweep**, well inside the default `GITHUB_TOKEN` limit of 1000/hour;
   `render-snapshots.sh` asserts the real-fleet count stays under 400.
-- **Series cardinality**: 2 series per repo/workflow + 1 per repo → **~336 series** for
-  the current fleet, against the Grafana Cloud free-tier budget of ~10k active series
+- **Series cardinality**: 2 series per repo/workflow + 1 per repo, plus the single global
+  `fleet_collector_heartbeat` pair the orchestrator emits per sweep → **~336 series (+2 heartbeat)**
+  for the current fleet, against the Grafana Cloud free-tier budget of ~10k active series
   (50 GB logs/mo, 14-day retention — re-verify at signup). 10× fleet growth still fits.
 
 ### Credentials (environment variables)
@@ -100,18 +102,56 @@ pipenv run python main.py collect --metrics-only --config-dir ../pipeline-manage
 # End-to-end proof: poll, push, then query the series back (needs all six
 # GRAFANA_* vars; exits 0 with a notice when they're absent):
 pipenv run python main.py live-check --config-dir ../pipeline-manager
+
+# The unattended sweep the hourly workflow runs: poll, push metrics + a
+# collector heartbeat. Exits nonzero only on an outright collector failure
+# (config/poll error, or a failed push) — per-repo poll errors stay green:
+pipenv run python main.py run --config-dir ../pipeline-manager
 ```
+
+`run` is the orchestrator: it wires config reader → poller → shipper and appends
+a `fleet_collector_heartbeat` series (`repos`, `errors`) that ships on **every**
+sweep. Its exit contract differs from `collect`'s by design — a red workflow run
+must mean the *collector* is down, so per-repo poll errors are logged but keep
+the run green (a degraded fleet surfaces through the metrics and Grafana alerts),
+and only a config/poll error or a failed push exits nonzero. Because the
+heartbeat always ships, an all-null sweep still proves the collector ran.
 
 `--config-dir` points at any directory holding fleet config YAMLs and their `templates/`
 folder, so the CLI runs against fixtures or the real config. Options can also be set via
 `FLEET_MONITOR_*` environment variables (click's `auto_envvar_prefix`, matching sibling
 actions), e.g. `FLEET_MONITOR_LIST_FLEET_CONFIG_DIR`.
 
+### Running the hourly workflow
+
+[`.github/workflows/fleet-monitor.yml`](../../.github/workflows/fleet-monitor.yml) runs the
+orchestrator (`run`) once an hour against the real `actions/pipeline-manager` config and pushes
+metrics + the collector heartbeat to Grafana Cloud. It's read-only on GitHub (the default
+`GITHUB_TOKEN` covers all reads), bounded by a 20-minute job timeout, and serialized by a
+`fleet-monitor` concurrency group so a manual dispatch never overlaps a scheduled sweep.
+
+To bring it up in a fork against your own Grafana Cloud account, set **one secret** and **two
+variables** on the repo (Settings → Secrets and variables → Actions):
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| **Secret** | `GRAFANA_PUSH_KEY` | Grafana Cloud access-policy token with `metrics:write` |
+| Variable | `GRAFANA_PUSH_URL` | Influx write endpoint, `https://influx-…/api/v1/push/influx/write` |
+| Variable | `GRAFANA_PUSH_USER` | Metrics instance ID |
+
+The endpoint and instance ID aren't secret, so they're repo **variables** (`vars`), keeping the
+Grafana write key the single secret. Then enable Actions on the fork (the Actions tab, if a fresh
+fork has workflows disabled) and trigger a first sweep by hand — **Actions → Fleet Monitor → Run
+workflow** (`workflow_dispatch`) — to confirm it goes green and the metrics land before the hourly
+schedule takes over. A forced failure (e.g. a bad `GRAFANA_PUSH_KEY`) exits nonzero and the run
+shows red, which is what the `heartbeat absent` alert keys off.
+
 ### As a GitHub Action
 
 See [action.yml](action.yml). Optional `config-dir` input, default `actions/pipeline-manager`.
-The Action currently exposes `list-fleet` only; wiring `collect` into an hourly workflow
-(with the `GRAFANA_*` secrets) is task 0003's orchestrator work.
+The composite Action exposes `list-fleet` for consumers embedding fleet discovery in their own
+workflows; the hourly monitor above invokes the `run` orchestrator directly rather than through
+the Action.
 
 ## Testing
 
@@ -134,7 +174,15 @@ completed conclusion, flaked `status=success` pages fall back to the unfiltered
 listing, workflow names are percent-encoded, an empty repo's 409 is null not error),
 asserts `collect`'s exit contract from all sides (1 on any poll error, 0 on a clean
 sweep with an identical payload, loud failure on an empty payload in push and
-dry-run modes alike, `--timestamp` override), locks `live-check`'s expected-series
+dry-run modes alike, `--timestamp` override), asserts the `run` orchestrator's
+distinct contract (a heartbeat-encoder unit check and a shipper-resilience unit
+check — an un-encodable record is skipped while the rest of the sweep still ships —
+plus: a partial-fail sweep exits 0 shipping metrics + heartbeat, a clean sweep
+carries a zero-error heartbeat, an all-errored sweep still exits 0 with the
+heartbeat alone, a sweep with one un-encodable repo still exits 0 and ships the
+good repos' metrics + heartbeat, and an outright push failure — missing credentials
+or a rejected key/HTTP 401 — exits nonzero so the workflow shows red), locks
+`live-check`'s expected-series
 accounting (its query-back proof requires every series this payload shipped, per
 metric, and skips metrics the payload legitimately omits), locks the HTTP retry
 policy (4xx fail-fast, rate-limited 403 retries like

--- a/actions/fleet-monitor/__snapshots__/run-payload.txt
+++ b/actions/fleet-monitor/__snapshots__/run-payload.txt
@@ -1,0 +1,7 @@
+fleet_workflow_run,state=wy,org=govbot-openstates-scrapers,workflow=openstates-scrape.yml,paused=false status=1,hours_since_success=5.25 1784635200000000000
+fleet_repo,state=wy,org=govbot-openstates-scrapers,paused=false data_commit_age_hours=6.5 1784635200000000000
+fleet_workflow_run,state=tx,org=govbot-openstates-scrapers,workflow=openstates-scrape.yml,paused=true status=0,hours_since_success=81 1784635200000000000
+fleet_repo,state=tx,org=govbot-openstates-scrapers,paused=true data_commit_age_hours=100.75 1784635200000000000
+fleet_workflow_run,state=gu,org=govbot-data,workflow=nightly\ build.yml,paused=false status=1,hours_since_success=1.5 1784635200000000000
+fleet_repo,state=gu,org=govbot-data,paused=false data_commit_age_hours=2 1784635200000000000
+fleet_collector_heartbeat repos=5,errors=1 1784635200000000000

--- a/actions/fleet-monitor/main.py
+++ b/actions/fleet-monitor/main.py
@@ -8,7 +8,7 @@ import yaml
 sys.path.append(str(Path(__file__).parent))
 
 from fleet_config import read_fleet
-from metrics_shipper import encode_metrics
+from metrics_shipper import encode_heartbeat, encode_metrics
 
 
 @click.group()
@@ -46,16 +46,7 @@ def collect(config_dir, metrics_only, dry_run, poller_records, timestamp):
     Exits 1 when any repo had poll errors — partial data still ships (or
     prints), but a degraded sweep must never look like a clean one.
     """
-    if poller_records is not None:
-        records = [
-            json.loads(line)
-            for line in poller_records.read_text().splitlines()
-            if line.strip()
-        ]
-    elif config_dir is not None:
-        records = _poll_live(config_dir)
-    else:
-        raise click.ClickException("pass --config-dir (live poll) or --poller-records (fixture)")
+    records = _load_records(config_dir, poller_records)
 
     errored = _report_poll_errors(records)
     payload = _encode(records, timestamp if timestamp is not None else _default_timestamp(records))
@@ -74,6 +65,68 @@ def collect(config_dir, metrics_only, dry_run, poller_records, timestamp):
         _push(payload)
     if errored:
         raise click.ClickException(f"poll errors on {len(errored)} of {len(records)} repos")
+
+
+@cli.command("run")
+@click.option(
+    "--config-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help="Pipeline-manager config directory to poll (required unless --poller-records).",
+)
+@click.option("--dry-run", is_flag=True, help="Print the encoded payload instead of pushing.")
+@click.option(
+    "--poller-records",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="JSONL file of pre-built poller records; skips the GitHub poll (used by snapshots).",
+)
+@click.option(
+    "--timestamp",
+    type=int,
+    default=None,
+    help="Epoch-seconds timestamp for every series (default: the records' polled_at, else now).",
+)
+def run(config_dir, dry_run, poller_records, timestamp):
+    """Unattended hourly sweep: poll the fleet, ship metrics + a heartbeat.
+
+    The orchestrator the hourly workflow invokes. Wires config reader → poller →
+    metrics shipper, then appends a collector heartbeat that ships on every run.
+
+    Exit contract differs from ``collect`` on purpose: only an *outright*
+    collector failure exits nonzero — a config or poll error, or a failed push
+    (e.g. a bad Grafana key) — so a red workflow run always means the collector
+    itself is down. Per-repo poll errors are logged to stderr but keep the run
+    green: a degraded fleet surfaces through the shipped metrics and Grafana
+    alerts, not by turning the collector's own workflow red. The heartbeat
+    always ships, so an all-null sweep still proves the collector ran.
+    """
+    records = _load_records(config_dir, poller_records)
+
+    errored = _report_poll_errors(records)
+    series_timestamp = timestamp if timestamp is not None else _default_timestamp(records)
+    # encode_metrics is resilient per record — one repo's un-encodable data is
+    # skipped, never blanks the rest of the sweep — so a red run always means the
+    # collector itself is down, never a single degraded repo.
+    payload = encode_metrics(records, series_timestamp)
+    payload += encode_heartbeat(len(records), len(errored), series_timestamp)
+
+    if dry_run:
+        click.echo(payload, nl=False)
+    else:
+        _push(payload)
+
+
+def _load_records(config_dir, poller_records):
+    """Records for a sweep: a pre-built --poller-records fixture (offline) or a
+    live poll of --config-dir. Shared by ``collect`` and ``run``."""
+    if poller_records is not None:
+        return [
+            json.loads(line)
+            for line in poller_records.read_text().splitlines()
+            if line.strip()
+        ]
+    if config_dir is not None:
+        return _poll_live(config_dir)
+    raise click.ClickException("pass --config-dir (live poll) or --poller-records (fixture)")
 
 
 def _expected_series(payload):
@@ -97,8 +150,10 @@ def _expected_series(payload):
 
 
 def _encode(records, timestamp):
-    """encode_metrics with its ValueError (e.g. control chars in a tag value)
-    surfaced as a clean CLI error instead of a traceback."""
+    """encode_metrics with any residual ValueError surfaced as a clean CLI error
+    instead of a traceback. (Per-record encode failures — a control char in a
+    tag, a missing key — are skipped inside encode_metrics, not raised; this
+    guard only catches a malformed timestamp.)"""
     try:
         return encode_metrics(records, timestamp)
     except ValueError as e:

--- a/actions/fleet-monitor/metrics_shipper.py
+++ b/actions/fleet-monitor/metrics_shipper.py
@@ -12,12 +12,19 @@ named ``<measurement>_<field>`` with the tags as labels:
     fleet_repo_data_commit_age_hours{state, org, paused}
         Hours since the last commit touching the repo's data path.
 
+The orchestrator (``run``) also emits, via ``encode_heartbeat`` below, one
+untagged global heartbeat series each sweep — ``fleet_collector_heartbeat_repos``
+and ``fleet_collector_heartbeat_errors`` (no state/org labels; it is about the
+collector, not the fleet).
+
 Labels are capped at state/org/workflow/paused by design; the README's Budgets
 section is the single source of the series-count arithmetic (~336 for the
 current fleet against the 10k free-tier limit). Repo name is derivable from
 state+org, so it is not a label. A missing value (workflow never succeeded or
-never completed a run, or a poll error recorded on the record) emits no line:
-absence, not a sentinel value, marks the gap.
+never completed a run, or a poll error recorded on the record) emits no line, and
+a record that cannot be encoded at all (a control character in a tag, a missing
+key) is skipped rather than aborting the sweep: absence, not a sentinel value,
+marks the gap.
 """
 
 
@@ -48,30 +55,70 @@ def _tags(pairs) -> str:
     return ",".join(f"{key}={_escape_tag(value)}" for key, value in pairs)
 
 
+def encode_heartbeat(repos: int, errors: int, timestamp_seconds: int) -> str:
+    """One line proving the collector itself ran this cycle.
+
+    A single global series (no state/org/workflow tags — the heartbeat is about
+    the collector, not the fleet) carrying the sweep size, so an absent
+    heartbeat means the collector is down, distinct from any individual repo or
+    workflow being down. Emitted on every run, even an all-errored or empty
+    sweep, so the orchestrator always has something to push and an all-null
+    fleet is provably the collector working on a broken fleet, not the collector
+    failing to run.
+    """
+    timestamp_ns = int(timestamp_seconds) * 1_000_000_000
+    fields = f"repos={_format_value(repos)},errors={_format_value(errors)}"
+    return f"fleet_collector_heartbeat {fields} {timestamp_ns}\n"
+
+
+def _record_lines(record, timestamp_ns: int) -> list:
+    """The line-protocol lines for one poller record. Raises (ValueError from a
+    bad tag/field, KeyError from a missing key) if the record can't be encoded;
+    the caller isolates that per record, so a bad line is never half-built into
+    the payload."""
+    base = [("state", record["state"]), ("org", record["org"])]
+    paused = ("paused", "true" if record["paused"] else "false")
+    lines = []
+    for wf in record.get("workflows", []):
+        tags = _tags(base + [("workflow", wf["workflow"]), paused])
+        fields = []
+        if wf.get("latest_conclusion") is not None:
+            status = 1 if wf["latest_conclusion"] == "success" else 0
+            fields.append(f"status={_format_value(status)}")
+        if wf.get("hours_since_success") is not None:
+            fields.append(f"hours_since_success={_format_value(wf['hours_since_success'])}")
+        if fields:
+            lines.append(f"fleet_workflow_run,{tags} {','.join(fields)} {timestamp_ns}")
+    if record.get("data_commit_age_hours") is not None:
+        tags = _tags(base + [paused])
+        age = _format_value(record["data_commit_age_hours"])
+        lines.append(f"fleet_repo,{tags} data_commit_age_hours={age} {timestamp_ns}")
+    return lines
+
+
 def encode_metrics(poller_records, timestamp_seconds: int) -> str:
     """Return the Influx line-protocol payload for a list of poller records.
 
     Pure function of its inputs: the same records and timestamp always produce
     a byte-identical payload (snapshot-tested). ``timestamp_seconds`` is epoch
     seconds, encoded as nanoseconds — the endpoint's default precision.
+
+    Resilient per record, the way the poller is resilient per repo: a record
+    that can't be encoded (a control character in a tag value, a non-numeric
+    field, a missing key) is skipped, never a half-built line, and never blanks
+    the rest of the sweep. Absence marks the gap — the same as a repo with no
+    value to report — so one degraded record can't turn an otherwise-good sweep
+    into an empty payload.
     """
     timestamp_ns = int(timestamp_seconds) * 1_000_000_000
     lines = []
     for record in poller_records:
-        base = [("state", record["state"]), ("org", record["org"])]
-        paused = ("paused", "true" if record["paused"] else "false")
-        for wf in record.get("workflows", []):
-            tags = _tags(base + [("workflow", wf["workflow"]), paused])
-            fields = []
-            if wf.get("latest_conclusion") is not None:
-                status = 1 if wf["latest_conclusion"] == "success" else 0
-                fields.append(f"status={_format_value(status)}")
-            if wf.get("hours_since_success") is not None:
-                fields.append(f"hours_since_success={_format_value(wf['hours_since_success'])}")
-            if fields:
-                lines.append(f"fleet_workflow_run,{tags} {','.join(fields)} {timestamp_ns}")
-        if record.get("data_commit_age_hours") is not None:
-            tags = _tags(base + [paused])
-            age = _format_value(record["data_commit_age_hours"])
-            lines.append(f"fleet_repo,{tags} data_commit_age_hours={age} {timestamp_ns}")
+        try:
+            lines.extend(_record_lines(record, timestamp_ns))
+        except (ValueError, KeyError, TypeError):
+            # ValueError: bad tag (control char) or non-numeric string field.
+            # KeyError: a missing required key. TypeError: a structured (list/
+            # dict) field value reaching float(). Any shape of one repo's bad
+            # data is skipped, never aborts the sweep.
+            continue
     return "\n".join(lines) + "\n" if lines else ""

--- a/actions/fleet-monitor/render-snapshots.sh
+++ b/actions/fleet-monitor/render-snapshots.sh
@@ -372,6 +372,198 @@ for mode in "" "--dry-run"; do
 done
 echo "✓ collect: empty payload fails loudly in push and dry-run modes"
 
+# Orchestrator `run` — the unattended hourly sweep. Its exit contract diverges
+# from collect's on purpose: a red workflow run must mean the *collector* is
+# down, so only an outright collector failure (config/poll error, or a failed
+# push) exits nonzero. Per-repo poll errors are logged but keep the run green —
+# a degraded fleet surfaces through metrics and Grafana alerts, not a red
+# collector workflow. A collector heartbeat ships on every run, so an all-null
+# sweep still proves the collector ran.
+
+# Heartbeat encoder: one untagged global line, always emitted.
+pipenv run python3 - <<'EOF'
+from metrics_shipper import encode_heartbeat
+
+assert encode_heartbeat(5, 1, 1784635200) == \
+    "fleet_collector_heartbeat repos=5,errors=1 1784635200000000000\n"
+# Always non-empty, even for a zero-repo sweep — the one line that always ships.
+assert encode_heartbeat(0, 0, 1) == "fleet_collector_heartbeat repos=0,errors=0 1000000000\n"
+print("✓ heartbeat: one untagged global line carrying the sweep size, always emitted")
+EOF
+
+# Partial-fail sweep (the fixture's 1-of-5 errored record): run exits 0 and its
+# dry-run payload is the metric lines PLUS a heartbeat carrying the sweep size.
+if ! pipenv run python3 main.py run --dry-run \
+    --poller-records fixtures/poller-records.jsonl \
+    > "$output_dir/run-payload.txt" 2> "$stderr_tmp"; then
+  echo "✗ run with a partial-fail fixture must stay green (exit 0)"
+  cat "$stderr_tmp"
+  exit 1
+fi
+if ! grep -q '^poll error: ' "$stderr_tmp"; then
+  echo "✗ run should still log per-repo poll errors to stderr; got:"
+  cat "$stderr_tmp"
+  exit 1
+fi
+if ! grep -q '^fleet_collector_heartbeat repos=5,errors=1 ' "$output_dir/run-payload.txt"; then
+  echo "✗ run payload must carry a heartbeat with the sweep size"
+  cat "$output_dir/run-payload.txt"
+  exit 1
+fi
+# The metric lines are exactly collect's (heartbeat aside): run adds the
+# heartbeat without altering the encoded series.
+if ! diff -q <(grep -v '^fleet_collector_heartbeat ' "$output_dir/run-payload.txt") \
+    "$output_dir/metrics-payload.txt" > /dev/null; then
+  echo "✗ run's metric lines should match the collect snapshot payload"
+  diff <(grep -v '^fleet_collector_heartbeat ' "$output_dir/run-payload.txt") \
+    "$output_dir/metrics-payload.txt" || true
+  exit 1
+fi
+echo "✓ run: partial-fail sweep exits 0, logs errors, ships metrics + heartbeat"
+
+# Clean sweep (errors-free records): exits 0, heartbeat reports zero errors.
+if ! pipenv run python3 main.py run --dry-run --poller-records "$clean_records" 2> /dev/null \
+    | grep -q '^fleet_collector_heartbeat repos=4,errors=0 '; then
+  echo "✗ run on a clean sweep should exit 0 with a zero-error heartbeat"
+  exit 1
+fi
+echo "✓ run: clean sweep exits 0 with a zero-error heartbeat"
+
+# All-errored sweep: no metric lines, yet run still exits 0 and ships the
+# heartbeat alone — an all-null fleet is the collector doing its job on a broken
+# fleet, not the collector failing (collect, by contrast, fails loudly here).
+run_all_errored=$(pipenv run python3 main.py run --dry-run --poller-records "$empty_records" 2> /dev/null)
+if [ -n "$(echo "$run_all_errored" | grep -v '^fleet_collector_heartbeat ' || true)" ]; then
+  echo "✗ an all-errored sweep should emit only the heartbeat line; got:"
+  echo "$run_all_errored"
+  exit 1
+fi
+if ! echo "$run_all_errored" | grep -q '^fleet_collector_heartbeat '; then
+  echo "✗ an all-errored sweep must still ship the heartbeat"
+  exit 1
+fi
+echo "✓ run: all-errored sweep still exits 0 and ships the heartbeat alone"
+
+# Outright failure: absent Grafana push credentials in real push mode exits
+# nonzero, so the workflow shows red — the acceptance case (a bad key = red).
+if env -u GRAFANA_PUSH_URL -u GRAFANA_PUSH_USER -u GRAFANA_PUSH_KEY \
+    pipenv run python3 main.py run --poller-records "$clean_records" \
+    > /dev/null 2> "$stderr_tmp"; then
+  echo "✗ run must exit nonzero when the Grafana push fails (missing credentials)"
+  exit 1
+fi
+if ! grep -q 'GRAFANA_PUSH' "$stderr_tmp"; then
+  echo "✗ an outright push failure should name the missing Grafana credentials; got:"
+  cat "$stderr_tmp"
+  exit 1
+fi
+echo "✓ run: outright push failure exits nonzero (workflow shows red)"
+
+# The shipper is resilient per record, the way the poller is per repo: a record
+# it can't encode (a control char in a tag, a missing key) is skipped — never a
+# half-built line — and never blanks the rest of the sweep.
+pipenv run python3 - <<'EOF'
+from metrics_shipper import encode_metrics
+
+good = {"state": "wy", "org": "o", "paused": False,
+        "workflows": [{"workflow": "s.yml", "latest_conclusion": "success",
+                       "hours_since_success": 1.0}],
+        "data_commit_age_hours": 2.0}
+bad = dict(good, state="w\ny")  # control char in a tag value -> ValueError
+missing = {"org": "o", "paused": False, "workflows": [],
+           "data_commit_age_hours": 1.0}  # no 'state' -> KeyError
+structured = dict(good, org="z", data_commit_age_hours=[1, 2])  # list field -> TypeError
+payload = encode_metrics([good, bad, missing, structured], 1784635200)
+assert payload.count("state=wy") == 2, payload  # the good record's two lines survive
+assert "w\ny" not in payload and "w\\ny" not in payload, "bad record must be skipped, not half-built"
+assert "org=z" not in payload, "a structured (TypeError) field value must be skipped too"
+print("✓ shipper: an un-encodable record (ValueError/KeyError/TypeError) is skipped; the rest ships")
+EOF
+
+# Through run: a good repo alongside a bad one — run exits 0, ships the good
+# repo's metrics + the heartbeat, and the un-encodable repo simply contributes
+# no line. One repo's bad data can neither blank the sweep nor turn it red.
+bad_encode=$(mktemp)
+trap 'rm -f "$stderr_tmp" "$clean_records" "$clean_out" "$empty_records" "$bad_encode"' EXIT
+pipenv run python3 - "$bad_encode" <<'EOF'
+import json, sys
+
+
+def rec(state):
+    return {"fleet": "f", "config": "f.yml", "state": state, "org": "o", "repo": "r-" + state,
+            "paused": False, "polled_at": "2026-07-21T12:00:00+00:00",
+            "workflows": [{"workflow": "openstates-scrape.yml",
+                           "latest_conclusion": "success", "hours_since_success": 1.0}],
+            "data_commit_age_hours": 2.0, "errors": []}
+
+
+with open(sys.argv[1], "w") as f:
+    f.write(json.dumps(rec("wy")) + "\n")    # good
+    f.write(json.dumps(rec("w\ny")) + "\n")  # control char in a tag -> skipped
+EOF
+if ! pipenv run python3 main.py run --dry-run --poller-records "$bad_encode" \
+    > "$clean_out" 2> "$stderr_tmp"; then
+  echo "✗ run must stay green when one repo's data fails to encode"
+  cat "$stderr_tmp"
+  exit 1
+fi
+wf_lines=$(grep -c '^fleet_workflow_run,' "$clean_out" || true)
+repo_lines=$(grep -c '^fleet_repo,' "$clean_out" || true)
+if [ "$wf_lines" != "1" ] || [ "$repo_lines" != "1" ]; then
+  echo "✗ only the good repo should contribute lines (got $wf_lines workflow, $repo_lines repo):"
+  cat "$clean_out"
+  exit 1
+fi
+if ! grep -q '^fleet_workflow_run,state=wy,' "$clean_out"; then
+  echo "✗ the good repo's metrics must still ship when another repo can't encode; got:"
+  cat "$clean_out"
+  exit 1
+fi
+if ! grep -q '^fleet_collector_heartbeat repos=2,errors=0 ' "$clean_out"; then
+  echo "✗ the heartbeat must report the full sweep size (repos=2), encode skips aside; got:"
+  cat "$clean_out"
+  exit 1
+fi
+echo "✓ run: a repo's un-encodable data is skipped, the good repo still ships, run stays green"
+
+# The named acceptance case — a bad Grafana key — end to end through run: a fake
+# urlopen returns HTTP 401, so the push fails at the wire (not the missing-env
+# guard above) and run exits nonzero. Driven in-process (CliRunner) because a
+# subprocess can't inject the fake urlopen.
+pipenv run python3 - "$clean_records" <<'EOF'
+import email.message
+import sys
+import urllib.error
+import urllib.request
+
+from click.testing import CliRunner
+
+import main
+
+
+def bad_key_urlopen(request, timeout=None):
+    raise urllib.error.HTTPError(
+        request.full_url, 401, "Unauthorized", email.message.Message(), None
+    )
+
+
+urllib.request.urlopen = bad_key_urlopen
+result = CliRunner().invoke(
+    main.cli,
+    ["run", "--poller-records", sys.argv[1]],
+    env={
+        "GRAFANA_PUSH_URL": "https://push.test/api/v1/push/influx/write",
+        "GRAFANA_PUSH_USER": "123456",
+        "GRAFANA_PUSH_KEY": "bad-key",
+    },
+)
+# click 8.2+ captures stdout/stderr separately; the ClickException lands on stderr.
+combined = result.output + (result.stderr or "")
+assert result.exit_code != 0, f"a rejected key (HTTP 401) must exit nonzero: {combined}"
+assert "HTTP 401" in combined, combined
+print("✓ run: a rejected Grafana key (HTTP 401) exits nonzero end to end")
+EOF
+
 # live-check's query-back proof derives expected series names AND counts from
 # the payload it pushed; the accounting is locked against the snapshot payload
 # (which includes an escaped-space tag value the parser must not trip on).


### PR DESCRIPTION
Part of #36. Builds on #116.

Adds the `run` orchestrator and `.github/workflows/fleet-monitor.yml` — the hourly sweep that ties the module together in CI. **This is the PR that makes the collector actually run.**

The workflow is read-only on GitHub (the default `GITHUB_TOKEN` covers every read; no PAT, no write scope), bounded by a 20-minute job timeout well inside the hour, and serialized by a `fleet-monitor` concurrency group so a manual dispatch never overlaps a scheduled sweep. `cancel-in-progress` is false: a running sweep is never killed mid-push.

**The heartbeat.** Each sweep emits one untagged `fleet_collector_heartbeat` series. That's the dead-man switch the alerting PR keys off — it's what stops every per-jurisdiction signal from being quietly meaningless when nothing is being measured at all.

### Before merging this

Once this lands on `main`, GitHub starts firing the workflow hourly, and without credentials it exits nonzero by design. **Set the repository variables and secrets first** and the first run goes green instead of putting a red X in the Actions tab every hour:

| Kind | Name |
| --- | --- |
| Variable | `GRAFANA_PUSH_URL`, `GRAFANA_PUSH_USER`, `GRAFANA_LOGS_URL`, `GRAFANA_LOGS_USER` |
| Secret | `GRAFANA_PUSH_KEY`, `GRAFANA_LOGS_KEY` |

Endpoints and instance IDs aren't secret, so they're variables — that keeps the two write keys as the only secrets. I have the exact values from the validated deployment and can supply them; the two tokens need a non-public channel.

### Reviewing this

The orchestrator's exit contract is the delicate part, and it's pinned from every side: a partial-fail sweep still ships metrics plus heartbeat and exits 0, an all-errored sweep still ships the heartbeat alone, an un-encodable repo is skipped while the rest of the sweep ships — but an outright push failure (missing credentials, a rejected key) exits nonzero so the run shows red. The rule underneath: never let a broken collector look like a healthy fleet.

---

### Where this sits in the stack

Six stacked PRs build `actions/fleet-monitor`, each based on its predecessor so every PR shows only its own task's diff. **Merge in order, 1 → 6.**

| # | PR | |
| --- | --- | --- |
| 1 | Fleet config reader + module scaffold | #115 |
| 2 | Fleet poller + metrics shipper | #116 |
| 3 | Orchestrator, hourly workflow + heartbeat | **← this PR** |
| 4 | Log harvester, Loki shipper + watermark | #118 |
| 5 | Fleet-overview dashboard as code | #119 |
| 6 | Alert rules, contact point + notification policy | #120 |

Please **merge or rebase rather than squash** — each PR is already one clean commit, and squashing rewrites it, which orphans the next PR's base.
