### PR TITLE
feat(fleet-monitor): fleet-overview dashboard as code (5/6)

### DIFF
--- a/actions/fleet-monitor/README.md
+++ b/actions/fleet-monitor/README.md
@@ -12,15 +12,6 @@ fleet. **Discovery convention**: any top-level `*.yml`/`*.yaml` in `--config-dir
 `chn-openstates-scrape.yml` and `chn-openstates-files.yml`; a new fleet config is picked
 up without code changes.
 
-**Non-production fleets are skipped by default.** Discovery finds every fleet config, but
-`EXCLUDED_FLEETS` keeps some out of the sweep — today `chn-openstates-test`, which mirrors the
-files fleet against the `govbot-test` org and whose own header says some locales "will fail
-fast … expected, not alarming". Monitoring it would put permanent expected-red on the board —
-the same reason paused jurisdictions are never coloured red — and it costs 56 repos × 2
-workflows of API budget. This is a default, not a law: `read_fleet(..., exclude_fleets=())`
-monitors everything discovery finds, so the pipeline-manager configs stay the authority on what
-*exists* and this is only a visible, reversible statement about what is worth watching.
-
 The record shape is the module's contract, declared in
 [schemas/fleet-record.schema.json](../../schemas/fleet-record.schema.json) and validated on
 every snapshot render: `fleet`,
@@ -28,6 +19,18 @@ every snapshot render: `fleet`,
 `template`, `base_template` (the `-paused` suffix stripped — the locale's durable
 identity, which downstream keys per-template facts off), `paused`, `runner`,
 `expected_workflows`.
+**Non-production fleets are skipped by default.** Discovery finds every fleet config, but
+`--exclude-fleet` (default: `chn-openstates-test`) keeps some out of the sweep.
+`chn-openstates-test` mirrors the files fleet against the `govbot-test` org to validate
+changes before cutting the real repos over, and its own header says some locales "will fail
+fast … expected, not alarming" — monitoring it would put permanent expected-red on the
+board and page someone once alerting lands, the same reason paused jurisdictions are never
+coloured red. It is also 56 repos × 2 workflows of API budget: including it takes an hourly
+sweep to **~1,008 requests against the 1,000/hour `GITHUB_TOKEN` limit**, before any log
+archive downloads. This is a default, not a law — `--exclude-fleet=` (empty) monitors
+everything discovery finds — so the pipeline-manager configs stay the authority on what
+*exists*, and this is only a visible, reversible statement about what is worth alerting on.
+
 A locale is paused when its `template` ends in `-paused`. `expected_workflows` lists the
 template's workflow files as they exist in rendered repos (`.j2` stripped), minus the
 locale's `disabled_jobs`. A config that references an unknown template, or a template
@@ -126,13 +129,21 @@ the offsets are assigned in event-time order within each stream.
 ### Budgets
 
 - **GitHub API**: only single-page queries (`per_page` ≤ 3) — 2 per workflow (recent
-  runs, latest success) + 1 per repo for the data-path commit. Current fleet: 112 repos × 1 workflow → **336
-  requests per sweep**, well inside the default `GITHUB_TOKEN` limit of 1000/hour;
-  `render-snapshots.sh` asserts the real-fleet count stays under 400. The logs leg
-  adds 1 run-listing request per workflow (paging up to 4 only when a page is full
-  and still inside the 24 h window — page 1 suffices on a normal hourly sweep) plus
-  1 archive download per *new* run — bounded by how many runs actually finished in
-  the hour, typically a handful, since the watermark skips everything already shipped.
+  runs, latest success) + 1 per repo for the data-path commit, plus the logs leg's
+  1 run-listing request per workflow (paging up to 4 only when a page is full and still
+  inside the 24 h window — page 1 suffices on a normal hourly sweep) and 1 archive download
+  per *new* run, bounded by how many runs actually finished in the hour, typically a
+  handful, since the watermark skips everything already shipped.
+
+  Against the `GITHUB_TOKEN` limit of **1000 requests/hour**, and the sweep runs hourly, so
+  one sweep must fit in one hour's budget. The monitored fleet — 56 scraper repos × 1
+  workflow plus 56 data repos × 2 — costs **448 metrics + 168 log listings = 616/hour, 62%
+  of the limit**. `render-snapshots.sh` asserts the whole sweep stays under 80%, leaving
+  ~200 for archive downloads, and prints a notice past 60% so the next fleet or workflow
+  doesn't arrive as a surprise. That check counts **both legs**: budgeting the metrics leg
+  alone against a flat number understated a sweep and let the real cost cross the ceiling
+  before anything complained. Including `chn-openstates-test` would put the sweep at
+  ~1,008/hour — over the limit — which is the arithmetic behind excluding it above.
 - **Series cardinality**: 2 series per repo/workflow + 1 per repo, plus the single global
   `fleet_collector_heartbeat` pair the orchestrator emits per sweep → **~336 series (+2 heartbeat)**
   for the current fleet, against the Grafana Cloud free-tier budget of ~10k active series.
@@ -160,6 +171,124 @@ the offsets are assigned in event-time order within each stream.
 | `GRAFANA_LOGS_USER` / `GRAFANA_LOGS_KEY` | logs instance ID / access-policy token (`logs:write`; also `logs:read` if you run `probe-loki`, whose query-back reads the entries back) |
 | `GRAFANA_QUERY_URL` | Prometheus API base, `https://prometheus-…/api/prom` (live-check only) |
 | `GRAFANA_QUERY_USER` / `GRAFANA_QUERY_KEY` | Prometheus instance ID / token (`metrics:read`, live-check only) |
+| `GRAFANA_DASHBOARD_URL` | stack base URL, `https://<stack>.grafana.net` (`check-dashboard` only) |
+| `GRAFANA_DASHBOARD_KEY` | service-account token with dashboard write (`check-dashboard` only; **bearer**-authed, unlike the Basic-auth push endpoints) |
+
+## Dashboard: the fleet view, as code
+
+One dashboard answers the whole question — anything red, anything stale, and what did it
+say — and it is committed rather than hand-built, so the Grafana side is reproducible:
+
+- **[dashboard.py](dashboard.py)** builds it as data; **[dashboards/fleet-overview.json](dashboards/fleet-overview.json)**
+  is that build, rendered and committed. The JSON is what you import; the module is what
+  you review. The render script re-renders the dashboard and fails if the committed copy
+  has drifted — it does not rewrite the file, so regenerate it yourself with
+  `main.py dashboard --out dashboards/fleet-overview.json` after editing the builder. The
+  file in the repo can never quietly stop matching the code that explains it.
+- **Scrapers, freshness, logs — then a grid per remaining workflow.** The scrape is the
+  fleet's entry point and everything downstream depends on it, so its status grid is pinned
+  to the top. Below it, one full-width freshness table on
+  `fleet_repo_data_commit_age_hours` and a logs panel on the Loki streams; below those, one
+  status grid per *other* workflow. The table turns red above 48 h — the same number the
+  staleness alert fires on, kept in one place so the dashboard and the alert cannot
+  disagree.
+- **Only the scrape workflow is named in the JSON.** The rest of the grids are Grafana
+  panel repeats over a variable fed by the metric's own `workflow` label, so a workflow
+  added to the pipeline-manager config gets a grid on its next sweep with no dashboard
+  edit. This is not hypothetical: `extract-text.yml` was added to the production files
+  fleet upstream, and the earlier hardcoded Scrapers/Formatters pair would have left it
+  silently unmonitored — no tile, no alert, and no offline check that could have caught it.
+- **A tile says only its state.** 112 tiles in a single panel shrank the text past reading;
+  56 apiece with the workflow carried by the panel title leaves the two-letter jurisdiction
+  code rendered as large as the OK/FAILING beside it. (The code renders as the metric label
+  stores it, lower-case — Grafana has no way to upper-case a series name without hardcoding
+  all 56 jurisdictions into the JSON, which would cost the property that a new jurisdiction
+  appears on its own.)
+- **Paused jurisdictions are dimmed in place, not split out.** Out of session, a failing run
+  and a month-old data commit are the legislative calendar, not an incident. In the grids
+  they come from a second query overridden to a flat colour — never red — whose text still
+  says whether the last run failed. In the freshness table they are a column. A separate
+  panel for them, which is what this replaced, was an empty box whenever the whole fleet
+  was in session, which is most of the time.
+- **One place the never-red rule cannot hold**: a table colours a column by threshold, not
+  a row by another row's value, so a paused repo stale past 48 h does turn red in the
+  freshness table. Sorting keeps it out of the way — in-session repos first, worst
+  staleness at the top of them — so rows needing action outrank rows waiting for a session.
+- **Nothing in the JSON belongs to one account.** Datasources are pickers (`${metrics}`,
+  `${logs}`), never UIDs, and the dashboard carries `id: null` with a stable uid, so the
+  same file imports into any stack instead of colliding with whatever holds that id there.
+  The pickers do *default* to this fleet's stack (`grafanacloud-govbot-prom` /
+  `grafanacloud-govbot-logs`) so an import renders immediately — a default, not a hardcode:
+  another stack changes them in the picker and nothing else about the JSON differs.
+- **Clicking a freshness row narrows the whole board to that jurisdiction** — grids, table,
+  and logs — through the single `Jurisdiction` picker, so the filter shown at the top is
+  always the filter applied. The link is an absolute dashboard path carrying the current
+  time range; the bare `?var=…` relative URL it replaced rewrote the address bar and re-ran
+  nothing, so it looked live and did nothing. It sets the jurisdiction only: adding the org
+  narrowed to one of that jurisdiction's two repos and hid its sibling.
+- **Every metric panel looks back six hours, and that number is measured.** An instant
+  query resolves against Prometheus's 5-minute staleness window, so a bare selector finds
+  nothing between sweeps — the board reads "No data", which it did on a real import.
+  `last_over_time(…[6h])` keeps the queries instant vectors, leaving the table
+  transformations and the stat reducer untouched.
+
+  Six hours, not one, because **the hourly cron is aspirational**. GitHub runs scheduled
+  workflows best-effort, and on a fork's non-default branch they drift hard: 25 consecutive
+  sweeps (2026-07-22..25) showed a median gap of **2.0h and a maximum of 3.6h**, with 4 of
+  24 gaps past three hours. A window sized off `cron: "0 * * * *"` blanked the board a
+  second time. Size it off the observed gap, with headroom.
+
+  The cost, worth knowing before you trust a number: a displayed value can be one window
+  old, so a repo whose data commit has just crossed 48 h can still read green for up to six
+  hours. **The same drift applies to alerting** — a "collector heartbeat absent 3h" rule
+  would false-fire on a routine 3.6h gap, so task 0006 needs to pick its thresholds from
+  this measurement, not from the cron expression.
+- **Filters are label-driven and URL-synced.** The state, org, and workflow pickers read
+  their options from the metrics labels and the outcome picker from Loki's, so a
+  jurisdiction added to the pipeline-manager config appears on its next sweep with no
+  dashboard edit. Each picker speaks its own datasource's variable-query dialect —
+  a Prometheus-shaped query on the Loki picker leaves it empty — and every one sets
+  `allValue: ".*"` explicitly, because a blank all-value makes Grafana expand "All" to
+  the options it resolved, or to the empty string when it resolved none, which quietly
+  turns each `=~` matcher into one that matches nothing. Every filter round-trips
+  through the URL — "here is Wyoming's freshness" is a link you can paste to someone,
+  and each freshness row links to its own jurisdiction's filtered view. The all-value is
+  `.+` rather than `.*` because LogQL rejects a stream selector whose every matcher is
+  empty-compatible: with all four pickers on All, `.*` would make the logs panel a parse
+  error instead of a query.
+- **Run id and run URL surface by expanding a log line**, not as labels: they travel as
+  structured metadata (see Budgets above), which is why log details stay on.
+
+### Importing it into a fresh stack
+
+Grafana → Dashboards → New → Import → upload
+[dashboards/fleet-overview.json](dashboards/fleet-overview.json). It asks for a name,
+folder, and uid, and nothing else. No edits, no find-and-replace.
+
+**Then check the two datasource pickers at the top of the dashboard.** The import screen
+never asks about datasources — that prompt only appears for dashboards carrying an
+`__inputs` block, and this one parameterizes through template variables instead — so
+Grafana auto-selects the first datasource of each type it finds. A Grafana Cloud stack has
+more than one Prometheus-type datasource (`grafanacloud-<stack>-prom` sits alongside
+`grafanacloud-usage`), and landing on the wrong one renders "No data" on every metric
+panel while looking perfectly healthy. If the board is empty, look here first.
+
+To do the same unattended — and to prove the file still imports — point
+`check-dashboard` at the stack:
+
+```bash
+export GRAFANA_DASHBOARD_URL=https://<stack>.grafana.net
+export GRAFANA_DASHBOARD_KEY=<service-account token with dashboard write>
+pipenv run python main.py check-dashboard
+```
+
+It POSTs the dashboard to the stack's API keyed by uid (so re-running updates rather than
+littering copies) and then **reads it back by uid**, checking both the panels and the
+template variables. A 200 on the push is not proof it renders — Grafana will store a
+payload it then shows as an empty dashboard — and panels alone are not proof either:
+every panel filters on `=~"$state"` and points at `${metrics}`/`${logs}`, so a variable
+Grafana declined to migrate leaves all five panels present and all five rendering nothing.
+Missing credentials exit 0 with a skip notice, so an offline run passes without an account.
 
 ## Usage
 
@@ -188,6 +317,15 @@ GITHUB_TOKEN=$(gh auth token) pipenv run python main.py collect --logs-only \
 # each BACK to see which actually landed — Grafana Cloud 204s a too-old push then
 # silently drops it (needs GRAFANA_LOGS_* vars; the token also needs logs:read):
 pipenv run python main.py probe-loki
+
+# Print the dashboard JSON, or regenerate the committed copy after editing
+# dashboard.py (the render script fails if the two have drifted):
+pipenv run python main.py dashboard
+pipenv run python main.py dashboard --out dashboards/fleet-overview.json
+
+# Import the dashboard into a real stack and read it back (needs
+# GRAFANA_DASHBOARD_URL/KEY; exits 0 with a notice when they're absent):
+pipenv run python main.py check-dashboard
 
 # End-to-end proof: poll, push, then query the series back (needs all six
 # GRAFANA_* vars; exits 0 with a notice when they're absent):
@@ -328,6 +466,42 @@ collection-time index stamps; that `run` wires the logs leg only when a log sour
 is present; `probe-loki`'s credential-free skip path, its bad-key exit, and its
 query-back detecting a silently-discarded (204-but-dropped) age against a fake
 Loki. The real ingest-window probe runs only with `GRAFANA_LOGS_*` set.
+
+The dashboard has no snapshot file because the committed JSON is the snapshot: the render
+re-renders it from `dashboard.py` into a temporary file and fails on any drift from the
+committed `dashboards/fleet-overview.json` (it never rewrites the committed copy — that is
+`main.py dashboard --out …`). Note that this one artifact lives outside `__snapshots__/`,
+so it is guarded by that diff rather than by the repo-wide `verify-snapshots.sh` gate.
+Around that, offline checks lock what the panels actually promise — every datasource
+reference is a variable and never a stack UID, `id` is null and the uid stable (so a fresh
+stack imports rather than collides), panel ids are unique, the Scrapers grid is first and
+pins the scrape workflow while every other grid is a panel repeat over a variable that
+excludes it (so no workflow list can fall behind the config) and sits after the logs, a
+tile is labelled `{{state}}` alone at the same text size as its value, paused tiles come from a second query overridden to a flat
+never-red colour whose text still reports the last run, the freshness table is one
+full-width panel whose query carries no paused filter and whose `paused` column survives
+the organize step uncoloured by the staleness thresholds, it sorts in-session rows first
+then worst staleness and turns red at exactly the 48 h alert
+threshold, each freshness row
+links to its jurisdiction's filtered view, the logs panel matches on all four stream
+labels as regexes with log details on, every metric panel wraps its selector in
+`last_over_time` over a window with real headroom on the *measured* worst sweep gap, not on
+the cron expression (checked over the metric panels derived from the board rather than a
+hand-written list), the datasource pickers default to this stack, the freshness row link is
+an absolute path setting the single jurisdiction picker and carrying the time range, the
+rendered logs selector keeps at least one matcher
+that is not empty-compatible, each picker carries its own
+datasource's query dialect and an explicit `allValue: ".+"`, the pickers are label-driven,
+multi-select, and URL-synced, and the encoding is
+deterministic. `check-dashboard` is locked the same way as the other live paths: its
+credential-free skip, and against a fake Grafana its wire shape (dashboards API endpoint,
+bearer auth, overwrite-by-uid, read-back by uid), its loud failure on a rejected import,
+its refusal to pass a push that returns 200 but reads back hollow, and its refusal to pass
+an import that lost a template variable or kept one in name only (stripped of its
+all-value, or repointed at the wrong datasource — a picker that resolves to nothing blanks
+every panel filtering on it). The real import is
+opt-in — `FLEET_MONITOR_DASHBOARD_CHECK=1 ./render-snapshots.sh` — so a bare render never
+writes into anyone's stack.
 
 ```bash
 ../../scripts/before-snapshots.sh __snapshots__

--- a/actions/fleet-monitor/dashboard.py
+++ b/actions/fleet-monitor/dashboard.py
@@ -1,0 +1,575 @@
+"""Build the fleet-overview Grafana dashboard as data, not by hand.
+
+The committed artifact is ``dashboards/fleet-overview.json``; this module is
+what produces it (``main.py dashboard``), so the dashboard is reviewable as
+code and regenerating it is a diff, not a re-export from somebody's browser.
+"""
+
+import json
+
+METRICS = {"type": "prometheus", "uid": "${metrics}"}
+LOGS = {"type": "loki", "uid": "${logs}"}
+
+# Stable across every stack this is imported into, so links to it (and the
+# alert rules in the next task) keep working after a re-import.
+DASHBOARD_UID = "fleet-monitor-overview"
+
+# The committed artifact: what a maintainer imports, and what the render script
+# re-renders and diffs to prove it still matches this module.
+DASHBOARD_PATH = "dashboards/fleet-overview.json"
+
+# The workflow's cron says hourly. GitHub does not honour it: scheduled runs are
+# best-effort and queue behind everything else, and on a fork's non-default
+# branch they drift badly. Measured over 25 consecutive sweeps (2026-07-22..25):
+# median gap 2.0h, MAX 3.6h, with 4 of 24 gaps past three hours.
+#
+# Size the look-back against that, never against the cron expression — a 3h
+# window read "No data" for the ~30 minutes after each long gap, which is
+# exactly how the board went blank the second time.
+OBSERVED_MAX_SWEEP_GAP_HOURS = 3.6
+
+# ~1.7x the worst observed gap. The cost of a wider window is that a displayed
+# value can be up to this old: a data-commit age can under-report by one window,
+# so a repo at 43h reads green when it has really crossed the 48h line. Against
+# a 48h threshold that is tolerable; a much wider window would not be.
+#
+# An instant query resolves against Prometheus's 5-minute staleness lookback, so
+# a bare selector finds nothing between sweeps whatever the schedule — hence
+# last_over_time, which stays an instant vector, leaving the table
+# transformations and the stat reducer unaffected. main.py's live-check
+# documents the same 5-minute trap from the other side.
+#
+# The other cost of the window: `paused` is a label, so flipping a jurisdiction
+# in or out of session starts a new series and abandons the old one, and the
+# abandoned twin stays resolvable for the look-back. For up to one window after a
+# transition a jurisdiction appears twice in a grid — including, briefly, red for
+# something now out of session. The same lag applies to a workflow dropped from
+# expected_workflows. It settles on its own; it is the price of a board that
+# renders at all between sweeps.
+LOOKBACK = "6h"
+
+# This fleet's own stack, so an import renders immediately instead of making
+# someone hunt through pickers. The import screen never asks (that prompt needs
+# an `__inputs` block, which parameterizing by variable deliberately avoids), and
+# Grafana's own fallback is the first datasource of the type in name order —
+# which on Grafana Cloud is as likely to be `grafanacloud-usage` as the stack's
+# own. These are defaults, not hardcoded uids: the pickers still work, so another
+# stack overrides them by hand and nothing else about the JSON changes.
+DEFAULT_METRICS_DATASOURCE = "grafanacloud-govbot-prom"
+DEFAULT_LOGS_DATASOURCE = "grafanacloud-govbot-logs"
+
+# The scrape is the fleet's entry point — every other workflow consumes what it
+# produces — so it gets a pinned grid at the top of the board. It is the ONLY
+# workflow named in this file: the rest are discovered from the metric's labels
+# (see the `other_workflow` variable), because a hardcoded list is exactly how
+# `extract-text.yml` shipped upstream and went unmonitored.
+SCRAPE_WORKFLOW = "openstates-scrape.yml"
+
+
+def _latest(selector: str) -> str:
+    """The last sample of a selector within the look-back, as an instant vector."""
+    return f"last_over_time({selector}[{LOOKBACK}])"
+
+
+def _datasource_variable(name: str, plugin: str, label: str, default: str) -> dict:
+    """A datasource picker, so the JSON carries no stack-specific UID."""
+    return {
+        "current": {"text": default, "value": default},
+        "hide": 0,
+        "includeAll": False,
+        "label": label,
+        "multi": False,
+        "name": name,
+        "options": [],
+        "query": plugin,
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "type": "datasource",
+    }
+
+
+# Scopes the Loki picker to this fleet's own streams: every stream the harvester
+# ships carries a state label, so another producer's `outcome` values in the same
+# logs instance can't leak into the picker.
+FLEET_STREAMS = '{state=~".+"}'
+
+
+def _label_variable(name: str, datasource: dict, query: dict, definition: str, label: str) -> dict:
+    """A multi-select picker fed by the datasource's own label values.
+
+    Label-driven rather than a hardcoded list: a jurisdiction or workflow added
+    to the pipeline-manager config shows up in the picker on its next sweep,
+    with no dashboard edit. Left URL-synced (the Grafana default) so a filtered
+    view — one state's freshness, one workflow's failures — is a link you can
+    paste to someone.
+
+    ``allValue`` is explicit and not optional. Left blank, Grafana expands "All"
+    to an alternation of the options it resolved — and to the empty string when
+    it resolved none, which turns every ``=~`` matcher into one that matches
+    nothing. A picker that hasn't populated yet would silently blank every panel
+    that uses it, and it would look identical to having no data at all.
+
+    It is ``.+`` rather than ``.*`` because LogQL rejects a stream selector
+    whose every matcher is empty-compatible: with all four pickers on All,
+    ``{state=~".*", …}`` is a parse error, not an empty result. Every fleet
+    stream and every fleet series carries all four labels, so ``.+`` selects
+    exactly the same thing and is legal in both LogQL and PromQL.
+
+    ``query`` is the datasource's own query object, not one shape for both:
+    Prometheus wants the label-values discriminator its editor writes, Loki
+    wants a different object entirely, and feeding either the other's shape
+    leaves the picker empty.
+    """
+    return {
+        "allValue": ".+",
+        "current": {"selected": True, "text": ["All"], "value": ["$__all"]},
+        "datasource": datasource,
+        "definition": definition,
+        "hide": 0,
+        "includeAll": True,
+        "label": label,
+        "multi": True,
+        "name": name,
+        "options": [],
+        "query": query,
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+    }
+
+
+def _prometheus_label_values(name: str) -> dict:
+    """A Prometheus label-values variable query.
+
+    The query string is the operative field — it is what Prometheus's
+    ``metricFindQuery`` parses — and this is the shape Grafana persists for a
+    label-values variable. Editor-state fields are deliberately absent: a
+    partial set of them opens the variable editor half-populated, and saving
+    from there writes back an empty ``label_values()`` that resolves to nothing.
+    """
+    return {
+        "query": f"label_values(fleet_workflow_run_status, {name})",
+        "refId": "PrometheusVariableQueryEditor-VariableQuery",
+    }
+
+
+def _metrics_picker(name: str, label: str) -> dict:
+    return _label_variable(
+        name,
+        METRICS,
+        _prometheus_label_values(name),
+        f"label_values(fleet_workflow_run_status, {name})",
+        label,
+    )
+
+
+def _templating() -> dict:
+    return {
+        "list": [
+            _datasource_variable(
+                "metrics", "prometheus", "Metrics datasource", DEFAULT_METRICS_DATASOURCE
+            ),
+            _datasource_variable("logs", "loki", "Logs datasource", DEFAULT_LOGS_DATASOURCE),
+            _metrics_picker("state", "Jurisdiction"),
+            _metrics_picker("org", "Org"),
+            _metrics_picker("workflow", "Workflow"),
+            # Outcome exists only on the Loki streams — metrics carry a status
+            # number, logs carry the run conclusion that produced them — so this
+            # one picker speaks Loki's variable-query dialect (type 1 = label
+            # values), not Prometheus's.
+            _label_variable(
+                "outcome",
+                LOGS,
+                {
+                    "label": "outcome",
+                    "refId": "LokiVariableQueryEditor-VariableQuery",
+                    "stream": FLEET_STREAMS,
+                    "type": 1,
+                },
+                f"label_values({FLEET_STREAMS}, outcome)",
+                "Log outcome",
+            ),
+            # Drives the repeated status grids: every workflow except the pinned
+            # scrape one, which has its own grid at the top. Excluded in the
+            # query rather than by a regex over the results, so the rule is one
+            # readable matcher. Hidden from the toolbar (hide: 2) — it is panel
+            # plumbing, not a filter anyone should be setting by hand.
+            {
+                **_label_variable(
+                    "other_workflow",
+                    METRICS,
+                    {
+                        "query": (
+                            f'label_values(fleet_workflow_run_status{{workflow!="{SCRAPE_WORKFLOW}"}}'
+                            ", workflow)"
+                        ),
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery",
+                    },
+                    f'label_values(fleet_workflow_run_status{{workflow!="{SCRAPE_WORKFLOW}"}}'
+                    ", workflow)",
+                    "Other workflows",
+                ),
+                "hide": 2,
+            },
+        ]
+    }
+
+
+# Paused jurisdictions are out of session, so a failing run is the legislative
+# calendar rather than something to act on. They sit in the same grid as
+# everything else — hiding them loses the fleet, and giving them their own panel
+# left a permanently empty box whenever the whole fleet is in session — but they
+# are dimmed to a flat colour and never red, and their text still says whether
+# the last run failed.
+ACTIVE_MAPPINGS = {
+    "0": {"color": "red", "index": 0, "text": "FAILING"},
+    "1": {"color": "green", "index": 1, "text": "OK"},
+}
+PAUSED_MAPPINGS = {
+    "0": {"color": "text", "index": 0, "text": "paused · last run failed"},
+    "1": {"color": "text", "index": 1, "text": "paused · last run ok"},
+}
+
+# The tile text, as large as the OK/FAILING beside it. A jurisdiction is its
+# two-letter code and nothing else: the workflow is the panel it sits in now,
+# so repeating it per tile only shrank the part that identifies the tile.
+TILE_TEXT_SIZE = 18
+
+
+def _status_grid(panel_id: int, title: str, workflow_matcher: str, y: int, height: int,
+                 description: str, repeat: str = None) -> dict:
+    """One tile per jurisdiction, coloured by its latest completed run.
+
+    A stat panel rather than a table because the question it answers is
+    "anything red?", read in one glance, and stat lays many series out as a grid
+    on its own. One grid per workflow keeps that glance readable: 112 tiles in a
+    single panel shrank the text past legibility.
+
+    ``workflow_matcher`` is the whole PromQL label matcher, not a bare value,
+    because the two callers need different operators. A pinned grid names a
+    literal and matches it exactly; a repeated grid matches its variable with
+    ``=~`` and must — Grafana interpolates a *multi-value* variable into a
+    Prometheus query using the regex form, ``(format.yml)`` with parentheses,
+    even where a repeat has scoped it to a single value. An ``=`` matcher then
+    compares against a literal ``(format.yml)`` and matches nothing: the panel
+    renders "No data" while its title, interpolated as plain text, reads
+    perfectly right.
+
+    ``repeat`` names a variable to generate one grid per value of, instead of
+    pinning a single workflow. That is how every workflow but the scrape gets a
+    grid without being named here — `extract-text.yml` was added upstream and
+    went unmonitored precisely because the workflows were a hardcoded pair.
+
+    Paused jurisdictions come from a second query rather than a second panel, so
+    the grid holds the whole fleet; an override keyed on that query's refId
+    flattens their colour and rewords their mapping, which is the only way
+    Grafana will colour some tiles by value and others not.
+    """
+    def target(ref_id: str, paused: str) -> dict:
+        return {
+            "datasource": METRICS,
+            "editorMode": "code",
+            # The workflow is fixed by the panel — pinned, or supplied by the
+            # repeat — so it carries no `workflow=~"$workflow"` matcher of its
+            # own. The workflow picker still scopes the logs panel.
+            "expr": _latest(
+                f'fleet_workflow_run_status{{{workflow_matcher}, paused="{paused}", '
+                'state=~"$state", org=~"$org"}'
+            ),
+            "instant": True,
+            "legendFormat": "{{state}}",
+            "range": False,
+            "refId": ref_id,
+        }
+
+    panel = {
+        "datasource": METRICS,
+        "description": description,
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "fixed", "fixedColor": "text"},
+                "mappings": [{"options": ACTIVE_MAPPINGS, "type": "value"}],
+                "noValue": "no data",
+            },
+            "overrides": [
+                {
+                    "matcher": {"id": "byFrameRefID", "options": "B"},
+                    "properties": [
+                        {"id": "color", "value": {"fixedColor": "text", "mode": "fixed"}},
+                        {"id": "mappings", "value": [
+                            {"options": PAUSED_MAPPINGS, "type": "value"}
+                        ]},
+                    ],
+                }
+            ],
+        },
+        "gridPos": {"h": height, "w": 24, "x": 0, "y": y},
+        "id": panel_id,
+        "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "text": {"titleSize": TILE_TEXT_SIZE, "valueSize": TILE_TEXT_SIZE},
+            "textMode": "value_and_name",
+            "wideLayout": False,
+        },
+        "targets": [target("A", "false"), target("B", "true")],
+        "title": title,
+        "type": "stat",
+    }
+    if repeat:
+        panel["repeat"] = repeat
+        panel["repeatDirection"] = "v"
+    return panel
+
+
+# The data-commit-age alert fires above 48 hours (README "Alerting"); the table
+# turns red at the same number so the dashboard and the alert can never disagree.
+STALE_HOURS = 48
+
+AGE_FIELD = "Value"
+
+
+def _freshness_table(panel_id: int, y: int, height: int) -> dict:
+    """Hours since each repo's last data commit — the whole fleet, one table.
+
+    Paused repos are a column here rather than a second panel: a table can say
+    "out of session" in a cell, and the separate panel it replaces was an empty
+    box whenever the whole fleet was in session, which is most of the time.
+
+    The cost, worth knowing: a table colours a column by threshold, not a row by
+    another row's value, so a paused repo stale past 48 h does turn red — the
+    one place the never-red-for-paused rule cannot hold. Sorting keeps it out of
+    the way: in-session repos first, worst staleness at the top of them, so the
+    rows that need action outrank rows that are just waiting for a session.
+    """
+    return {
+        "datasource": METRICS,
+        "description": (
+            "Hours since the last commit touching each repo's data path, in-session repos "
+            f"first. Red above {STALE_HOURS}h — the same line the staleness alert fires on. "
+            "A paused repo is stale by the session calendar, not by fault; read the paused "
+            "column before reacting to its colour."
+        ),
+        "fieldConfig": {
+            "defaults": {
+                "custom": {"align": "auto", "cellOptions": {"type": "color-text"}},
+                "links": STATE_LINK,
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "green", "value": None},
+                        {"color": "red", "value": STALE_HOURS},
+                    ],
+                },
+                "unit": "h",
+            },
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": AGE_FIELD},
+                    "properties": [{"id": "displayName", "value": "Hours since data commit"}],
+                },
+                {
+                    # The paused column is a label, not a measurement — colouring
+                    # it by the staleness thresholds would be meaningless.
+                    "matcher": {"id": "byName", "options": "paused"},
+                    "properties": [
+                        {"id": "displayName", "value": "In session"},
+                        {"id": "custom.cellOptions", "value": {"type": "auto"}},
+                        {"id": "mappings", "value": [{
+                            "options": {
+                                "false": {"color": "text", "index": 0, "text": "yes"},
+                                "true": {"color": "text", "index": 1, "text": "paused"},
+                            },
+                            "type": "value",
+                        }]},
+                    ],
+                },
+            ],
+        },
+        "gridPos": {"h": height, "w": 24, "x": 0, "y": y},
+        "id": panel_id,
+        "options": {"showHeader": True},
+        "targets": [
+            {
+                "datasource": METRICS,
+                "editorMode": "code",
+                "expr": _latest(
+                    'fleet_repo_data_commit_age_hours{state=~"$state", org=~"$org"}'
+                ),
+                "format": "table",
+                "instant": True,
+                "range": False,
+                "refId": "A",
+            }
+        ],
+        "title": "Data freshness",
+        "transformations": [
+            # The instant query returns one row per series with the labels as
+            # columns; drop the bookkeeping ones. `paused` stays — it is the
+            # column that replaced the second table. (No __name__ to drop: a
+            # range-vector function strips it.)
+            {"id": "organize", "options": {"excludeByName": {"Time": True}}},
+            # In-session first ("false" sorts before "true"), worst staleness at
+            # the top of each group.
+            {"id": "sortBy", "options": {"fields": {}, "sort": [
+                {"desc": False, "field": "paused"},
+                {"desc": True, "field": AGE_FIELD},
+            ]}},
+        ],
+        "type": "table",
+    }
+
+
+# Clicking a freshness row narrows the whole board — grids, table, and logs — to
+# that jurisdiction, through the single `state` picker. One picker means the
+# filter you can see at the top is the filter that is applied, everywhere.
+#
+# The path is absolute on purpose: the bare "?var=..." relative URL this replaced
+# was silently inert, rewriting the address bar without re-running a thing, which
+# is why the link looked live and did nothing. Carrying the time range through
+# means the click doesn't also reset the window someone just chose. It sets the
+# jurisdiction only — adding `var-org` narrowed to one of the jurisdiction's two
+# repos, hiding its sibling.
+STATE_LINK = [
+    {
+        "title": "Filter to ${__data.fields.state}",
+        "url": (
+            f"/d/{DASHBOARD_UID}?var-state=${{__data.fields.state}}"
+            "&${__url_time_range}"
+        ),
+    }
+]
+
+
+def _logs_panel(panel_id: int, y: int) -> dict:
+    """The harvested run logs, filtered by the same pickers as the grids.
+
+    Every stream label the harvester ships (org, state, workflow, outcome) is a
+    regex matcher against a multi-select variable, so "All" (``.*``) and a
+    single pick both work, and with outcome left on All a failure's full log and
+    a recent success's tail sit in the same view. Run id and run URL travel as
+    structured metadata rather than labels, so they surface by expanding a line
+    — hence log details on.
+    """
+    return {
+        "datasource": LOGS,
+        "description": (
+            "Harvested run logs. Failures ship in full (capped at 256 KB); successes ship "
+            "their last ~100 lines. Expand a line for its run id and a link to the run."
+        ),
+        "gridPos": {"h": 12, "w": 24, "x": 0, "y": y},
+        "id": panel_id,
+        "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": True,
+            "prettifyLogMessage": False,
+            "showCommonLabels": False,
+            "showLabels": True,
+            "showTime": True,
+            "sortOrder": "Descending",
+            "wrapLogMessage": True,
+        },
+        "targets": [
+            {
+                "datasource": LOGS,
+                "editorMode": "code",
+                "expr": (
+                    '{state=~"$state", org=~"$org", workflow=~"$workflow", outcome=~"$outcome"}'
+                ),
+                "queryType": "range",
+                "refId": "A",
+            }
+        ],
+        "title": "Run logs",
+        "type": "logs",
+    }
+
+
+GRID_HEIGHT = 12
+TABLE_HEIGHT = 14
+LOGS_HEIGHT = 12
+
+
+def _panels() -> list:
+    """Scrapers, freshness, logs — then a grid per remaining workflow.
+
+    The scrape is the fleet's entry point and everything downstream depends on
+    it, so it is pinned to the top where it needs no scrolling. The rest of the
+    workflows are generated by Grafana's panel repeat and sit below the logs:
+    naming them here is what let `extract-text.yml` ship upstream and go
+    unmonitored, so the dashboard no longer holds a list that can fall behind.
+    """
+    return [
+        _status_grid(
+            1,
+            "Scrapers",
+            f'workflow="{SCRAPE_WORKFLOW}"',
+            y=0,
+            height=GRID_HEIGHT,
+            description=(
+                "Latest completed scrape per jurisdiction — the fleet's entry point. Red is "
+                "actionable; a dimmed tile is out of session, where a failing run is the "
+                "calendar, not a fault."
+            ),
+        ),
+        _freshness_table(2, y=GRID_HEIGHT, height=TABLE_HEIGHT),
+        _logs_panel(3, y=GRID_HEIGHT + TABLE_HEIGHT),
+        _status_grid(
+            4,
+            "$other_workflow",
+            # Regex, not exact: see _status_grid on multi-value interpolation.
+            'workflow=~"$other_workflow"',
+            y=GRID_HEIGHT + TABLE_HEIGHT + LOGS_HEIGHT,
+            height=GRID_HEIGHT,
+            description=(
+                "Latest completed run per jurisdiction for this workflow. One grid per "
+                "workflow the fleet runs besides the scrape, generated from the metric's own "
+                "labels — a workflow added to the pipeline-manager config appears here on its "
+                "next sweep, with no dashboard edit."
+            ),
+            repeat="other_workflow",
+        ),
+    ]
+
+
+def build_dashboard() -> dict:
+    """The whole dashboard as a plain dict.
+
+    ``id: None`` is deliberate: a numeric id belongs to one stack's database, so
+    carrying one would make the import either collide with or overwrite whatever
+    holds that id in the destination. The uid is the stable identity instead.
+    """
+    return {
+        "annotations": {"list": []},
+        "editable": True,
+        "graphTooltip": 0,
+        "id": None,
+        "links": [],
+        "panels": _panels(),
+        "refresh": "5m",
+        "schemaVersion": 39,
+        "tags": ["fleet-monitor"],
+        "templating": _templating(),
+        # A day covers the hourly sweep with room to see a gap; the logs panel
+        # inherits it, so the default view holds roughly a day of run logs.
+        "time": {"from": "now-24h", "to": "now"},
+        "timezone": "utc",
+        "title": "Fleet Monitor",
+        "uid": DASHBOARD_UID,
+        "version": 0,
+    }
+
+
+def encode_dashboard() -> str:
+    """The dashboard as the JSON that gets committed and imported.
+
+    Indented and key-sorted so the committed artifact reviews as a readable
+    diff, and byte-identical run to run so regenerating it proves nothing
+    drifted.
+    """
+    return json.dumps(build_dashboard(), indent=2, sort_keys=True) + "\n"

--- a/actions/fleet-monitor/dashboards/fleet-overview.json
+++ b/actions/fleet-monitor/dashboards/fleet-overview.json
@@ -1,0 +1,648 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "description": "Latest completed scrape per jurisdiction \u2014 the fleet's entry point. Red is actionable; a dimmed tile is out of session, where a failing run is the calendar, not a fault.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "FAILING"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "no data"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "paused \u00b7 last run failed"
+                      },
+                      "1": {
+                        "color": "text",
+                        "index": 1,
+                        "text": "paused \u00b7 last run ok"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 18,
+          "valueSize": 18
+        },
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(fleet_workflow_run_status{workflow=\"openstates-scrape.yml\", paused=\"false\", state=~\"$state\", org=~\"$org\"}[6h])",
+          "instant": true,
+          "legendFormat": "{{state}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(fleet_workflow_run_status{workflow=\"openstates-scrape.yml\", paused=\"true\", state=~\"$state\", org=~\"$org\"}[6h])",
+          "instant": true,
+          "legendFormat": "{{state}}",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Scrapers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "description": "Hours since the last commit touching each repo's data path, in-session repos first. Red above 48h \u2014 the same line the staleness alert fires on. A paused repo is stale by the session calendar, not by fault; read the paused column before reacting to its colour.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            }
+          },
+          "links": [
+            {
+              "title": "Filter to ${__data.fields.state}",
+              "url": "/d/fleet-monitor-overview?var-state=${__data.fields.state}&${__url_time_range}"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 48
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hours since data commit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "paused"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "In session"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "false": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "yes"
+                      },
+                      "true": {
+                        "color": "text",
+                        "index": 1,
+                        "text": "paused"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(fleet_repo_data_commit_age_hours{state=~\"$state\", org=~\"$org\"}[6h])",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Data freshness",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "paused"
+              },
+              {
+                "desc": true,
+                "field": "Value"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${logs}"
+      },
+      "description": "Harvested run logs. Failures ship in full (capped at 256 KB); successes ship their last ~100 lines. Expand a line for its run id and a link to the run.",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${logs}"
+          },
+          "editorMode": "code",
+          "expr": "{state=~\"$state\", org=~\"$org\", workflow=~\"$workflow\", outcome=~\"$outcome\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Run logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "description": "Latest completed run per jurisdiction for this workflow. One grid per workflow the fleet runs besides the scrape, generated from the metric's own labels \u2014 a workflow added to the pipeline-manager config appears here on its next sweep, with no dashboard edit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "FAILING"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "no data"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "paused \u00b7 last run failed"
+                      },
+                      "1": {
+                        "color": "text",
+                        "index": 1,
+                        "text": "paused \u00b7 last run ok"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 18,
+          "valueSize": 18
+        },
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "repeat": "other_workflow",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(fleet_workflow_run_status{workflow=~\"$other_workflow\", paused=\"false\", state=~\"$state\", org=~\"$org\"}[6h])",
+          "instant": true,
+          "legendFormat": "{{state}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(fleet_workflow_run_status{workflow=~\"$other_workflow\", paused=\"true\", state=~\"$state\", org=~\"$org\"}[6h])",
+          "instant": true,
+          "legendFormat": "{{state}}",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "$other_workflow",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "fleet-monitor"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "grafanacloud-govbot-prom",
+          "value": "grafanacloud-govbot-prom"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Metrics datasource",
+        "multi": false,
+        "name": "metrics",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "grafanacloud-govbot-logs",
+          "value": "grafanacloud-govbot-logs"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Logs datasource",
+        "multi": false,
+        "name": "logs",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${metrics}"
+        },
+        "definition": "label_values(fleet_workflow_run_status, state)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Jurisdiction",
+        "multi": true,
+        "name": "state",
+        "options": [],
+        "query": {
+          "query": "label_values(fleet_workflow_run_status, state)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${metrics}"
+        },
+        "definition": "label_values(fleet_workflow_run_status, org)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Org",
+        "multi": true,
+        "name": "org",
+        "options": [],
+        "query": {
+          "query": "label_values(fleet_workflow_run_status, org)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${metrics}"
+        },
+        "definition": "label_values(fleet_workflow_run_status, workflow)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Workflow",
+        "multi": true,
+        "name": "workflow",
+        "options": [],
+        "query": {
+          "query": "label_values(fleet_workflow_run_status, workflow)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "${logs}"
+        },
+        "definition": "label_values({state=~\".+\"}, outcome)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Log outcome",
+        "multi": true,
+        "name": "outcome",
+        "options": [],
+        "query": {
+          "label": "outcome",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{state=~\".+\"}",
+          "type": 1
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${metrics}"
+        },
+        "definition": "label_values(fleet_workflow_run_status{workflow!=\"openstates-scrape.yml\"}, workflow)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Other workflows",
+        "multi": true,
+        "name": "other_workflow",
+        "options": [],
+        "query": {
+          "query": "label_values(fleet_workflow_run_status{workflow!=\"openstates-scrape.yml\"}, workflow)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Fleet Monitor",
+  "uid": "fleet-monitor-overview",
+  "version": 0
+}

--- a/actions/fleet-monitor/fleet_config.py
+++ b/actions/fleet-monitor/fleet_config.py
@@ -15,18 +15,20 @@ DEFAULT_MARKER_OPEN = "✏️{"
 DEFAULT_MARKER_CLOSE = "}✏️"
 DEFAULT_RUNNER = "ubuntu-latest"
 
-
+# Fleets discovery finds but the monitor skips by default.
+#
 # `chn-openstates-test` mirrors the files fleet against the govbot-test org to
 # validate changes before cutting the real repos over, and its own header says
 # some locales "will fail fast ... expected, not alarming". Monitoring it would
 # put permanent expected-red on the board and page someone for it once alerting
 # lands — the same reason paused jurisdictions are never coloured red. It is
 # also 56 repos × 2 workflows of API budget: including it takes an hourly sweep
-# past the GITHUB_TOKEN ceiling once the logs leg lands.
+# to ~1000 GitHub requests, at the GITHUB_TOKEN ceiling, before the logs leg.
 #
-# A default, not a law: pass `exclude_fleets=()` to monitor everything discovery
-# finds, so the pipeline-manager configs stay the authority on what exists and
-# this is only a visible, reversible statement about what is worth alerting on.
+# A default, not a law: `--exclude-fleet` overrides it (name nothing and the
+# whole fleet is monitored), so the pipeline-manager configs stay the authority
+# on what exists and this is only a visible, reversible statement about what is
+# worth alerting on.
 EXCLUDED_FLEETS = ("chn-openstates-test",)
 
 
@@ -36,12 +38,13 @@ def read_fleet(config_dir, exclude_fleets=EXCLUDED_FLEETS):
     A fleet config is any top-level *.yml/*.yaml file with a `locales` mapping;
     the fleet name is the file's stem. Fleets named in ``exclude_fleets`` are
     skipped (see EXCLUDED_FLEETS for why the default is non-empty); passing an
-    empty collection monitors everything discovery finds. Records are sorted by (fleet, state) so
-    output is deterministic. Raises ValueError on malformed input — two fleet
-    configs sharing a stem, a non-mapping top-level section, a config without
-    org.username, a non-string locale key, a locale that isn't a mapping, a
-    locale referencing a template the config doesn't define, a non-list
-    disabled_jobs, or a referenced template with no workflow files on disk.
+    empty collection monitors everything discovery finds. Records are sorted by
+    (fleet, state) so output is deterministic. Raises ValueError on malformed
+    input — two fleet configs sharing a stem, a non-mapping top-level section, a
+    config without org.username, a non-string locale key, a locale that isn't a
+    mapping, a locale referencing a template the config doesn't define, a
+    non-list disabled_jobs, or a referenced template with no workflow files on
+    disk.
     """
     config_dir = Path(config_dir)
     excluded = set(exclude_fleets or ())

--- a/actions/fleet-monitor/main.py
+++ b/actions/fleet-monitor/main.py
@@ -9,7 +9,8 @@ import yaml
 
 sys.path.append(str(Path(__file__).parent))
 
-from fleet_config import read_fleet
+from dashboard import DASHBOARD_PATH, encode_dashboard
+from fleet_config import EXCLUDED_FLEETS, read_fleet
 from log_harvester import github_log_fetchers, harvest_logs
 from logs_shipper import encode_logs
 from metrics_shipper import encode_heartbeat, encode_metrics
@@ -52,8 +53,17 @@ def cli():
     help="Epoch-seconds timestamp for every series (default: the records' polled_at, "
          "else now); also anchors the log harvester's look-back window.",
 )
+@click.option(
+    "--exclude-fleet",
+    "exclude_fleets",
+    multiple=True,
+    default=EXCLUDED_FLEETS,
+    show_default=True,
+    help="Fleet config stem to skip (repeatable). Pass --exclude-fleet= to monitor every "
+         "fleet discovery finds, including non-production ones.",
+)
 def collect(config_dir, metrics_only, logs_only, dry_run, poller_records, log_fixture,
-            watermark_file, timestamp):
+            watermark_file, timestamp, exclude_fleets):
     """Poll the fleet and push (or print) Grafana Cloud metric and/or log payloads.
 
     Both legs share collect's exit contract — a degraded sweep must never look
@@ -71,13 +81,14 @@ def collect(config_dir, metrics_only, logs_only, dry_run, poller_records, log_fi
     failures = []
     if metrics_only:
         try:
-            _collect_metrics(config_dir, poller_records, dry_run, timestamp)
+            _collect_metrics(config_dir, poller_records, dry_run, timestamp,
+                             exclude_fleets)
         except click.ClickException as e:
             failures.append(e.message)
     if logs_only:
         try:
             log_errors = _collect_logs(config_dir, log_fixture, watermark_file, dry_run,
-                                       _harvest_now(timestamp))
+                                       _harvest_now(timestamp), exclude_fleets)
             if log_errors:
                 failures.append(f"log harvest errors on {len(log_errors)} target(s)")
         except click.ClickException as e:
@@ -86,11 +97,11 @@ def collect(config_dir, metrics_only, logs_only, dry_run, poller_records, log_fi
         raise click.ClickException("; ".join(failures))
 
 
-def _collect_metrics(config_dir, poller_records, dry_run, timestamp):
+def _collect_metrics(config_dir, poller_records, dry_run, timestamp, exclude_fleets):
     """collect's metrics leg: poll, encode, ship (or print). Raises ClickException
     on poll errors — after shipping what it has — so the caller decides whether
     that failure stands alone or merges with the logs leg's."""
-    records = _load_records(config_dir, poller_records)
+    records = _load_records(config_dir, poller_records, exclude_fleets)
 
     errored = _report_poll_errors(records)
     payload = _encode(records, timestamp if timestamp is not None else _default_timestamp(records))
@@ -140,7 +151,17 @@ def _collect_metrics(config_dir, poller_records, dry_run, timestamp):
     help="Epoch-seconds timestamp for every series (default: the records' polled_at, "
          "else now); also anchors the log harvester's look-back window.",
 )
-def run(config_dir, dry_run, poller_records, log_fixture, watermark_file, timestamp):
+@click.option(
+    "--exclude-fleet",
+    "exclude_fleets",
+    multiple=True,
+    default=EXCLUDED_FLEETS,
+    show_default=True,
+    help="Fleet config stem to skip (repeatable). Pass --exclude-fleet= to monitor every "
+         "fleet discovery finds, including non-production ones.",
+)
+def run(config_dir, dry_run, poller_records, log_fixture, watermark_file, timestamp,
+        exclude_fleets):
     """Unattended hourly sweep: poll the fleet, ship metrics + a heartbeat + logs.
 
     The orchestrator the hourly workflow invokes. Wires config reader → poller →
@@ -159,7 +180,7 @@ def run(config_dir, dry_run, poller_records, log_fixture, watermark_file, timest
     live harvest, or ``--log-fixture`` offline); a metrics-only invocation
     (``--poller-records`` alone) skips it.
     """
-    records = _load_records(config_dir, poller_records)
+    records = _load_records(config_dir, poller_records, exclude_fleets)
 
     errored = _report_poll_errors(records)
     series_timestamp = timestamp if timestamp is not None else _default_timestamp(records)
@@ -176,10 +197,10 @@ def run(config_dir, dry_run, poller_records, log_fixture, watermark_file, timest
 
     if config_dir is not None or log_fixture is not None:
         _collect_logs(config_dir, log_fixture, watermark_file, dry_run,
-                      _harvest_now(timestamp))
+                      _harvest_now(timestamp), exclude_fleets)
 
 
-def _load_records(config_dir, poller_records):
+def _load_records(config_dir, poller_records, exclude_fleets=EXCLUDED_FLEETS):
     """Records for a sweep: a pre-built --poller-records fixture (offline) or a
     live poll of --config-dir. Shared by ``collect`` and ``run``."""
     if poller_records is not None:
@@ -189,7 +210,7 @@ def _load_records(config_dir, poller_records):
             if line.strip()
         ]
     if config_dir is not None:
-        return _poll_live(config_dir)
+        return _poll_live(config_dir, exclude_fleets)
     raise click.ClickException("pass --config-dir (live poll) or --poller-records (fixture)")
 
 
@@ -245,7 +266,7 @@ def _default_timestamp(records):
     return int(time.time())
 
 
-def _poll_live(config_dir):
+def _poll_live(config_dir, exclude_fleets=EXCLUDED_FLEETS):
     """Read the fleet config and poll GitHub for every repo's current state."""
     import os
 
@@ -255,7 +276,7 @@ def _poll_live(config_dir):
             "costs ~336 requests and the unauthenticated GitHub limit is 60/hour"
         )
     try:
-        jurisdictions = read_fleet(config_dir)
+        jurisdictions = read_fleet(config_dir, exclude_fleets)
     except (ValueError, yaml.YAMLError) as e:
         raise click.ClickException(str(e)) from e
     from fleet_poller import poll_fleet
@@ -289,7 +310,7 @@ def _harvest_now(timestamp):
     return datetime.now(timezone.utc)
 
 
-def _log_sources(config_dir, log_fixture, now):
+def _log_sources(config_dir, log_fixture, now, exclude_fleets=EXCLUDED_FLEETS):
     """Resolve (jurisdictions, fetch_runs, fetch_archive) for the logs leg: an
     offline fixture directory, or a live GitHub harvest of the fleet config.
     ``now`` is the harvest anchor, threaded into the live fetchers so pagination
@@ -300,7 +321,7 @@ def _log_sources(config_dir, log_fixture, now):
         # Same clean-error contract as _poll_live and list-fleet: a malformed
         # config is a CLI error line, never a raw traceback.
         try:
-            jurisdictions = read_fleet(config_dir)
+            jurisdictions = read_fleet(config_dir, exclude_fleets)
         except (ValueError, yaml.YAMLError) as e:
             raise click.ClickException(str(e)) from e
         fetch_runs, fetch_archive = github_log_fetchers(now)
@@ -335,7 +356,7 @@ def _load_log_fixture(directory):
     return jurisdictions, fetch_runs, fetch_archive
 
 
-def _collect_logs(config_dir, log_fixture, watermark_file, dry_run, now):
+def _collect_logs(config_dir, log_fixture, watermark_file, dry_run, now, exclude_fleets):
     """Harvest new-run logs and print (dry-run) or push them to Loki. Returns the
     per-repo harvest errors so ``collect`` can turn them into a nonzero exit while
     ``run`` keeps them green.
@@ -356,7 +377,8 @@ def _collect_logs(config_dir, log_fixture, watermark_file, dry_run, now):
     a red run means the collector needs attention, but it never un-ships the
     fleet's progress.
     """
-    jurisdictions, fetch_runs, fetch_archive = _log_sources(config_dir, log_fixture, now)
+    jurisdictions, fetch_runs, fetch_archive = _log_sources(config_dir, log_fixture, now,
+                                                            exclude_fleets)
     watermarks = (
         load_watermarks(watermark_file, warn=lambda message: click.echo(message, err=True))
         if watermark_file
@@ -414,14 +436,137 @@ def _collect_logs(config_dir, log_fixture, watermark_file, dry_run, now):
     required=True,
     help="Directory holding pipeline-manager config YAMLs and their templates/ folder.",
 )
-def list_fleet(config_dir: Path):
+@click.option(
+    "--exclude-fleet",
+    "exclude_fleets",
+    multiple=True,
+    default=EXCLUDED_FLEETS,
+    show_default=True,
+    help="Fleet config stem to skip (repeatable). Pass --exclude-fleet= to monitor every "
+         "fleet discovery finds, including non-production ones.",
+)
+def list_fleet(config_dir: Path, exclude_fleets):
     """Print one JSON Lines jurisdiction record per locale per fleet."""
     try:
-        records = read_fleet(config_dir)
+        records = read_fleet(config_dir, exclude_fleets)
     except (ValueError, yaml.YAMLError) as e:
         raise click.ClickException(str(e)) from e
     for record in records:
         click.echo(json.dumps(record, ensure_ascii=False))
+
+
+@cli.command("dashboard")
+@click.option(
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help=f"Write the dashboard JSON here instead of stdout (committed at {DASHBOARD_PATH}).",
+)
+def dashboard(out):
+    """Emit the fleet-overview dashboard JSON, ready to import into any stack.
+
+    The dashboard is built as data (dashboard.py) and committed rendered
+    (dashboards/fleet-overview.json) so it reviews as code and imports as JSON.
+    Datasource references are variables, not UIDs, so the same file imports into
+    any Grafana Cloud stack; nothing here is specific to the account it was
+    developed against.
+    """
+    text = encode_dashboard()
+    if out:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text)
+        click.echo(f"wrote {out}", err=True)
+    else:
+        click.echo(text, nl=False)
+
+
+@cli.command("check-dashboard")
+def check_dashboard():
+    """Import the committed dashboard into a real stack and read it back; skips
+    without credentials.
+
+    A dashboard that only ever renders in the browser it was built in is not
+    reproducible, so the check is the import itself: POST the JSON to the
+    stack's dashboards API, then GET it by uid. The read-back matters — Grafana
+    answers the push before it has stored anything renderable, and a payload it
+    quietly mangles still returns 200.
+
+    Needs GRAFANA_DASHBOARD_URL (the stack base URL) and GRAFANA_DASHBOARD_KEY
+    (a service-account token with dashboards write; bearer-authed, unlike the
+    Basic-auth push endpoints). Exits 0 with a skip notice otherwise, so an
+    offline run passes without a Grafana account.
+    """
+    import os
+
+    names = ["GRAFANA_DASHBOARD_URL", "GRAFANA_DASHBOARD_KEY"]
+    missing = [name for name in names if not os.environ.get(name)]
+    if missing:
+        click.echo(f"dashboard check skipped: missing {', '.join(missing)}")
+        return
+
+    from dashboard import DASHBOARD_UID, build_dashboard
+    from http_util import RequestFailed, request_json, request_with_retry
+
+    base = os.environ["GRAFANA_DASHBOARD_URL"].rstrip("/")
+    auth = {"Authorization": f"Bearer {os.environ['GRAFANA_DASHBOARD_KEY']}"}
+    board = build_dashboard()
+    payload = json.dumps({
+        "dashboard": board,
+        # Idempotent by uid: re-running the check updates the same dashboard
+        # instead of erroring on the second run or littering copies.
+        "overwrite": True,
+        "message": "fleet-monitor import check",
+    }).encode()
+    try:
+        request_with_retry(
+            f"{base}/api/dashboards/db",
+            data=payload,
+            headers={**auth, "Content-Type": "application/json"},
+        )
+    except RequestFailed as e:
+        raise click.ClickException(f"dashboard import rejected: {e}") from e
+
+    try:
+        loaded = request_json(f"{base}/api/dashboards/uid/{DASHBOARD_UID}", headers=auth)
+    except RequestFailed as e:
+        raise click.ClickException(f"dashboard imported but does not load back: {e}") from e
+    panels = loaded.get("dashboard", {}).get("panels", [])
+    if len(panels) != len(board["panels"]):
+        raise click.ClickException(
+            f"dashboard loaded with {len(panels)} panels, expected {len(board['panels'])}"
+        )
+    # Panels alone are not proof. Every panel filters on `=~"$state"` and points
+    # at `${metrics}`/`${logs}`, so a variable Grafana declined to migrate leaves
+    # all five panels present and all five rendering nothing — a blank board that
+    # a panel count reports as a clean import.
+    stored = {
+        v.get("name"): v
+        for v in loaded.get("dashboard", {}).get("templating", {}).get("list", [])
+    }
+    want = {v["name"] for v in board["templating"]["list"]}
+    if want - set(stored):
+        raise click.ClickException(
+            f"dashboard imported without variable(s) {', '.join(sorted(want - set(stored)))}; "
+            "panels would render empty"
+        )
+    # Presence by name is not enough — that is precisely how the first broken
+    # import passed. A picker stripped of its all-value, or repointed at the
+    # wrong datasource, resolves to nothing and blanks every panel that filters
+    # on it while the name sits there looking fine. Only the fields that decide
+    # whether a picker resolves are compared; the query object itself is left
+    # alone, since Grafana may legitimately normalise it on store.
+    for variable in board["templating"]["list"]:
+        landed = stored[variable["name"]]
+        for field in ("allValue", "datasource"):
+            if field in variable and landed.get(field) != variable[field]:
+                raise click.ClickException(
+                    f"variable {variable['name']} imported with {field}="
+                    f"{landed.get(field)!r}, expected {variable[field]!r}; "
+                    "it would resolve to nothing and blank every panel using it"
+                )
+    click.echo(
+        f"✓ dashboard imports and loads back with all {len(panels)} panels "
+        f"and {len(want)} variables"
+    )
 
 
 @cli.command("live-check")

--- a/actions/fleet-monitor/render-snapshots.sh
+++ b/actions/fleet-monitor/render-snapshots.sh
@@ -1349,21 +1349,30 @@ if [ "$real_count" -lt 1 ]; then
 fi
 echo "✓ real-config smoke: $real_count records from ../pipeline-manager"
 
-# API budget: the sweep runs hourly, so one sweep must fit inside one hour of
-# the default GITHUB_TOKEN allowance (1000/hour). Not snapshotted — the count
-# moves with the fleet; this locks the ceiling, not the number.
+# API budget: one sweep of the real fleet, against the GITHUB_TOKEN ceiling of
+# 1000 requests/hour. Not snapshotted — the count moves with the fleet; this
+# locks the ceiling, not the number.
+#
+# It counts BOTH legs. The old check looked only at the metrics leg against a
+# flat 400, which understated a sweep by the logs leg's run-listing request per
+# workflow — and it fired for real when upstream added a third fleet config plus
+# a second production workflow, at which point the true cost was over the
+# ceiling, not merely over 400. Budget the whole sweep or the tripwire lies.
 pipenv run python3 - <<'EOF'
-from fleet_config import EXCLUDED_FLEETS, read_fleet
+from fleet_config import read_fleet
 from fleet_poller import DATA_PATHS, estimate_request_count
 
-# A flat ceiling goes stale the moment the fleet grows, so derive it from the
-# limit the sweep actually runs against. This counts BOTH legs: budgeting the
-# metrics leg alone understates a sweep and would let the real cost cross the
-# ceiling before anything complained.
+# GITHUB_TOKEN's documented limit for an Actions workflow, and the sweep runs
+# hourly, so one sweep must fit inside one hour's budget with room for the
+# archive downloads (one per NEW run, unpredictable and unbounded by config).
+# 80% leaves ~200 requests/hour for those; the measured fleet sits at ~62%.
 TOKEN_LIMIT_PER_HOUR = 1000
 HEADROOM = 0.8
+
 records = read_fleet("../pipeline-manager")
 metrics_requests = estimate_request_count(records)
+# The logs leg lists runs once per workflow; archive downloads are extra and
+# depend on how many runs actually finished, which is why the ceiling keeps 40%.
 logs_requests = sum(len(r["expected_workflows"]) for r in records)
 count = metrics_requests + logs_requests
 budget = int(TOKEN_LIMIT_PER_HOUR * HEADROOM)
@@ -1372,19 +1381,14 @@ assert count < budget, (
     f"{logs_requests} log listings) against a {TOKEN_LIMIT_PER_HOUR}/hour token limit; "
     "revisit the polling strategy or exclude a fleet"
 )
+utilisation = 100 * count / TOKEN_LIMIT_PER_HOUR
 print(f"✓ API budget: one sweep of the real fleet = {count} GitHub requests "
       f"({metrics_requests} metrics + {logs_requests} log listings) = "
-      f"{100 * count / TOKEN_LIMIT_PER_HOUR:.0f}% of the {TOKEN_LIMIT_PER_HOUR}/hour token limit")
-
-# The test fleet is skipped by default, but the config stays the authority:
-# opting out restores everything. Both directions are checked, because a skip
-# that could not be undone would make this module, not the config, the authority.
-fleets = {r["fleet"] for r in records}
-assert not fleets & set(EXCLUDED_FLEETS), sorted(fleets & set(EXCLUDED_FLEETS))
-everything = {r["fleet"] for r in read_fleet("../pipeline-manager", exclude_fleets=())}
-skipped = everything - fleets
-print(f"✓ fleet exclusion: monitoring {sorted(fleets)}"
-      + (f", skipping {sorted(skipped)}" if skipped else " (nothing to skip in this checkout)"))
+      f"{utilisation:.0f}% of the {TOKEN_LIMIT_PER_HOUR}/hour token limit")
+if utilisation > 60:
+    # Not a failure — a heads-up that the next fleet or workflow may not fit.
+    print(f"· note: the sweep is over 60% of the token budget; one more fleet or "
+          f"workflow would need a polling-strategy change")
 
 # Every real-fleet base template needs a DATA_PATHS entry, or the first live
 # sweep after a new template ships would fail at startup while snapshots
@@ -1392,6 +1396,467 @@ print(f"✓ fleet exclusion: monitoring {sorted(fleets)}"
 missing = {r["base_template"] for r in records} - DATA_PATHS.keys()
 assert not missing, f"real-fleet base template(s) missing from DATA_PATHS: {sorted(missing)}"
 print("✓ data paths: every real-fleet base template has a DATA_PATHS entry")
+
+# Non-production fleets stay out of the sweep by default. `chn-openstates-test`
+# mirrors the files fleet against govbot-test and its own header says some
+# locales are expected to fail — monitoring it would put permanent expected-red
+# on the board, page someone once alerting lands, and (with its 56 repos ×
+# 2 workflows) take the sweep over the token ceiling above.
+from fleet_config import EXCLUDED_FLEETS
+
+fleets = {r["fleet"] for r in records}
+assert not fleets & set(EXCLUDED_FLEETS), sorted(fleets & set(EXCLUDED_FLEETS))
+# ...but the config stays the authority: opting out restores everything, so the
+# skip is a visible, reversible statement about what is worth alerting on.
+everything = {r["fleet"] for r in read_fleet("../pipeline-manager", exclude_fleets=())}
+skipped = everything - fleets
+print(f"✓ fleet exclusion: monitoring {sorted(fleets)}"
+      + (f", skipping {sorted(skipped)}" if skipped else " (nothing to skip in this checkout)"))
+EOF
+
+# Dashboard: built as data, committed rendered. The checks below are the whole
+# test for it — there is no snapshot file, because the committed artifact
+# (dashboards/fleet-overview.json) IS the snapshot: the drift check further down
+# regenerates it and fails if the repo copy no longer matches the builder.
+pipenv run python3 - <<'EOF'
+import json
+import re
+
+from dashboard import (DEFAULT_LOGS_DATASOURCE, DEFAULT_METRICS_DATASOURCE,
+                       OBSERVED_MAX_SWEEP_GAP_HOURS, SCRAPE_WORKFLOW, build_dashboard,
+                       encode_dashboard)
+
+board = build_dashboard()
+panels = {p["title"]: p for p in board["panels"] if "title" in p}
+variables = {v["name"]: v for v in board["templating"]["list"]}
+
+
+def colors(node):
+    """Every colour named anywhere under a panel, however nested."""
+    found = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "color" and isinstance(value, str):
+                found.append(value)
+            elif key == "color" and isinstance(value, dict) and "fixedColor" in value:
+                found.append(value["fixedColor"])
+            else:
+                found.extend(colors(value))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(colors(item))
+    return found
+
+
+def datasource_uids(node):
+    found = []
+    if isinstance(node, dict):
+        if set(node) >= {"type", "uid"} and node["type"] in ("prometheus", "loki"):
+            found.append(node["uid"])
+        for value in node.values():
+            found.extend(datasource_uids(value))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(datasource_uids(item))
+    return found
+
+
+# 1. Datasources are pickers, not UIDs — a UID belongs to one stack, and the
+#    committed JSON has to import into any of them.
+assert variables["metrics"]["type"] == "datasource", variables["metrics"]
+assert variables["metrics"]["query"] == "prometheus", variables["metrics"]
+assert variables["logs"]["query"] == "loki", variables["logs"]
+# ...and each defaults to this fleet's own stack, because the import screen never
+# asks and Grafana's own fallback is the first datasource of the type in name
+# order — on Grafana Cloud as likely to be grafanacloud-usage as the real one.
+assert variables["metrics"]["current"]["value"] == DEFAULT_METRICS_DATASOURCE, variables["metrics"]
+assert variables["logs"]["current"]["value"] == DEFAULT_LOGS_DATASOURCE, variables["logs"]
+uids = datasource_uids(board["panels"])
+assert uids, "no panel datasource references found"
+assert set(uids) <= {"${metrics}", "${logs}"}, sorted(set(uids))
+
+# 2. A fresh stack must accept this as a NEW dashboard; a numeric id would
+#    collide with whatever holds it there.
+assert board["id"] is None, board["id"]
+assert board["uid"] == "fleet-monitor-overview", board["uid"]
+ids = [p["id"] for p in board["panels"]]
+assert len(ids) == len(set(ids)), ids
+
+# 2b. The collector sweeps hourly and an instant query looks back only 5
+#     minutes, so a bare selector leaves every metric panel empty for ~55
+#     minutes of each hour — a whole-board "No data" that every offline check
+#     here would otherwise pass. Observed on a real import; locked so it cannot
+#     come back.
+#
+#     Derived from the board, not a hand-written list of titles: a sixth metric
+#     panel added later must be covered too, or the same regression returns for
+#     it with a green suite. And the window is asserted against a measured sweep
+#     gap rather than against LOOKBACK itself — importing the constant under test
+#     would let LOOKBACK="1m" reintroduce the exact bug and stay green.
+#
+#     The gap is MEASURED, not the cron expression. The workflow says hourly;
+#     GitHub runs scheduled workflows best-effort and on a fork's non-default
+#     branch they drift hard — 25 consecutive sweeps showed a median of 2.0h and
+#     a max of 3.6h. Sizing the window off "0 * * * *" is what blanked the board
+#     a second time, so this asserts real headroom over the observed worst case.
+metric_panels = [
+    p for p in board["panels"]
+    if p.get("datasource", {}).get("uid") == "${metrics}"
+]
+assert len(metric_panels) == 3, [p.get("title") for p in metric_panels]
+for panel in metric_panels:
+    target = panel["targets"][0]
+    expr = target["expr"]
+    assert expr.startswith("last_over_time("), (panel["title"], expr)
+    window = re.search(r"\[(\d+)([smh])\]\)$", expr)
+    assert window, (panel["title"], expr)
+    hours = int(window.group(1)) * {"s": 1 / 3600, "m": 1 / 60, "h": 1}[window.group(2)]
+    assert hours >= 1.5 * OBSERVED_MAX_SWEEP_GAP_HOURS, (panel["title"], expr, hours)
+    # Still an instant vector, so the table transformations and the stat
+    # reducer keep working unchanged.
+    assert target["instant"] is True, (panel["title"], target)
+assert OBSERVED_MAX_SWEEP_GAP_HOURS >= 3.6, OBSERVED_MAX_SWEEP_GAP_HOURS
+
+# 3. One status grid per workflow — 112 tiles in a single panel shrank the text
+#    past legibility, so the split is the readability fix, not decoration.
+#    Scrapers is pinned to the top (the fleet's entry point, worth seeing without
+#    scrolling); every OTHER workflow is generated by Grafana's panel repeat and
+#    sits after the logs. Only the scrape may be named in dashboard.py: a
+#    hardcoded workflow list is how `extract-text.yml` shipped upstream and went
+#    unmonitored, and no offline check could have caught it.
+ordered = sorted((p["gridPos"]["y"], p["title"]) for p in board["panels"] if "title" in p)
+titles = [t for _, t in ordered]
+assert titles[0] == "Scrapers", titles
+assert titles.index("Data freshness") < titles.index("Run logs"), titles
+
+scrapers = panels["Scrapers"]
+assert f'workflow="{SCRAPE_WORKFLOW}"' in scrapers["targets"][0]["expr"], scrapers["targets"][0]
+assert "repeat" not in scrapers, scrapers.get("repeat")
+
+repeated = next(p for p in board["panels"] if p.get("repeat"))
+assert repeated["repeat"] == "other_workflow", repeated["repeat"]
+assert repeated["title"] == "$other_workflow", repeated["title"]
+# REGEX matcher, never exact. Grafana interpolates a multi-value variable into a
+# Prometheus query using the regex form — `(format.yml)`, parentheses included —
+# even where a repeat has scoped it to one value, so `workflow="$var"` compares
+# against a literal "(format.yml)" and matches nothing. That renders "No data"
+# under a title that interpolated as plain text and reads perfectly right, which
+# is exactly how it shipped. The rule is asserted over every panel below.
+assert 'workflow=~"$other_workflow"' in repeated["targets"][0]["expr"], repeated["targets"][0]
+for panel in board["panels"]:
+    for target in panel.get("targets", []):
+        assert '="$' not in target.get("expr", ""), (panel.get("title"), target.get("expr"))
+# After the logs, as laid out deliberately.
+assert repeated["gridPos"]["y"] > panels["Run logs"]["gridPos"]["y"], ordered
+# The repeat variable is every workflow EXCEPT the pinned one, excluded in the
+# query itself — otherwise the scrapers grid renders a second time at the bottom.
+other = variables["other_workflow"]
+assert other["type"] == "query", other
+assert f'workflow!="{SCRAPE_WORKFLOW}"' in other["query"]["query"], other["query"]
+assert other["multi"] and other["includeAll"], other
+
+for grid in (scrapers, repeated):
+    # A tile is its jurisdiction and nothing else: the workflow is the panel it
+    # sits in now, so repeating it per tile only shrank the identifying part.
+    assert grid["targets"][0]["legendFormat"] == "{{state}}", grid["targets"][0]
+    # ...rendered as large as the OK/FAILING beside it.
+    text = grid["options"]["text"]
+    assert text["titleSize"] == text["valueSize"], text
+    for target in grid["targets"]:
+        assert target["instant"] is True, target
+
+    # Paused jurisdictions live in the SAME grid (a separate panel was an empty
+    # box whenever the whole fleet was in session), dimmed via an override on
+    # the second query's frame — the only way Grafana will colour some tiles by
+    # value and leave others flat.
+    active, paused = grid["targets"]
+    assert 'paused="false"' in active["expr"], active["expr"]
+    assert 'paused="true"' in paused["expr"], paused["expr"]
+    assert paused["refId"] == "B", paused
+    options = grid["fieldConfig"]["defaults"]["mappings"][0]["options"]
+    assert options["0"] == {"color": "red", "index": 0, "text": "FAILING"}, options
+    assert options["1"] == {"color": "green", "index": 1, "text": "OK"}, options
+    override = next(
+        o for o in grid["fieldConfig"]["overrides"]
+        if o["matcher"] == {"id": "byFrameRefID", "options": "B"}
+    )
+    properties = {p["id"]: p["value"] for p in override["properties"]}
+    assert properties["color"] == {"fixedColor": "text", "mode": "fixed"}, properties
+    paused_options = properties["mappings"][0]["options"]
+    assert paused_options["0"]["text"].startswith("paused"), paused_options
+    assert paused_options["1"]["text"].startswith("paused"), paused_options
+    # A paused tile is never red, whatever its last run did.
+    assert "red" not in repr(properties).lower(), properties
+
+# 4. One full-width freshness table for the whole fleet, red exactly at the 48h
+#    alert line (one number, so dashboard and alert can never disagree), paused
+#    carried as a column rather than a second table, in-session rows first with
+#    the worst staleness on top, and every row linking to its own filtered view.
+fresh = panels["Data freshness"]
+assert "Data freshness · paused" not in panels, list(panels)
+assert fresh["gridPos"]["w"] == 24, fresh["gridPos"]
+target = fresh["targets"][0]
+assert "fleet_repo_data_commit_age_hours{" in target["expr"], target["expr"]
+assert target["instant"] is True and target["format"] == "table", target
+# No paused filter: one query covers the fleet.
+assert "paused=" not in target["expr"], target["expr"]
+# ...and the paused label survives as a column rather than being dropped.
+organize = next(t for t in fresh["transformations"] if t["id"] == "organize")
+assert not organize["options"]["excludeByName"].get("paused"), organize
+sort = next(t for t in fresh["transformations"] if t["id"] == "sortBy")["options"]["sort"]
+assert sort[0] == {"desc": False, "field": "paused"}, sort
+assert sort[1] == {"desc": True, "field": "Value"}, sort
+steps = fresh["fieldConfig"]["defaults"]["thresholds"]["steps"]
+assert {"color": "red", "value": 48} in steps, steps
+assert any(s["color"] == "green" and s["value"] is None for s in steps), steps
+# The paused column is a label, not a measurement: it must not be coloured by
+# the staleness thresholds.
+paused_column = next(
+    o for o in fresh["fieldConfig"]["overrides"] if o["matcher"]["options"] == "paused"
+)
+paused_properties = {p["id"]: p["value"] for p in paused_column["properties"]}
+assert paused_properties["custom.cellOptions"] == {"type": "auto"}, paused_properties
+assert "red" not in repr(paused_properties).lower(), paused_properties
+# The row link narrows the whole board through the single `state` picker. It is
+# an absolute dashboard path: a bare "?var=..." relative URL rewrote the address
+# bar and re-ran nothing, so the link looked live and did nothing.
+links = fresh["fieldConfig"]["defaults"]["links"]
+assert links, "no data link on the freshness table"
+assert links[0]["url"].startswith("/d/fleet-monitor-overview"), links
+assert "var-state=${__data.fields.state}" in links[0]["url"], links
+# The jurisdiction, not one of its two repos: var-org would hide the sibling.
+assert "var-org=" not in links[0]["url"], links
+# Carry the chosen time range through, so a drill-down does not silently reset it.
+assert "${__url_time_range}" in links[0]["url"], links
+
+# 5. The logs panel filters on every stream label the harvester ships, each as a
+#    regex matcher so multi-select "All" and a single pick both work. Run id
+#    and run URL are structured metadata, not labels, so they surface by
+#    expanding a line — log details must stay on.
+#
+#    One jurisdiction picker drives the whole board — grids, table, and logs —
+#    so the filter shown at the top is the filter applied everywhere.
+logs = panels["Run logs"]
+assert logs["type"] == "logs", logs["type"]
+for label in ("state", "org", "workflow", "outcome"):
+    assert f'{label}=~"${label}"' in logs["targets"][0]["expr"], logs["targets"][0]["expr"]
+assert "log_state" not in repr(board["templating"]), "a second jurisdiction picker came back"
+for title in ("Scrapers", "Data freshness", "$other_workflow"):
+    assert 'state=~"$state"' in panels[title]["targets"][0]["expr"], title
+assert logs["options"]["enableLogDetails"] is True, logs["options"]
+assert logs["options"]["sortOrder"] == "Descending", logs["options"]
+
+# 6. Pickers are label-driven (a new jurisdiction appears without a dashboard
+#    edit) and URL-synced, which is what makes a filtered view a shareable link.
+#    Each speaks its own datasource's variable-query dialect: a Prometheus-shaped
+#    query on the Loki picker leaves it empty, which blanks the logs panel.
+for name in ("state", "org", "workflow"):
+    variable = variables[name]
+    assert variable["type"] == "query", variable
+    assert variable["datasource"]["type"] == "prometheus", variable
+    assert variable["query"]["query"] == f"label_values(fleet_workflow_run_status, {name})", variable
+    # Editor-state keys are deliberately absent: a partial set opens the
+    # variable editor half-populated, and saving from there writes back an
+    # empty label_values() that resolves to nothing.
+    assert set(variable["query"]) == {"query", "refId"}, variable
+    assert variable["multi"] and variable["includeAll"], variable
+outcome = variables["outcome"]
+assert outcome["datasource"]["type"] == "loki", outcome
+# Loki's own dialect (type 1 = label values), scoped to fleet streams so another
+# producer's `outcome` label in the same logs instance can't leak into the picker.
+assert outcome["query"]["type"] == 1 and outcome["query"]["label"] == "outcome", outcome
+assert outcome["query"]["stream"] == '{state=~".+"}', outcome
+# Every picker needs an explicit allValue: blank, Grafana expands "All" to an
+# alternation of the options it resolved, and to the EMPTY STRING when it
+# resolved none — turning each =~ matcher into one that matches nothing. A
+# not-yet-populated picker would silently blank every panel that uses it.
+#
+# It must be ".+", not ".*": LogQL rejects a stream selector whose every matcher
+# is empty-compatible, so with all four pickers on All (the default on a fresh
+# import) ".*" makes the logs panel a parse error rather than an empty result.
+for name in ("state", "org", "workflow", "outcome", "other_workflow"):
+    assert variables[name]["allValue"] == ".+", variables[name]
+    assert variables[name].get("skipUrlSync") is not True, variables[name]
+
+# Proven on the rendered selector, not just the variable: interpolate every
+# picker to its All value and confirm the logs query still holds one matcher
+# that cannot match empty.
+interpolated = re.sub(r"\$(state|org|workflow|outcome)", ".+", logs["targets"][0]["expr"])
+matchers = re.findall(r'(\w+)\s*=~\s*"([^"]*)"', interpolated)
+assert matchers, interpolated
+assert any(not re.fullmatch(value, "") for _, value in matchers), interpolated
+
+# 7. Nothing volatile in the encoding — a timestamp or a run-varying id would
+#    make the committed artifact drift on every render. (Determinism itself is
+#    proven by the byte diff against the committed JSON further down, which is a
+#    real oracle; comparing encode_dashboard() to itself in one process is not.)
+encoded = encode_dashboard()
+assert not re.search(r"20\d\d-\d\d-\d\dT", encoded), "a timestamp leaked into the dashboard"
+print(f"✓ dashboard: {len(board['panels'])} panels, parameterized datasources, "
+      "scrapers before formatters, paused dimmed inline, logs filtered on all four labels")
+EOF
+
+# The committed dashboard must be exactly what the builder produces — otherwise
+# the JSON people import and the code reviewers read have quietly diverged.
+dashboard_tmp=$(mktemp)
+pipenv run python3 main.py dashboard > "$dashboard_tmp"
+if ! diff -u dashboards/fleet-overview.json "$dashboard_tmp"; then
+  echo "✗ dashboards/fleet-overview.json is stale; regenerate it:"
+  echo "    pipenv run python3 main.py dashboard --out dashboards/fleet-overview.json"
+  rm -f "$dashboard_tmp"
+  exit 1
+fi
+rm -f "$dashboard_tmp"
+echo "✓ dashboard: committed dashboards/fleet-overview.json matches the builder"
+
+# The import check pushes to a real stack, so like every other live path it must
+# self-skip without credentials; the offline suite locks that skip.
+dashboard_skip=$(env -u GRAFANA_DASHBOARD_URL -u GRAFANA_DASHBOARD_KEY \
+  pipenv run python3 main.py check-dashboard 2>&1)
+if ! echo "$dashboard_skip" | grep -q "dashboard check skipped"; then
+  echo "✗ check-dashboard without credentials should skip cleanly; got:"
+  echo "$dashboard_skip"
+  exit 1
+fi
+echo "✓ check-dashboard: skips cleanly when credentials are absent"
+
+# Offline proof of the import itself: a fake Grafana answers the push and the
+# read-back, so the request shape (endpoint, bearer auth, overwrite-by-uid) and
+# the rejection path are both tested without an account. The real import runs
+# opt-in below.
+pipenv run python3 - <<'EOF'
+import json
+import urllib.error
+import urllib.request
+from io import BytesIO
+
+from click.testing import CliRunner
+
+import main
+from dashboard import DASHBOARD_UID, build_dashboard
+
+CREDS = {"GRAFANA_DASHBOARD_URL": "https://stack.grafana.net/", "GRAFANA_DASHBOARD_KEY": "tok"}
+
+
+class FakeResponse(BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def run(env, respond):
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(request)
+        return respond(request)
+
+    real, urllib.request.urlopen = urllib.request.urlopen, fake_urlopen
+    try:
+        return CliRunner().invoke(main.cli, ["check-dashboard"], env=env), calls
+    finally:
+        urllib.request.urlopen = real
+
+
+def happy(request):
+    if request.full_url.endswith("/api/dashboards/db"):
+        return FakeResponse(json.dumps({"uid": DASHBOARD_UID, "status": "success"}).encode())
+    return FakeResponse(json.dumps({"dashboard": build_dashboard()}).encode())
+
+
+ok, calls = run(CREDS, happy)
+assert ok.exit_code == 0, ok.output + str(ok.exception)
+posted, fetched = calls[0], calls[-1]
+assert posted.full_url == "https://stack.grafana.net/api/dashboards/db", posted.full_url
+assert posted.get_header("Authorization") == "Bearer tok", posted.header_items()
+body = json.loads(posted.data)
+assert body["dashboard"]["uid"] == DASHBOARD_UID, body["dashboard"]["uid"]
+# Idempotent by uid: a re-run updates the same dashboard rather than erroring or
+# littering copies across the stack.
+assert body["overwrite"] is True, body
+# A 200 on the push is not proof it renders, so the check reads it back by uid.
+assert fetched.full_url == f"https://stack.grafana.net/api/dashboards/uid/{DASHBOARD_UID}", (
+    fetched.full_url
+)
+
+
+def rejected(request):
+    raise urllib.error.HTTPError(request.full_url, 400, "Bad Request", {}, None)
+
+
+bad, _ = run(CREDS, rejected)
+assert bad.exit_code != 0, bad.output
+assert "400" in bad.output, bad.output
+
+# A push that succeeds but comes back missing panels is a failure, not a pass:
+# Grafana will happily store a payload it then renders as an empty dashboard.
+def truncated(request):
+    if request.full_url.endswith("/api/dashboards/db"):
+        return FakeResponse(json.dumps({"status": "success"}).encode())
+    return FakeResponse(json.dumps({"dashboard": {"panels": []}}).encode())
+
+
+empty, _ = run(CREDS, truncated)
+assert empty.exit_code != 0, empty.output
+assert "0 panels" in empty.output, empty.output
+
+
+# Panels alone are not proof of a working import. Every panel filters on
+# `=~"$state"` and points at `${metrics}`/`${logs}`, so a variable Grafana
+# declined to migrate leaves all five panels present and all five rendering
+# nothing — a blank board that a panel count reports as a clean import. This is
+# the check that was missing when a real import came back all "No data".
+def loads_as(dashboard):
+    def respond(request):
+        if request.full_url.endswith("/api/dashboards/db"):
+            return FakeResponse(json.dumps({"uid": DASHBOARD_UID, "status": "success"}).encode())
+        return FakeResponse(json.dumps({"dashboard": dashboard}).encode())
+
+    return respond
+
+
+board = build_dashboard()
+for dropped in ("state", "outcome", "metrics"):
+    mangled = json.loads(json.dumps(board))
+    mangled["templating"]["list"] = [
+        v for v in mangled["templating"]["list"] if v["name"] != dropped
+    ]
+    lost, _ = run(CREDS, loads_as(mangled))
+    assert lost.exit_code != 0, (dropped, lost.output)
+    assert dropped in lost.output, (dropped, lost.output)
+
+none_at_all = json.loads(json.dumps(board))
+none_at_all["templating"] = {"list": []}
+blank, _ = run(CREDS, loads_as(none_at_all))
+assert blank.exit_code != 0, blank.output
+
+
+# Presence by name is not enough — that is exactly how the first broken import
+# passed. A picker stripped of its all-value, or repointed at the wrong
+# datasource, resolves to nothing and blanks every panel that filters on it.
+def mangled(name, key, value):
+    copy = json.loads(json.dumps(board))
+    for variable in copy["templating"]["list"]:
+        if variable["name"] == name:
+            variable[key] = value
+    return copy
+
+
+for name, key, value in (
+    ("state", "allValue", ""),
+    ("outcome", "datasource", {"type": "prometheus", "uid": "${metrics}"}),
+):
+    hollow, _ = run(CREDS, loads_as(mangled(name, key, value)))
+    assert hollow.exit_code != 0, (name, key, hollow.output)
+    assert name in hollow.output, (name, key, hollow.output)
+
+intact, _ = run(CREDS, loads_as(board))
+assert intact.exit_code == 0, intact.output + str(intact.exception)
+assert f"{len(board['templating']['list'])} variables" in intact.output, intact.output
+print("✓ check-dashboard: pushes by uid, reads back panels AND variables, fails on rejection, "
+      "on a hollow import, on a dropped picker, and on one that survives in name only")
 EOF
 
 # Live check self-skips without credentials (exit 0, says so) — CI has no
@@ -1427,6 +1892,15 @@ if [ "${FLEET_MONITOR_LIVE_CHECK:-}" = "1" ]; then
   pipenv run python3 main.py live-check --config-dir ../pipeline-manager
 else
   echo "· live-check (real push + query-back) not run; opt in with FLEET_MONITOR_LIVE_CHECK=1"
+fi
+
+# Same bargain for the dashboard import: it writes a real dashboard into a real
+# stack, so a bare render never does it even on a machine with GRAFANA_DASHBOARD_*
+# set. Opting in makes the render the automated import check.
+if [ "${FLEET_MONITOR_DASHBOARD_CHECK:-}" = "1" ]; then
+  pipenv run python3 main.py check-dashboard
+else
+  echo "· check-dashboard (real import) not run; opt in with FLEET_MONITOR_DASHBOARD_CHECK=1"
 fi
 
 echo "✓ Snapshot generation complete. Output in $output_dir"


### PR DESCRIPTION
Part of #36. Builds on #118.

One dashboard answers the whole question — anything red, anything stale, and what did it say — and it's committed rather than hand-built, so the Grafana side is reproducible.

**`dashboard.py`** builds it as data; **`dashboards/fleet-overview.json`** is that build, rendered and committed. The render script re-renders and fails if the committed copy has drifted, but does not rewrite it — so the file in the repo can never quietly stop matching the code that explains it. The JSON is what you import; the module is what you review.

**Layout follows the dependency chain.** The scrape workflow is the fleet's entry point and everything downstream depends on it, so its status grid is pinned to the top. Below it, a full-width freshness table and a logs panel; below those, one grid per remaining workflow — discovered from the config rather than named, so a new workflow appears without a dashboard change.

The freshness table turns red at `STALE_HOURS` (48 h), the same constant the alerting PR imports rather than restates. Board and alert can't drift apart.

### Importing it

Dashboards → New → Import → upload the JSON. It asks for a name, folder, and uid, and nothing else — no edits, no find-and-replace.

**Then check the datasource pickers at the top.** The import screen never asks about datasources for a dashboard that parameterizes through template variables, so Grafana auto-selects the first of each type it finds — and a Grafana Cloud stack has more than one Prometheus datasource (`grafanacloud-<stack>-prom` sits next to `grafanacloud-usage`). Landing on the wrong one renders "No data" on every metric panel while looking perfectly healthy. If the board is empty, look here first.

### Reviewing this

`check-dashboard` does the import unattended and then **reads it back by uid, checking panels *and* template variables**. A 200 on the push isn't proof it renders — Grafana will store a payload it then shows as empty — and panels alone aren't proof either: every panel filters on `=~"$state"` against `${metrics}`/`${logs}`, so a variable Grafana declined to migrate leaves all five panels present and all five rendering nothing.

Missing credentials exit 0 with a skip notice, so CI and a fresh clone pass without a Grafana account.

---

### Where this sits in the stack

Six stacked PRs build `actions/fleet-monitor`, each based on its predecessor so every PR shows only its own task's diff. **Merge in order, 1 → 6.**

| # | PR | |
| --- | --- | --- |
| 1 | Fleet config reader + module scaffold | #115 |
| 2 | Fleet poller + metrics shipper | #116 |
| 3 | Orchestrator, hourly workflow + heartbeat | #117 |
| 4 | Log harvester, Loki shipper + watermark | #118 |
| 5 | Fleet-overview dashboard as code | **← this PR** |
| 6 | Alert rules, contact point + notification policy | #120 |

Please **merge or rebase rather than squash** — each PR is already one clean commit, and squashing rewrites it, which orphans the next PR's base.
