### PR TITLE
Govbot MCP MVP

### DIFF
--- a/actions/govbot/src/lib.rs
+++ b/actions/govbot/src/lib.rs
@@ -12,6 +12,7 @@ pub mod locale_generated;
 pub mod pipeline;
 pub mod processor;
 pub mod publish;
+pub mod query;
 pub mod rss;
 pub mod selectors;
 pub mod types;
@@ -26,6 +27,7 @@ pub use filter::{FilterAlias, FilterManager, FilterResult, LogFilter};
 pub use locale::WorkingLocale;
 pub use locale_generated as locale;
 pub use processor::PipelineProcessor;
+pub use query::{QueryKind, QueryRequest, QueryResponse};
 pub use types::{LogContent, LogEntry, Metadata, VoteEventResult};
 
 /// Re-export commonly used types for convenience

--- a/actions/govbot/src/main.rs
+++ b/actions/govbot/src/main.rs
@@ -89,6 +89,71 @@ enum Command {
         list: bool,
     },
 
+    /// Query cloned legislation and get back a bounded, cited JSON answer.
+    ///
+    /// Unlike `logs`, which streams every matching record, `query` caps its output
+    /// and reports what it left out. Every row carries the repository, commit, and
+    /// path it came from. Every response reports what the data does and does not
+    /// cover, so an empty result is never mistaken for an absence of action.
+    ///
+    /// Jurisdictions may be given as Open Civic Data identifiers or as locale
+    /// codes: `ocd-jurisdiction/country:us/state:il/government`,
+    /// `ocd-division/country:us/state:il/sldl:4`, or simply `il`.
+    Query {
+        /// What to ask for: bills | votes | people | coverage
+        #[arg(value_parser = ["bills", "votes", "people", "coverage"])]
+        kind: String,
+
+        /// Jurisdictions, as OCD ids or locale codes (default: everything cloned)
+        #[arg(long = "jurisdiction", num_args = 0.., value_delimiter = ',')]
+        jurisdictions: Vec<String>,
+
+        /// Restrict to one legislative session
+        #[arg(long)]
+        session: Option<String>,
+
+        /// Restrict to one bill, by identifier
+        #[arg(long)]
+        identifier: Option<String>,
+
+        /// A legislator name to match against sponsors and voters
+        #[arg(long)]
+        person: Option<String>,
+
+        /// A tag from govbot.yml, used to rank and filter by relevance
+        #[arg(long)]
+        tag: Option<String>,
+
+        /// Minimum tag score (default: the tag's own threshold)
+        #[arg(long = "min-score")]
+        min_score: Option<f64>,
+
+        /// How sure a name match must be before anything is attributed
+        #[arg(long = "min-confidence", default_value = "medium",
+              value_parser = ["any", "medium", "high", "exact"])]
+        min_confidence: String,
+
+        /// Free-text match against identifier, title, abstract, and subjects
+        #[arg(long)]
+        text: Option<String>,
+
+        /// Restrict to bills carrying this subject
+        #[arg(long)]
+        subject: Option<String>,
+
+        /// Maximum rows to return (default: 20)
+        #[arg(long, default_value = "20")]
+        limit: usize,
+
+        /// Directory containing repositories (default: $CWD/govbot_data/repos)
+        #[arg(long = "govbot-dir")]
+        govbot_dir: Option<String>,
+
+        /// Directory `govbot tag` wrote to (default: current directory)
+        #[arg(long = "tags-dir")]
+        tags_dir: Option<String>,
+    },
+
     /// Process and display pipeline log files
     Logs {
         /// Repos to output (default: `all`) `--repos="il,ca"`
@@ -1388,6 +1453,101 @@ async fn run_load_command(cmd: Command) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Run `govbot query`.
+///
+/// Resolves jurisdictions, hands off to `govbot::query`, and prints one JSON object.
+/// Stdout carries JSON and nothing else, so this can be piped straight into `jq` or
+/// read by a program; progress and warnings go to stderr.
+async fn run_query_command(cmd: Command) -> anyhow::Result<()> {
+    let Command::Query {
+        kind,
+        jurisdictions,
+        session,
+        identifier,
+        person,
+        tag,
+        min_score,
+        min_confidence,
+        text,
+        subject,
+        limit,
+        govbot_dir,
+        tags_dir,
+    } = cmd else {
+        unreachable!()
+    };
+
+    let repos_dir = get_govbot_dir(govbot_dir)?;
+    if !repos_dir.exists() {
+        anyhow::bail!(
+            "No cloned data at {}. Run `govbot clone <jurisdiction>` first.",
+            repos_dir.display()
+        );
+    }
+
+    let kind = govbot::query::QueryKind::parse(&kind)
+        .ok_or_else(|| anyhow::anyhow!("Unknown query type: {}", kind))?;
+
+    let min_confidence = govbot::query::Confidence::parse(&min_confidence)
+        .ok_or_else(|| anyhow::anyhow!("Unknown confidence level: {}", min_confidence))?;
+
+    // No jurisdiction given means everything already on disk. That keeps the common
+    // case short, and it never implies we hold data we do not.
+    let resolved: Vec<govbot::query::Jurisdiction> = if jurisdictions.is_empty() {
+        govbot::git::get_available_locales(&repos_dir)
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+            .iter()
+            .map(govbot::query::Jurisdiction::new)
+            .collect()
+    } else {
+        let mut resolved = Vec::new();
+        for raw in &jurisdictions {
+            let jurisdiction = govbot::query::ocd::parse_jurisdiction(raw).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not read {:?} as a jurisdiction. Use a locale code such as `il`, \
+                     or an Open Civic Data id such as \
+                     `ocd-jurisdiction/country:us/state:il/government`.",
+                    raw
+                )
+            })?;
+            resolved.push(jurisdiction);
+        }
+        resolved
+    };
+
+    if resolved.is_empty() {
+        anyhow::bail!(
+            "Nothing cloned at {} yet. Run `govbot clone <jurisdiction>` first.",
+            repos_dir.display()
+        );
+    }
+
+    let tags_dir = match tags_dir {
+        Some(dir) => PathBuf::from(dir),
+        None => std::env::current_dir()?,
+    };
+
+    let request = govbot::query::QueryRequest {
+        kind,
+        repos_dir,
+        tags_dir,
+        jurisdictions: resolved,
+        session,
+        identifier,
+        person,
+        tag,
+        min_score,
+        min_confidence,
+        text,
+        subject,
+        limit,
+    };
+
+    let response = govbot::query::run(&request)?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
 /// Extract country, state, and session_id from a log path
 /// Path format: .../country:us/state:il/sessions/104th/bills/...
 fn extract_path_info(path: &str) -> Option<(String, String, String)> {
@@ -2300,6 +2460,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(cmd @ Command::Delete { .. }) => {
             run_delete_command(cmd).await
+        }
+        Some(cmd @ Command::Query { .. }) => {
+            run_query_command(cmd).await
         }
         Some(cmd @ Command::Logs { .. }) => {
             run_logs_command(cmd).await

--- a/actions/govbot/src/main.rs
+++ b/actions/govbot/src/main.rs
@@ -1572,13 +1572,33 @@ fn extract_path_info(path: &str) -> Option<(String, String, String)> {
 /// Download a file from a URL to a local path
 fn download_file(url: &str, path: &std::path::Path) -> anyhow::Result<()> {
     eprintln!("Downloading {}...", url);
-    let response = reqwest::blocking::get(url)?;
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!("Failed to download {}: HTTP {}", url, response.status()));
-    }
-    let mut file = std::fs::File::create(path)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut file)?;
-    Ok(())
+
+    // `reqwest::blocking` builds its own tokio runtime and panics when that runtime
+    // is dropped inside an async context — which is where every caller here sits,
+    // since the commands are `async fn` under `#[tokio::main]`. Doing the download
+    // on a plain thread keeps the blocking runtime out of the async one.
+    //
+    // Without this, `govbot tag` panics the first time it runs on any machine that
+    // does not already have the embedding model cached:
+    //
+    //     Cannot drop a runtime in a context where blocking is not allowed.
+    let url = url.to_string();
+    let path = path.to_path_buf();
+    std::thread::spawn(move || -> anyhow::Result<()> {
+        let response = reqwest::blocking::get(&url)?;
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to download {}: HTTP {}",
+                url,
+                response.status()
+            ));
+        }
+        let mut file = std::fs::File::create(&path)?;
+        std::io::copy(&mut response.bytes()?.as_ref(), &mut file)?;
+        Ok(())
+    })
+    .join()
+    .map_err(|_| anyhow::anyhow!("Download thread panicked"))?
 }
 
 /// Ensure embedding model and tokenizer exist; if missing, download them from Hugging Face.

--- a/actions/govbot/src/query/mod.rs
+++ b/actions/govbot/src/query/mod.rs
@@ -1,0 +1,1047 @@
+//! `govbot query` — bounded, cited answers over cloned legislation.
+//!
+//! `govbot logs` streams unbounded nested JSON Lines. That is the right shape for a
+//! Unix pipe and the wrong shape for anything with a context window: there is no
+//! way to cap the output, no way to filter by tag score, and every row carries the
+//! full nesting of its source files.
+//!
+//! `query` answers the same corpus with a capped, flat array. Every row carries a
+//! citation — repository, commit, and path — so any claim built on it can be
+//! checked by hand. Every response carries a coverage report and, where the data
+//! cannot support the question, plainly worded caveats.
+//!
+//! The vocabulary is Open Civic Data, because the data already speaks it: every
+//! `metadata.json` carries `jurisdiction: {id, name, classification, division_id}`.
+
+pub mod names;
+pub mod ocd;
+pub mod scan;
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+pub use names::{Confidence, MatchMethod, NameIndex, NameMatch};
+pub use ocd::{District, Jurisdiction};
+use scan::{BillRecord, ControlFlow, VoteEventRecord};
+
+/// The four things a caller can ask for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryKind {
+    /// Bills, optionally narrowed by person, tag score, subject, or text.
+    Bills,
+    /// Roll calls, optionally narrowed to how one person voted.
+    Votes,
+    /// The distinct people named in the data, with how often each appears.
+    People,
+    /// What data is present and what it can and cannot answer.
+    Coverage,
+}
+
+impl QueryKind {
+    pub fn parse(input: &str) -> Option<Self> {
+        match input.trim().to_lowercase().as_str() {
+            "bills" | "bill" => Some(QueryKind::Bills),
+            "votes" | "vote" | "vote_events" => Some(QueryKind::Votes),
+            "people" | "person" => Some(QueryKind::People),
+            "coverage" => Some(QueryKind::Coverage),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QueryKind::Bills => "bills",
+            QueryKind::Votes => "votes",
+            QueryKind::People => "people",
+            QueryKind::Coverage => "coverage",
+        }
+    }
+}
+
+/// Everything one `govbot query` invocation needs to know.
+#[derive(Debug, Clone)]
+pub struct QueryRequest {
+    pub kind: QueryKind,
+    pub repos_dir: PathBuf,
+    /// Where `govbot tag` wrote its output. Tag files live beside `govbot.yml`,
+    /// which for a workspace is the workspace root.
+    pub tags_dir: PathBuf,
+    pub jurisdictions: Vec<Jurisdiction>,
+    pub session: Option<String>,
+    /// Restrict to one bill, by its identifier or directory name.
+    pub identifier: Option<String>,
+    /// A legislator name to match against sponsors and voters.
+    pub person: Option<String>,
+    /// A tag from `govbot.yml`, used to rank and filter by relevance.
+    pub tag: Option<String>,
+    pub min_score: Option<f64>,
+    pub min_confidence: Confidence,
+    /// Free-text match against identifier, title, abstract, and subjects.
+    pub text: Option<String>,
+    pub subject: Option<String>,
+    pub limit: usize,
+}
+
+/// The envelope every query returns.
+///
+/// `coverage` and `caveats` are present on success as well as on failure — the
+/// point is that a caller should never have to infer whether an empty result means
+/// "nothing matched" or "this jurisdiction publishes no such data".
+#[derive(Debug, Serialize)]
+pub struct QueryResponse {
+    pub query: Value,
+    pub results: Vec<Value>,
+    pub truncation: Truncation,
+    pub coverage: Vec<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub caveats: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Truncation {
+    pub returned: usize,
+    pub total_matching: usize,
+    pub limit: usize,
+}
+
+/// Run a query.
+pub fn run(request: &QueryRequest) -> Result<QueryResponse> {
+    let mut caveats = Vec::new();
+    let mut coverage = Vec::new();
+
+    // A jurisdiction that was asked for but never cloned is an error condition, not
+    // an empty result. An empty result reads as "this person did nothing", which is
+    // exactly the fabrication this command exists to prevent.
+    let mut missing = Vec::new();
+    for jurisdiction in &request.jurisdictions {
+        if scan::jurisdiction_root(&request.repos_dir, jurisdiction).is_none() {
+            missing.push(jurisdiction.locale.clone());
+        }
+    }
+    if !missing.is_empty() {
+        caveats.push(format!(
+            "Not cloned yet, so nothing here reflects them: {}. \
+             Run `govbot clone {}` first. This is missing data, not an empty record.",
+            missing.join(", "),
+            missing.join(" ")
+        ));
+    }
+
+    for jurisdiction in &request.jurisdictions {
+        if scan::jurisdiction_root(&request.repos_dir, jurisdiction).is_some() {
+            let report = coverage_for(request, jurisdiction)?;
+            caveats.extend(report.caveats.clone());
+            coverage.push(report.to_json());
+        }
+    }
+
+    let (results, total_matching, extra_caveats) = match request.kind {
+        QueryKind::Bills => query_bills(request)?,
+        QueryKind::Votes => query_votes(request)?,
+        QueryKind::People => query_people(request)?,
+        QueryKind::Coverage => (Vec::new(), 0, Vec::new()),
+    };
+    caveats.extend(extra_caveats);
+
+    Ok(QueryResponse {
+        query: describe(request),
+        truncation: Truncation {
+            returned: results.len(),
+            total_matching,
+            limit: request.limit,
+        },
+        results,
+        coverage,
+        caveats,
+    })
+}
+
+fn describe(request: &QueryRequest) -> Value {
+    let mut described = serde_json::Map::new();
+    described.insert("type".into(), json!(request.kind.as_str()));
+    described.insert(
+        "jurisdictions".into(),
+        json!(request
+            .jurisdictions
+            .iter()
+            .map(|j| j.ocd_jurisdiction_id())
+            .collect::<Vec<_>>()),
+    );
+    for (key, value) in [
+        ("session", request.session.clone()),
+        ("identifier", request.identifier.clone()),
+        ("person", request.person.clone()),
+        ("tag", request.tag.clone()),
+        ("text", request.text.clone()),
+        ("subject", request.subject.clone()),
+    ] {
+        if let Some(value) = value {
+            described.insert(key.into(), json!(value));
+        }
+    }
+    if let Some(min_score) = request.min_score {
+        described.insert("min_score".into(), json!(min_score));
+    }
+    described.insert("min_confidence".into(), json!(request.min_confidence));
+    Value::Object(described)
+}
+
+// ---------------------------------------------------------------------------
+// Tag scores
+// ---------------------------------------------------------------------------
+
+/// Scores written by `govbot tag`, loaded per session.
+///
+/// Tag files are keyed by the bill id that `govbot logs` emitted, which is the
+/// bill's `identifier` — `"HR 1"`, with a space, where the directory is `HR1`.
+/// Both are tried.
+struct TagScores {
+    threshold: f64,
+    by_bill: BTreeMap<String, Value>,
+}
+
+impl TagScores {
+    fn load(request: &QueryRequest, jurisdiction: &Jurisdiction, session_id: &str) -> Option<Self> {
+        let tag = request.tag.as_ref()?;
+        let path = request
+            .tags_dir
+            .join("country:us")
+            .join(format!("state:{}", jurisdiction.path_segment()))
+            .join("sessions")
+            .join(session_id)
+            .join("tags")
+            .join(format!("{tag}.tag.json"));
+
+        let raw = std::fs::read_to_string(&path).ok()?;
+        let value: Value = serde_json::from_str(&raw).ok()?;
+
+        let threshold = value
+            .get("tag_config")
+            .and_then(|config| config.get("threshold"))
+            .and_then(Value::as_f64)
+            .unwrap_or(0.5);
+
+        let by_bill = value
+            .get("bills")
+            .and_then(Value::as_object)
+            .map(|bills| {
+                bills
+                    .iter()
+                    .filter_map(|(bill_id, entry)| {
+                        entry.get("score").map(|s| (bill_id.clone(), s.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Some(Self { threshold, by_bill })
+    }
+
+    fn score_for(&self, bill: &BillRecord) -> Option<&Value> {
+        self.by_bill
+            .get(&bill.identifier)
+            .or_else(|| self.by_bill.get(&bill.bill_id))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bills
+// ---------------------------------------------------------------------------
+
+fn query_bills(request: &QueryRequest) -> Result<(Vec<Value>, usize, Vec<String>)> {
+    let mut caveats = Vec::new();
+
+    // Matching a person needs to know every name in scope before it can tell a
+    // unique surname from an ambiguous one, so that costs a first pass.
+    let person_match = match request.person.as_deref() {
+        Some(person) => {
+            let index = build_sponsor_index(request)?;
+            let resolved = index.resolve(person);
+            caveats.extend(describe_match(person, &resolved, request.min_confidence));
+            Some(resolved)
+        }
+        None => None,
+    };
+
+    if let Some(resolved) = &person_match {
+        if !resolved.is_attributable(request.min_confidence) {
+            return Ok((Vec::new(), 0, caveats));
+        }
+    }
+
+    let mut rows: Vec<(f64, Value)> = Vec::new();
+    let mut total = 0usize;
+
+    for jurisdiction in &request.jurisdictions {
+        for session_id in sessions_in_scope(request, jurisdiction) {
+            let scores = TagScores::load(request, jurisdiction, &session_id);
+            if request.tag.is_some() && scores.is_none() {
+                caveats.push(format!(
+                    "No tag file for '{}' in {} session {}. Run `govbot tag` before \
+                     filtering by tag, or results will be missing rather than empty.",
+                    request.tag.clone().unwrap_or_default(),
+                    jurisdiction.locale,
+                    session_id
+                ));
+            }
+
+            scan::for_each_bill(
+                &request.repos_dir,
+                jurisdiction,
+                Some(&session_id),
+                |bill| {
+                    if !bill_matches(request, &bill) {
+                        return Ok(ControlFlow::Continue);
+                    }
+
+                    let sponsorship = match person_match.as_ref() {
+                        Some(resolved) => {
+                            let Some(found) = matching_sponsorship(&bill, resolved) else {
+                                return Ok(ControlFlow::Continue);
+                            };
+                            Some(found)
+                        }
+                        None => None,
+                    };
+
+                    let score = match scores.as_ref() {
+                        Some(scores) => {
+                            let Some(score) = scores.score_for(&bill) else {
+                                return Ok(ControlFlow::Continue);
+                            };
+                            let final_score =
+                                score.get("final_score").and_then(Value::as_f64).unwrap_or(0.0);
+                            let floor = request.min_score.unwrap_or(scores.threshold);
+                            if final_score < floor {
+                                return Ok(ControlFlow::Continue);
+                            }
+                            Some((final_score, score.clone()))
+                        }
+                        None => None,
+                    };
+
+                    total += 1;
+                    let rank = score.as_ref().map(|(value, _)| *value).unwrap_or(0.0);
+                    rows.push((
+                        rank,
+                        bill_row(&bill, sponsorship, score, person_match.as_ref()),
+                    ));
+                    Ok(ControlFlow::Continue)
+                },
+            )?;
+        }
+    }
+
+    // Rank by tag score when there is one; otherwise keep the deterministic
+    // filesystem order the scan produced.
+    if request.tag.is_some() {
+        rows.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    }
+    let results = rows
+        .into_iter()
+        .take(request.limit)
+        .map(|(_, row)| row)
+        .collect();
+
+    Ok((results, total, caveats))
+}
+
+fn bill_matches(request: &QueryRequest, bill: &BillRecord) -> bool {
+    if let Some(identifier) = &request.identifier {
+        let wanted = identifier.trim().to_lowercase().replace(' ', "");
+        let actual = bill.identifier.to_lowercase().replace(' ', "");
+        if actual != wanted && bill.bill_id.to_lowercase() != wanted {
+            return false;
+        }
+    }
+    if let Some(subject) = &request.subject {
+        let wanted = subject.to_lowercase();
+        if !bill
+            .subjects()
+            .iter()
+            .any(|s| s.to_lowercase().contains(&wanted))
+        {
+            return false;
+        }
+    }
+    if let Some(text) = &request.text {
+        let haystack = bill.searchable_text();
+        // Every term must appear as a whole word. Plain substring matching is far
+        // too loose here: searching for "rent" would match "Trenton", which is the
+        // kind of quiet nonsense that makes a values answer untrustworthy.
+        if !text
+            .to_lowercase()
+            .split_whitespace()
+            .all(|term| contains_word(&haystack, term))
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Whether `haystack` contains `needle` as a whole word.
+///
+/// Word boundaries are any non-alphanumeric character, which suits legislative
+/// text where terms are separated by spaces, hyphens, and punctuation.
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let bytes = haystack.as_bytes();
+    let mut from = 0usize;
+    while let Some(offset) = haystack[from..].find(needle) {
+        let start = from + offset;
+        let end = start + needle.len();
+        let before_ok = start == 0 || !is_word_byte(bytes[start - 1]);
+        let after_ok = end == bytes.len() || !is_word_byte(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        // Advance by one byte boundary so overlapping matches are still found.
+        from = match haystack[start..].char_indices().nth(1) {
+            Some((next, _)) => start + next,
+            None => return false,
+        };
+    }
+    false
+}
+
+fn is_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte >= 0x80
+}
+
+fn matching_sponsorship(bill: &BillRecord, resolved: &NameMatch) -> Option<scan::Sponsorship> {
+    bill.sponsorships().into_iter().find(|sponsorship| {
+        sponsorship.is_person() && resolved.candidates.contains(&sponsorship.name)
+    })
+}
+
+fn bill_row(
+    bill: &BillRecord,
+    sponsorship: Option<scan::Sponsorship>,
+    score: Option<(f64, Value)>,
+    person_match: Option<&NameMatch>,
+) -> Value {
+    let mut row = serde_json::Map::new();
+    row.insert("identifier".into(), json!(bill.identifier));
+    row.insert("title".into(), json!(bill.title()));
+    row.insert("legislative_session".into(), json!(bill.session_id));
+    row.insert(
+        "jurisdiction".into(),
+        json!({
+            "id": bill.jurisdiction.ocd_jurisdiction_id(),
+            "name": bill.jurisdiction_name(),
+        }),
+    );
+
+    let classification = bill.classification();
+    if !classification.is_empty() {
+        row.insert("classification".into(), json!(classification));
+    }
+    let subjects = bill.subjects();
+    if !subjects.is_empty() {
+        row.insert("subject".into(), json!(subjects));
+    }
+    if let Some(abstract_text) = bill.abstract_text() {
+        row.insert("abstract".into(), json!(truncate(&abstract_text, 400)));
+    }
+    if let Some((date, description)) = bill.latest_action() {
+        row.insert(
+            "latest_action".into(),
+            json!({ "date": date, "description": truncate(&description, 200) }),
+        );
+    }
+
+    if let Some(sponsorship) = sponsorship {
+        row.insert(
+            "sponsorship".into(),
+            json!({
+                "name": sponsorship.name,
+                "classification": sponsorship.classification,
+                "primary": sponsorship.primary,
+            }),
+        );
+    } else {
+        let sponsorships = bill.sponsorships();
+        if !sponsorships.is_empty() {
+            row.insert("sponsorships".into(), json!(sponsorships));
+        }
+    }
+
+    if let Some((final_score, breakdown)) = score {
+        row.insert(
+            "tag".into(),
+            json!({ "final_score": final_score, "score": breakdown }),
+        );
+    }
+    if let Some(resolved) = person_match {
+        row.insert("match".into(), json!(resolved));
+    }
+
+    row.insert("citation".into(), json!(bill.citation));
+    Value::Object(row)
+}
+
+// ---------------------------------------------------------------------------
+// Votes
+// ---------------------------------------------------------------------------
+
+fn query_votes(request: &QueryRequest) -> Result<(Vec<Value>, usize, Vec<String>)> {
+    let mut caveats = Vec::new();
+
+    let person_match = match request.person.as_deref() {
+        Some(person) => {
+            let index = build_voter_index(request)?;
+            let resolved = index.resolve(person);
+            caveats.extend(describe_match(person, &resolved, request.min_confidence));
+            Some(resolved)
+        }
+        None => None,
+    };
+
+    if let Some(resolved) = &person_match {
+        if !resolved.is_attributable(request.min_confidence) {
+            return Ok((Vec::new(), 0, caveats));
+        }
+    }
+
+    let mut results = Vec::new();
+    let mut total = 0usize;
+
+    for jurisdiction in &request.jurisdictions {
+        for session_id in sessions_in_scope(request, jurisdiction) {
+            scan::for_each_bill(
+                &request.repos_dir,
+                jurisdiction,
+                Some(&session_id),
+                |bill| {
+                    if !bill_matches(request, &bill) {
+                        return Ok(ControlFlow::Continue);
+                    }
+                    for event in scan::vote_events(&bill, &request.repos_dir) {
+                        let person_vote = match person_match.as_ref() {
+                            Some(resolved) => {
+                                let Some(found) = matching_vote(&event, resolved) else {
+                                    continue;
+                                };
+                                Some(found)
+                            }
+                            None => None,
+                        };
+                        total += 1;
+                        if results.len() < request.limit {
+                            results.push(vote_row(
+                                &bill,
+                                &event,
+                                person_vote,
+                                person_match.as_ref(),
+                            ));
+                        }
+                    }
+                    Ok(ControlFlow::Continue)
+                },
+            )?;
+        }
+    }
+
+    Ok((results, total, caveats))
+}
+
+fn matching_vote(event: &VoteEventRecord, resolved: &NameMatch) -> Option<names::RawVoteRow> {
+    event
+        .votes
+        .iter()
+        .find(|row| resolved.candidates.contains(&row.voter_name))
+        .cloned()
+}
+
+fn vote_row(
+    bill: &BillRecord,
+    event: &VoteEventRecord,
+    person_vote: Option<names::RawVoteRow>,
+    person_match: Option<&NameMatch>,
+) -> Value {
+    let mut row = serde_json::Map::new();
+    row.insert("bill_identifier".into(), json!(event.bill_identifier));
+    row.insert("bill_title".into(), json!(bill.title()));
+    row.insert("legislative_session".into(), json!(bill.session_id));
+    row.insert(
+        "jurisdiction".into(),
+        json!({ "id": bill.jurisdiction.ocd_jurisdiction_id() }),
+    );
+    row.insert("motion_text".into(), json!(event.motion_text));
+    row.insert("start_date".into(), json!(event.start_date));
+    row.insert("result".into(), json!(event.result));
+    if !event.chamber.is_empty() {
+        row.insert("organization".into(), json!(event.chamber));
+    }
+    row.insert("counts".into(), json!(event.counts));
+    row.insert("has_member_votes".into(), json!(event.has_member_votes()));
+
+    if let Some(vote) = person_vote {
+        let mut entry = serde_json::Map::new();
+        entry.insert("voter_name".into(), json!(vote.voter_name));
+        entry.insert("option".into(), json!(vote.option));
+        if !vote.note.is_empty() {
+            entry.insert("note".into(), json!(vote.note));
+        }
+        row.insert("person_vote".into(), Value::Object(entry));
+    }
+    if let Some(resolved) = person_match {
+        row.insert("match".into(), json!(resolved));
+    }
+    if event.repaired_rows > 0 {
+        row.insert("split_rows_repaired".into(), json!(event.repaired_rows));
+    }
+
+    row.insert("citation".into(), json!(event.citation));
+    Value::Object(row)
+}
+
+// ---------------------------------------------------------------------------
+// People
+// ---------------------------------------------------------------------------
+
+/// Tallies for one distinct name found in the data.
+#[derive(Default)]
+struct PersonTally {
+    /// Every way this person's name is spelled in the data, in first-seen order.
+    spellings: Vec<String>,
+    sponsored: usize,
+    cosponsored: usize,
+    votes: usize,
+}
+
+impl PersonTally {
+    fn record_spelling(&mut self, raw: &str) {
+        if !self.spellings.iter().any(|seen| seen == raw) {
+            self.spellings.push(raw.to_string());
+        }
+    }
+}
+
+fn query_people(request: &QueryRequest) -> Result<(Vec<Value>, usize, Vec<String>)> {
+    let caveats = vec![
+        "These names are derived from sponsorship and vote records, not from a \
+         legislator roster. They carry no party, district, or term information, and \
+         a name appearing here is not proof that person currently holds office."
+            .to_string(),
+    ];
+
+    // Keyed by normalized name, so `Smith, S` and `SMITH, S` are one person.
+    let mut tallies: BTreeMap<String, PersonTally> = BTreeMap::new();
+    let wanted = request.person.as_ref().map(|p| names::normalize(p));
+
+    for jurisdiction in &request.jurisdictions {
+        for session_id in sessions_in_scope(request, jurisdiction) {
+            scan::for_each_bill(
+                &request.repos_dir,
+                jurisdiction,
+                Some(&session_id),
+                |bill| {
+                    for sponsorship in bill.sponsorships() {
+                        if !sponsorship.is_person() {
+                            continue;
+                        }
+                        let entry = tallies
+                            .entry(names::normalize(&sponsorship.name).key())
+                            .or_default();
+                        entry.record_spelling(&sponsorship.name);
+                        if sponsorship.primary {
+                            entry.sponsored += 1;
+                        } else {
+                            entry.cosponsored += 1;
+                        }
+                    }
+                    for event in scan::vote_events(&bill, &request.repos_dir) {
+                        for vote in &event.votes {
+                            if names::is_suspect_fragment(&vote.voter_name) {
+                                continue;
+                            }
+                            let entry = tallies
+                                .entry(names::normalize(&vote.voter_name).key())
+                                .or_default();
+                            entry.record_spelling(&vote.voter_name);
+                            entry.votes += 1;
+                        }
+                    }
+                    Ok(ControlFlow::Continue)
+                },
+            )?;
+        }
+    }
+
+    let mut rows: Vec<(usize, Value)> = tallies
+        .into_iter()
+        .filter(|(key, _)| match &wanted {
+            // A name filter here is a substring search, because the caller is
+            // browsing the roster rather than attributing anything to a person.
+            Some(wanted) => wanted.surname().is_some_and(|s| key.contains(s)),
+            None => true,
+        })
+        .map(|(_, tally)| {
+            let activity = tally.sponsored + tally.cosponsored + tally.votes;
+            let mut row = serde_json::Map::new();
+            row.insert("name".into(), json!(tally.spellings.first()));
+            if tally.spellings.len() > 1 {
+                row.insert(
+                    "also_spelled".into(),
+                    json!(&tally.spellings[1..]),
+                );
+            }
+            row.insert("sponsored".into(), json!(tally.sponsored));
+            row.insert("cosponsored".into(), json!(tally.cosponsored));
+            row.insert("votes".into(), json!(tally.votes));
+            (activity, Value::Object(row))
+        })
+        .collect();
+
+    rows.sort_by(|a, b| b.0.cmp(&a.0));
+    let total = rows.len();
+    let results = rows
+        .into_iter()
+        .take(request.limit)
+        .map(|(_, row)| row)
+        .collect();
+
+    Ok((results, total, caveats))
+}
+
+// ---------------------------------------------------------------------------
+// Coverage
+// ---------------------------------------------------------------------------
+
+/// What one jurisdiction's data can and cannot answer.
+struct CoverageReport {
+    jurisdiction: Jurisdiction,
+    jurisdiction_name: Option<String>,
+    sessions: Vec<String>,
+    bills: usize,
+    vote_events: usize,
+    vote_events_with_member_votes: usize,
+    member_vote_rows: usize,
+    distinct_voter_names: usize,
+    /// Raw spellings before normalization; higher than the headcount where a
+    /// jurisdiction spells the same legislator more than one way.
+    distinct_voter_spellings: usize,
+    suspect_name_fragments: usize,
+    split_rows_repaired: usize,
+    caveats: Vec<String>,
+}
+
+impl CoverageReport {
+    /// A one-word summary of whether individual votes can be attributed here.
+    fn roll_call_data(&self) -> &'static str {
+        if self.vote_events == 0 {
+            "none"
+        } else if self.vote_events_with_member_votes == 0 {
+            "counts_only"
+        } else {
+            "available"
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "jurisdiction": {
+                "id": self.jurisdiction.ocd_jurisdiction_id(),
+                "division_id": self.jurisdiction.ocd_division_id(),
+                "name": self.jurisdiction_name,
+                "locale": self.jurisdiction.locale,
+            },
+            "sessions": self.sessions,
+            "bills": self.bills,
+            "vote_events": self.vote_events,
+            "vote_events_with_member_votes": self.vote_events_with_member_votes,
+            "member_vote_rows": self.member_vote_rows,
+            "distinct_voter_names": self.distinct_voter_names,
+            "distinct_voter_spellings": self.distinct_voter_spellings,
+            "suspect_name_fragments": self.suspect_name_fragments,
+            "split_rows_repaired": self.split_rows_repaired,
+            "roll_call_data": self.roll_call_data(),
+        })
+    }
+}
+
+fn coverage_for(request: &QueryRequest, jurisdiction: &Jurisdiction) -> Result<CoverageReport> {
+    let mut report = CoverageReport {
+        jurisdiction: jurisdiction.clone(),
+        jurisdiction_name: None,
+        sessions: sessions_in_scope(request, jurisdiction),
+        bills: 0,
+        vote_events: 0,
+        vote_events_with_member_votes: 0,
+        member_vote_rows: 0,
+        distinct_voter_names: 0,
+        distinct_voter_spellings: 0,
+        suspect_name_fragments: 0,
+        split_rows_repaired: 0,
+        caveats: Vec::new(),
+    };
+
+    let mut voters = NameIndex::new();
+    for session_id in report.sessions.clone() {
+        scan::for_each_bill(
+            &request.repos_dir,
+            jurisdiction,
+            Some(&session_id),
+            |bill| {
+                report.bills += 1;
+                if report.jurisdiction_name.is_none() {
+                    report.jurisdiction_name = bill.jurisdiction_name();
+                }
+                for event in scan::vote_events(&bill, &request.repos_dir) {
+                    report.vote_events += 1;
+                    report.split_rows_repaired += event.repaired_rows;
+                    if event.has_member_votes() {
+                        report.vote_events_with_member_votes += 1;
+                        report.member_vote_rows += event.votes.len();
+                        for vote in &event.votes {
+                            voters.insert(&vote.voter_name);
+                        }
+                    }
+                }
+                Ok(ControlFlow::Continue)
+            },
+        )?;
+    }
+    report.distinct_voter_names = voters.distinct_people();
+    report.distinct_voter_spellings = voters.distinct_raw_spellings();
+    report.suspect_name_fragments = voters.suspect_fragment_count();
+
+    let name = report
+        .jurisdiction_name
+        .clone()
+        .unwrap_or_else(|| jurisdiction.locale.to_uppercase());
+
+    match report.roll_call_data() {
+        "none" => report.caveats.push(format!(
+            "{name} publishes no roll-call votes in this dataset ({} bills, 0 vote \
+             events). Sponsorship is the only available evidence. Do not describe \
+             this as a legislator not having voted on something.",
+            report.bills
+        )),
+        "counts_only" => report.caveats.push(format!(
+            "{name} publishes vote totals but not how individuals voted ({} vote \
+             events, 0 member rows). Report the tallies; do not attribute a vote to \
+             any person.",
+            report.vote_events
+        )),
+        _ => {}
+    }
+
+    if report.suspect_name_fragments > 0 {
+        report.caveats.push(format!(
+            "{name} has {} voter names that look like upstream parsing debris — \
+             one- or two-letter fragments left when a name such as \"Brown, L.\" was \
+             split on its comma. {} rows were rejoined; anything still fragmentary is \
+             excluded from attribution and from counts.",
+            report.suspect_name_fragments, report.split_rows_repaired
+        ));
+    }
+
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn sessions_in_scope(request: &QueryRequest, jurisdiction: &Jurisdiction) -> Vec<String> {
+    let available = scan::sessions(&request.repos_dir, jurisdiction);
+    match &request.session {
+        Some(wanted) => available.into_iter().filter(|s| s == wanted).collect(),
+        None => available,
+    }
+}
+
+/// A first pass over sponsorship names, so a surname can be told unique from
+/// ambiguous before anything is attributed.
+fn build_sponsor_index(request: &QueryRequest) -> Result<NameIndex> {
+    let mut index = NameIndex::new();
+    for jurisdiction in &request.jurisdictions {
+        for session_id in sessions_in_scope(request, jurisdiction) {
+            scan::for_each_bill(
+                &request.repos_dir,
+                jurisdiction,
+                Some(&session_id),
+                |bill| {
+                    for sponsorship in bill.sponsorships() {
+                        if sponsorship.is_person() {
+                            index.insert(&sponsorship.name);
+                        }
+                    }
+                    for bioguide in bill.sponsor_bioguides() {
+                        if let Some(primary) =
+                            bill.sponsorships().iter().find(|s| s.is_person())
+                        {
+                            index.insert_identifier(&bioguide, &primary.name);
+                        }
+                    }
+                    Ok(ControlFlow::Continue)
+                },
+            )?;
+        }
+    }
+    Ok(index)
+}
+
+/// The same first pass, over voter names.
+fn build_voter_index(request: &QueryRequest) -> Result<NameIndex> {
+    let mut index = NameIndex::new();
+    for jurisdiction in &request.jurisdictions {
+        for session_id in sessions_in_scope(request, jurisdiction) {
+            scan::for_each_bill(
+                &request.repos_dir,
+                jurisdiction,
+                Some(&session_id),
+                |bill| {
+                    for event in scan::vote_events(&bill, &request.repos_dir) {
+                        for vote in &event.votes {
+                            index.insert(&vote.voter_name);
+                            // Federal rows carry the bioguide id in `note`, which
+                            // is the one exact join this data offers.
+                            if !vote.note.is_empty() {
+                                index.insert_identifier(&vote.note, &vote.voter_name);
+                            }
+                        }
+                    }
+                    Ok(ControlFlow::Continue)
+                },
+            )?;
+        }
+    }
+    Ok(index)
+}
+
+/// Turn a name match into something a caller can act on honestly.
+fn describe_match(query: &str, resolved: &NameMatch, minimum: Confidence) -> Vec<String> {
+    match resolved.method {
+        MatchMethod::Ambiguous => vec![format!(
+            "\"{query}\" matches {} people in this data: {}. Nothing has been \
+             attributed. Ask which one is meant, then query that exact name.",
+            resolved.candidates.len(),
+            resolved.candidates.join(", ")
+        )],
+        MatchMethod::Unmatched => vec![format!(
+            "\"{query}\" does not appear in the sponsorship or vote records for the \
+             jurisdictions searched. This means the name was not found, not that the \
+             person took no action. Check the spelling, or use `govbot query people` \
+             to see the names that are present."
+        )],
+        _ if !resolved.is_attributable(minimum) => vec![format!(
+            "\"{query}\" matched with {:?} confidence, below the requested minimum of \
+             {:?}, so nothing has been attributed.",
+            resolved.confidence, minimum
+        )],
+        MatchMethod::UniqueSurname | MatchMethod::SurnameInitial => vec![format!(
+            "\"{query}\" was matched to \"{}\" by name alone — govbot has no \
+             legislator roster, so this is a name match rather than a verified \
+             identity. Say so when reporting it.",
+            resolved.candidates.join(", ")
+        )],
+        _ => Vec::new(),
+    }
+}
+
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut truncated: String = text.chars().take(max_chars).collect();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_search_matches_whole_words_only() {
+        let haystack = "appoint-trenton taber rent-control and tenant rights".to_lowercase();
+        // The bug this guards: "rent" must not match "Trenton".
+        assert!(!contains_word(&haystack, "trent"));
+        assert!(contains_word(&haystack, "rent"));
+        assert!(contains_word(&haystack, "trenton"));
+        assert!(contains_word(&haystack, "tenant"));
+        assert!(!contains_word(&haystack, "tenants"));
+        // Hyphens are boundaries, so a hyphenated compound is searchable by part.
+        assert!(contains_word(&haystack, "control"));
+        assert!(contains_word(&haystack, "appoint"));
+    }
+
+    #[test]
+    fn text_search_handles_multibyte_without_panicking() {
+        let haystack = "protección de inquilinos ñ".to_lowercase();
+        assert!(contains_word(&haystack, "inquilinos"));
+        assert!(!contains_word(&haystack, "quilin"));
+    }
+
+    #[test]
+    fn parses_query_kinds() {
+        assert_eq!(QueryKind::parse("bills"), Some(QueryKind::Bills));
+        assert_eq!(QueryKind::parse("VOTES"), Some(QueryKind::Votes));
+        assert_eq!(QueryKind::parse("people"), Some(QueryKind::People));
+        assert_eq!(QueryKind::parse("coverage"), Some(QueryKind::Coverage));
+        assert_eq!(QueryKind::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn truncates_on_character_boundaries() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("abcdefghij", 5), "abcde…");
+        // Multi-byte input must not panic or split a character.
+        assert_eq!(truncate("ñññññ", 2), "ññ…");
+    }
+
+    #[test]
+    fn ambiguity_produces_an_actionable_caveat() {
+        let resolved = NameMatch {
+            method: MatchMethod::Ambiguous,
+            confidence: Confidence::None,
+            candidates: vec!["Brown, G".into(), "Brown, L".into()],
+        };
+        let caveats = describe_match("Brown", &resolved, Confidence::Medium);
+        assert_eq!(caveats.len(), 1);
+        assert!(caveats[0].contains("Nothing has been attributed"));
+        assert!(caveats[0].contains("Brown, G"));
+    }
+
+    /// The distinction the whole command exists to preserve.
+    #[test]
+    fn an_unmatched_name_is_not_reported_as_inaction() {
+        let resolved = NameMatch {
+            method: MatchMethod::Unmatched,
+            confidence: Confidence::None,
+            candidates: Vec::new(),
+        };
+        let caveats = describe_match("Nobody", &resolved, Confidence::Medium);
+        assert!(caveats[0].contains("not that the person took no action"));
+    }
+
+    #[test]
+    fn a_name_only_match_says_so() {
+        let resolved = NameMatch {
+            method: MatchMethod::UniqueSurname,
+            confidence: Confidence::Medium,
+            candidates: vec!["Filer".into()],
+        };
+        let caveats = describe_match("Filer", &resolved, Confidence::Medium);
+        assert!(caveats[0].contains("no legislator roster"));
+    }
+
+    #[test]
+    fn a_high_confidence_match_needs_no_caveat() {
+        let resolved = NameMatch {
+            method: MatchMethod::ExactName,
+            confidence: Confidence::High,
+            candidates: vec!["Cunningham, Bill".into()],
+        };
+        assert!(describe_match("Bill Cunningham", &resolved, Confidence::Medium).is_empty());
+    }
+}

--- a/actions/govbot/src/query/names.rs
+++ b/actions/govbot/src/query/names.rs
@@ -1,0 +1,706 @@
+//! Matching a caller-supplied legislator name against the names that appear in the
+//! data, and being honest about how sure we are.
+//!
+//! govbot has no legislator roster. Sponsors and voters are name strings, and
+//! `person_id` is pseudo-JSON derived from the name itself (`~{"name": "Filer"}`),
+//! so it carries no identity the name doesn't already carry. Everything here works
+//! from the names in the corpus alone.
+//!
+//! Formats vary by jurisdiction, and all of these are real:
+//!
+//! | jurisdiction | what a vote row says |
+//! |---|---|
+//! | usa    | `Arrington`, with the bioguide id in `note` |
+//! | co, oh | `Max Brooks`, `Roy Klopfenstein` |
+//! | il, sc | `Cunningham, Bill`, `Adams, Brian` |
+//! | ga     | `ADESANYA`, with the district in `note` |
+//! | wy     | `Brown` — bare surname, and see [`is_suspect_fragment`] |
+//!
+//! The rule that matters: **a refusal is a success.** Attributing a vote to the
+//! wrong legislator is far worse than saying we can't tell. So surname collisions
+//! resolve to [`MatchMethod::Ambiguous`] with the candidates listed, never to a
+//! guess, and edit distance is never used to assign a person — `Hanson`/`Hansen`
+//! and `Reed`/`Reid` are one edit apart and are different people.
+
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+/// How a name was matched. Ordering is not meaningful; use [`Confidence`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchMethod {
+    /// A stable external id agreed: the bioguide in a federal vote row's `note`.
+    Bioguide,
+    /// Full name matched exactly after normalization.
+    ExactName,
+    /// `Adams, Brian` matched `Brian Adams`.
+    ReversedName,
+    /// Surname matched exactly one distinct person in scope.
+    UniqueSurname,
+    /// Surname plus a given-name initial selected exactly one person.
+    SurnameInitial,
+    /// Surname matched more than one person and nothing disambiguated them.
+    Ambiguous,
+    /// The name is a committee or other body, not a person.
+    Organization,
+    /// No candidate at all.
+    Unmatched,
+}
+
+/// How much a match should be trusted. `query --min-confidence` gates on this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    /// Nothing was matched, or the match was ambiguous.
+    None,
+    /// A surname plus a weak signal.
+    Medium,
+    /// A full-name agreement.
+    High,
+    /// A stable external identifier agreed.
+    Exact,
+}
+
+impl Confidence {
+    pub fn parse(input: &str) -> Option<Self> {
+        match input.trim().to_lowercase().as_str() {
+            "any" | "none" => Some(Confidence::None),
+            "medium" => Some(Confidence::Medium),
+            "high" => Some(Confidence::High),
+            "exact" => Some(Confidence::Exact),
+            _ => None,
+        }
+    }
+}
+
+impl MatchMethod {
+    pub fn confidence(&self) -> Confidence {
+        match self {
+            MatchMethod::Bioguide => Confidence::Exact,
+            MatchMethod::ExactName | MatchMethod::ReversedName => Confidence::High,
+            MatchMethod::UniqueSurname | MatchMethod::SurnameInitial => Confidence::Medium,
+            MatchMethod::Ambiguous | MatchMethod::Organization | MatchMethod::Unmatched => {
+                Confidence::None
+            }
+        }
+    }
+}
+
+/// The outcome of resolving one caller-supplied name against the corpus.
+#[derive(Debug, Clone, Serialize)]
+pub struct NameMatch {
+    pub method: MatchMethod,
+    pub confidence: Confidence,
+    /// The raw corpus names this resolved to. Exactly one unless `method` is
+    /// [`MatchMethod::Ambiguous`], in which case it lists what the caller must
+    /// choose between.
+    pub candidates: Vec<String>,
+}
+
+impl NameMatch {
+    fn unmatched() -> Self {
+        Self {
+            method: MatchMethod::Unmatched,
+            confidence: Confidence::None,
+            candidates: Vec::new(),
+        }
+    }
+
+    fn resolved(method: MatchMethod, name: String) -> Self {
+        Self::resolved_many(method, vec![name])
+    }
+
+    /// One person, spelled several ways in the data. Every spelling is carried so a
+    /// caller filtering on `candidates` catches all of that person's rows.
+    fn resolved_many(method: MatchMethod, spellings: Vec<String>) -> Self {
+        Self {
+            method,
+            confidence: method.confidence(),
+            candidates: spellings,
+        }
+    }
+
+    fn ambiguous(candidates: Vec<String>) -> Self {
+        Self {
+            method: MatchMethod::Ambiguous,
+            confidence: Confidence::None,
+            candidates,
+        }
+    }
+
+    /// Whether this match may be used to attribute a bill or vote to a person.
+    pub fn is_attributable(&self, minimum: Confidence) -> bool {
+        self.confidence >= minimum && self.confidence > Confidence::None
+    }
+}
+
+/// Fold the accented Latin characters that actually occur in US legislator names
+/// down to ASCII, so `Ortíz` and `Ortiz` compare equal.
+///
+/// This is a table rather than full Unicode NFKD because the input domain is
+/// names in US legislative data — Latin-1 and Latin Extended-A cover it, and a
+/// table keeps this dependency-free and obvious. Characters outside the table
+/// pass through unchanged, so a name we don't fold simply fails to match rather
+/// than matching something wrong.
+fn fold_accents(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' | 'ā' | 'ă' | 'ą' => 'a',
+            'é' | 'è' | 'ê' | 'ë' | 'ē' | 'ĕ' | 'ė' | 'ę' | 'ě' => 'e',
+            'í' | 'ì' | 'î' | 'ï' | 'ī' | 'ĭ' | 'į' | 'ı' => 'i',
+            'ó' | 'ò' | 'ô' | 'ö' | 'õ' | 'ø' | 'ō' | 'ŏ' | 'ő' => 'o',
+            'ú' | 'ù' | 'û' | 'ü' | 'ū' | 'ŭ' | 'ů' | 'ű' | 'ų' => 'u',
+            'ñ' | 'ń' | 'ņ' | 'ň' => 'n',
+            'ç' | 'ć' | 'ĉ' | 'ċ' | 'č' => 'c',
+            'ý' | 'ÿ' => 'y',
+            'š' | 'ś' | 'ş' => 's',
+            'ž' | 'ź' | 'ż' => 'z',
+            'ł' => 'l',
+            'ř' | 'ŕ' => 'r',
+            'ť' | 'ţ' => 't',
+            'ď' => 'd',
+            'ğ' => 'g',
+            other => other,
+        })
+        .collect()
+}
+
+/// Titles that appear in front of names in some sources and carry no identity.
+const HONORIFICS: &[&str] = &[
+    "sen", "senator", "rep", "representative", "del", "delegate", "assemblymember",
+    "assemblyman", "assemblywoman", "mr", "mrs", "ms", "dr", "hon", "speaker",
+    "president", "chairman", "chairwoman", "chair",
+];
+
+/// Generational suffixes, which vary between sources for the same person.
+const SUFFIXES: &[&str] = &["jr", "sr", "ii", "iii", "iv", "v"];
+
+/// A name reduced to comparable parts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedName {
+    /// All meaningful tokens, in given-name-first order.
+    pub tokens: Vec<String>,
+    /// A parenthetical or trailing hint, e.g. the `NV` in `Amodei (NV)`.
+    pub hint: Option<String>,
+}
+
+impl NormalizedName {
+    /// The full name as a single comparable key.
+    pub fn key(&self) -> String {
+        self.tokens.join(" ")
+    }
+
+    /// The last token, which for US legislative data is the family name.
+    pub fn surname(&self) -> Option<&str> {
+        self.tokens.last().map(|s| s.as_str())
+    }
+
+    /// The first letter of the first given name, when there is one.
+    pub fn given_initial(&self) -> Option<char> {
+        if self.tokens.len() < 2 {
+            return None;
+        }
+        self.tokens[0].chars().next()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+/// Reduce a raw name to comparable tokens.
+///
+/// Handles the `Family, Given` form by reordering, captures and removes
+/// parenthetical disambiguators, and drops honorifics and generational suffixes.
+pub fn normalize(raw: &str) -> NormalizedName {
+    let folded = fold_accents(&raw.to_lowercase());
+
+    // Capture a parenthetical hint: `Amodei (NV)` -> hint `nv`.
+    let (body, hint) = match (folded.find('('), folded.find(')')) {
+        (Some(open), Some(close)) if close > open + 1 => {
+            let hint = folded[open + 1..close].trim().to_string();
+            let mut body = String::with_capacity(folded.len());
+            body.push_str(&folded[..open]);
+            body.push_str(&folded[close + 1..]);
+            (body, Some(hint))
+        }
+        _ => (folded, None),
+    };
+
+    // `Family, Given Middle` -> `Given Middle Family`. Only the first comma is
+    // structural; anything after it (`Smith, John, Jr.`) is handled by suffix
+    // stripping below.
+    let reordered = match body.split_once(',') {
+        Some((family, rest)) if !rest.trim().is_empty() => {
+            format!("{} {}", rest.trim(), family.trim())
+        }
+        _ => body,
+    };
+
+    let tokens: Vec<String> = reordered
+        .split(|c: char| !c.is_alphanumeric() && c != '\'' && c != '-')
+        .map(|t| t.trim_matches(|c: char| c == '\'' || c == '-'))
+        .filter(|t| !t.is_empty())
+        .filter(|t| !HONORIFICS.contains(t))
+        .filter(|t| !SUFFIXES.contains(t))
+        .map(|t| t.to_string())
+        .collect();
+
+    NormalizedName { tokens, hint }
+}
+
+/// Whether a raw voter name looks like debris from an upstream parsing bug rather
+/// than a person.
+///
+/// Wyoming's vote rows are the known case: `"Brown, L."` was split on the comma
+/// into two separate voters, so `"L"` appears as a voter 768 times, alongside
+/// `"G"`, `"K"`, `"E"`, and `"JT"`. Counting those as legislators invents people
+/// and double-counts real ones. See [`repair_split_rows`] for the recovery.
+pub fn is_suspect_fragment(raw: &str) -> bool {
+    let trimmed = raw.trim().trim_end_matches('.');
+    !trimmed.is_empty() && trimmed.len() <= 2 && trimmed.chars().all(|c| c.is_alphabetic())
+}
+
+/// One row of a roll call, as it appears in the data.
+#[derive(Debug, Clone)]
+pub struct RawVoteRow {
+    pub voter_name: String,
+    pub option: String,
+    pub note: String,
+}
+
+/// Rejoin vote rows that an upstream parser split on a comma.
+///
+/// In Wyoming's data the severed initial always follows its surname and carries
+/// the same vote option:
+///
+/// ```text
+/// [0] 'Brown'    -> yes      [37] 'Brown'    -> no
+/// [1] 'L'        -> yes      [38] 'G'        -> no
+/// [2] 'Campbell' -> yes      [39] 'Campbell' -> no
+/// [3] 'E'        -> yes      [40] 'K'        -> no
+/// ```
+///
+/// Rejoining them turns `Brown` + `L` back into `Brown, L.`, which is what
+/// separates Landon Brown from Gary Brown — the only thing that makes Wyoming's
+/// two colliding surnames attributable at all.
+///
+/// The repair is deliberately conservative: it fires only when the *preceding*
+/// row is a plausible surname and the options agree, because at least one stray
+/// `L` appears in the data with no `Brown` before it.
+pub fn repair_split_rows(rows: Vec<RawVoteRow>) -> (Vec<RawVoteRow>, usize) {
+    let mut repaired: Vec<RawVoteRow> = Vec::with_capacity(rows.len());
+    let mut repairs = 0usize;
+    let mut index = 0usize;
+
+    while index < rows.len() {
+        let current = &rows[index];
+        let next = rows.get(index + 1);
+
+        let is_rejoinable = match next {
+            Some(next) => {
+                is_suspect_fragment(&next.voter_name)
+                    && !is_suspect_fragment(&current.voter_name)
+                    && next.option == current.option
+            }
+            None => false,
+        };
+
+        if is_rejoinable {
+            let next = next.expect("checked above");
+            repaired.push(RawVoteRow {
+                voter_name: format!(
+                    "{}, {}",
+                    current.voter_name.trim(),
+                    next.voter_name.trim().trim_end_matches('.')
+                ),
+                option: current.option.clone(),
+                note: current.note.clone(),
+            });
+            repairs += 1;
+            index += 2;
+        } else {
+            repaired.push(current.clone());
+            index += 1;
+        }
+    }
+
+    (repaired, repairs)
+}
+
+/// The distinct names present in some scope, and the lookups needed to resolve a
+/// caller's name against them.
+///
+/// "Scope" is the caller's business — build one per jurisdiction, or per
+/// jurisdiction and chamber. Narrower scope means fewer surname collisions.
+#[derive(Debug, Default)]
+pub struct NameIndex {
+    by_full_key: HashMap<String, BTreeSet<String>>,
+    by_surname: HashMap<String, BTreeSet<String>>,
+    by_bioguide: HashMap<String, String>,
+    suspect_fragments: BTreeSet<String>,
+    all: BTreeSet<String>,
+}
+
+impl NameIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a name that appears in the data.
+    pub fn insert(&mut self, raw: &str) {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return;
+        }
+        if is_suspect_fragment(raw) {
+            self.suspect_fragments.insert(raw.to_string());
+            return;
+        }
+
+        let normalized = normalize(raw);
+        if normalized.is_empty() {
+            return;
+        }
+
+        self.all.insert(raw.to_string());
+        self.by_full_key
+            .entry(normalized.key())
+            .or_default()
+            .insert(raw.to_string());
+        if let Some(surname) = normalized.surname() {
+            self.by_surname
+                .entry(surname.to_string())
+                .or_default()
+                .insert(raw.to_string());
+        }
+    }
+
+    /// Record a stable external identifier for a name — the bioguide id carried in
+    /// the `note` field of federal vote rows.
+    pub fn insert_identifier(&mut self, identifier: &str, raw_name: &str) {
+        let identifier = identifier.trim();
+        if identifier.is_empty() {
+            return;
+        }
+        self.by_bioguide
+            .insert(identifier.to_uppercase(), raw_name.trim().to_string());
+    }
+
+    /// Distinct people, counted after normalization.
+    ///
+    /// Prefer this over [`Self::distinct_raw_spellings`] for anything a reader will
+    /// interpret as a headcount. Wyoming's data spells the same legislator both
+    /// `Smith, S` and `SMITH, S`, so counting raw strings reports 184 voters for a
+    /// 93-member legislature.
+    pub fn distinct_people(&self) -> usize {
+        self.by_full_key.len()
+    }
+
+    /// Distinct raw strings, before normalization. Useful for describing how noisy a
+    /// jurisdiction's spelling is, not as a headcount.
+    pub fn distinct_raw_spellings(&self) -> usize {
+        self.all.len()
+    }
+
+    pub fn suspect_fragment_count(&self) -> usize {
+        self.suspect_fragments.len()
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &String> {
+        self.all.iter()
+    }
+
+    /// Resolve a caller-supplied name against the corpus.
+    pub fn resolve(&self, query: &str) -> NameMatch {
+        let query = query.trim();
+        if query.is_empty() {
+            return NameMatch::unmatched();
+        }
+
+        // A bioguide id, if the caller happens to have one, beats every heuristic.
+        if let Some(name) = self.by_bioguide.get(&query.to_uppercase()) {
+            return NameMatch::resolved(MatchMethod::Bioguide, name.clone());
+        }
+
+        let normalized = normalize(query);
+        if normalized.is_empty() {
+            return NameMatch::unmatched();
+        }
+
+        // Full name, exactly as given. Several raw strings may share one normalized
+        // key — `Smith, S` and `SMITH, S` are one legislator spelled two ways, not
+        // two legislators — so every spelling is returned and none is ambiguity.
+        if let Some(matches) = self.by_full_key.get(&normalized.key()) {
+            return NameMatch::resolved_many(MatchMethod::ExactName, to_vec(matches));
+        }
+
+        // The caller wrote the name in the other order from the data, or the data
+        // wrote it in the other order from the caller. `normalize` already
+        // reorders an explicit `Family, Given`, so this covers the rest.
+        if normalized.tokens.len() > 1 {
+            let mut swapped = normalized.tokens.clone();
+            let last = swapped.len() - 1;
+            swapped.rotate_left(last);
+            if let Some(matches) = self.by_full_key.get(&swapped.join(" ")) {
+                return NameMatch::resolved_many(MatchMethod::ReversedName, to_vec(matches));
+            }
+        }
+
+        // Surname only. This is where collisions live.
+        let Some(surname) = normalized.surname() else {
+            return NameMatch::unmatched();
+        };
+        let Some(surname_matches) = self.by_surname.get(surname) else {
+            return NameMatch::unmatched();
+        };
+
+        let people = group_by_person(surname_matches);
+        if people.len() == 1 {
+            let spellings = people.into_values().next().expect("checked above");
+            return NameMatch::resolved_many(MatchMethod::UniqueSurname, spellings);
+        }
+
+        // Several distinct people share the surname. A given-name initial from the
+        // caller may pick one out; anything less and we refuse.
+        if let Some(initial) = normalized.given_initial() {
+            let narrowed: Vec<Vec<String>> = people
+                .values()
+                .filter(|spellings| {
+                    spellings.first().is_some_and(|name| {
+                        normalize(name)
+                            .given_initial()
+                            .is_some_and(|c| c == initial)
+                    })
+                })
+                .cloned()
+                .collect();
+            if narrowed.len() == 1 {
+                return NameMatch::resolved_many(
+                    MatchMethod::SurnameInitial,
+                    narrowed.into_iter().next().expect("checked above"),
+                );
+            }
+        }
+
+        // Report one representative spelling per person, so the caller is choosing
+        // between people rather than between spellings.
+        NameMatch::ambiguous(
+            people
+                .into_values()
+                .filter_map(|spellings| spellings.into_iter().next())
+                .collect(),
+        )
+    }
+}
+
+/// Group raw spellings by the person they normalize to.
+///
+/// This is what separates "one legislator written two ways" from "two legislators
+/// who share a surname" — the first is resolvable, the second must not be.
+fn group_by_person(names: &BTreeSet<String>) -> BTreeMap<String, Vec<String>> {
+    let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for name in names {
+        grouped
+            .entry(normalize(name).key())
+            .or_default()
+            .push(name.clone());
+    }
+    grouped
+}
+
+fn to_vec(set: &BTreeSet<String>) -> Vec<String> {
+    set.iter().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index_of(names: &[&str]) -> NameIndex {
+        let mut index = NameIndex::new();
+        for name in names {
+            index.insert(name);
+        }
+        index
+    }
+
+    #[test]
+    fn folds_accents_so_ortiz_matches_ortiz() {
+        assert_eq!(normalize("Ortíz, Aarón").key(), "aaron ortiz");
+        assert_eq!(normalize("Aaron Ortiz").key(), "aaron ortiz");
+        assert_eq!(normalize("González, Edgar").key(), "edgar gonzalez");
+        assert_eq!(normalize("Guzmán, Graciela").key(), "graciela guzman");
+    }
+
+    #[test]
+    fn reorders_family_given_form() {
+        // Illinois and South Carolina publish names this way.
+        assert_eq!(normalize("Cunningham, Bill").key(), "bill cunningham");
+        assert_eq!(normalize("Adams, Brian").key(), "brian adams");
+        assert_eq!(normalize("Alexander, Thomas C.").key(), "thomas c alexander");
+    }
+
+    #[test]
+    fn captures_parenthetical_hints() {
+        let n = normalize("Amodei (NV)");
+        assert_eq!(n.key(), "amodei");
+        assert_eq!(n.hint.as_deref(), Some("nv"));
+    }
+
+    #[test]
+    fn strips_honorifics_and_suffixes() {
+        assert_eq!(normalize("Sen. Bill Cunningham").key(), "bill cunningham");
+        assert_eq!(normalize("Joseph A. Miller, III").key(), "joseph a miller");
+    }
+
+    #[test]
+    fn matches_full_names_and_reversals() {
+        let index = index_of(&["Cunningham, Bill", "Max Brooks"]);
+
+        let m = index.resolve("Bill Cunningham");
+        assert_eq!(m.method, MatchMethod::ExactName);
+        assert_eq!(m.confidence, Confidence::High);
+        assert_eq!(m.candidates, vec!["Cunningham, Bill"]);
+
+        let m = index.resolve("Brooks, Max");
+        assert_eq!(m.method, MatchMethod::ExactName);
+    }
+
+    #[test]
+    fn unique_surname_resolves_but_collision_refuses() {
+        // Wyoming publishes bare surnames, so the caller's surname matches the
+        // data's full name outright.
+        let index = index_of(&["Filer", "Geringer", "Love"]);
+        let m = index.resolve("Filer");
+        assert_eq!(m.method, MatchMethod::ExactName);
+
+        // Where the data carries full names, a surname-only query falls to the
+        // surname lookup and is only attributable because it is unique.
+        let index = index_of(&["Bill Cunningham", "Robert Peters"]);
+        let m = index.resolve("Cunningham");
+        assert_eq!(m.method, MatchMethod::UniqueSurname);
+        assert_eq!(m.confidence, Confidence::Medium);
+        assert_eq!(m.candidates, vec!["Bill Cunningham"]);
+
+        // Wyoming really does have two Browns and two Campbells.
+        let index = index_of(&["Brown, G", "Brown, L", "Campbell, E", "Campbell, K"]);
+        let m = index.resolve("Brown");
+        assert_eq!(m.method, MatchMethod::Ambiguous);
+        assert_eq!(m.confidence, Confidence::None);
+        assert_eq!(m.candidates, vec!["Brown, G", "Brown, L"]);
+        assert!(!m.is_attributable(Confidence::None));
+    }
+
+    #[test]
+    fn given_initial_breaks_a_surname_collision() {
+        let index = index_of(&["Brown, G", "Brown, L"]);
+        let m = index.resolve("Brown, L");
+        // An exact hit on the full key, since the data uses the same form.
+        assert_eq!(m.method, MatchMethod::ExactName);
+
+        let index = index_of(&["Gary Brown", "Landon Brown"]);
+        let m = index.resolve("L Brown");
+        assert_eq!(m.method, MatchMethod::SurnameInitial);
+        assert_eq!(m.candidates, vec!["Landon Brown"]);
+    }
+
+    #[test]
+    fn never_matches_a_near_miss() {
+        // One edit apart, different people. This must not resolve.
+        let index = index_of(&["Hanson", "Reed"]);
+        assert_eq!(index.resolve("Hansen").method, MatchMethod::Unmatched);
+        assert_eq!(index.resolve("Reid").method, MatchMethod::Unmatched);
+    }
+
+    #[test]
+    fn bioguide_beats_everything() {
+        let mut index = index_of(&["Arrington"]);
+        index.insert_identifier("A000375", "Arrington");
+        let m = index.resolve("a000375");
+        assert_eq!(m.method, MatchMethod::Bioguide);
+        assert_eq!(m.confidence, Confidence::Exact);
+    }
+
+    #[test]
+    fn identifies_wyoming_split_fragments() {
+        assert!(is_suspect_fragment("L"));
+        assert!(is_suspect_fragment("JT"));
+        assert!(is_suspect_fragment("E."));
+        assert!(!is_suspect_fragment("Brown"));
+        assert!(!is_suspect_fragment(""));
+    }
+
+    #[test]
+    fn case_variants_are_one_person_not_two() {
+        // Wyoming publishes both spellings for the same legislator.
+        let index = index_of(&["Smith, S", "SMITH, S", "Brown, G", "BROWN, G"]);
+        assert_eq!(index.distinct_people(), 2);
+        assert_eq!(index.distinct_raw_spellings(), 4);
+
+        // A query resolves to every spelling, so no votes are missed.
+        let m = index.resolve("S Smith");
+        assert_eq!(m.method, MatchMethod::ExactName);
+        assert_eq!(m.candidates, vec!["SMITH, S", "Smith, S"]);
+    }
+
+    #[test]
+    fn suspect_fragments_never_become_legislators() {
+        let index = index_of(&["Brown", "L", "Campbell", "E"]);
+        assert_eq!(index.distinct_people(), 2);
+        assert_eq!(index.suspect_fragment_count(), 2);
+        assert_eq!(index.resolve("L").method, MatchMethod::Unmatched);
+    }
+
+    #[test]
+    fn rejoins_wyoming_split_vote_rows() {
+        let rows = vec![
+            row("Brown", "yes"),
+            row("L", "yes"),
+            row("Campbell", "yes"),
+            row("E", "yes"),
+            row("Chestek", "yes"),
+        ];
+        let (repaired, repairs) = repair_split_rows(rows);
+        assert_eq!(repairs, 2);
+        let names: Vec<&str> = repaired.iter().map(|r| r.voter_name.as_str()).collect();
+        assert_eq!(names, vec!["Brown, L", "Campbell, E", "Chestek"]);
+    }
+
+    #[test]
+    fn leaves_a_stray_fragment_alone() {
+        // A fragment with no surname before it is not evidence of a split.
+        let rows = vec![row("Chestek", "yes"), row("L", "no")];
+        let (repaired, repairs) = repair_split_rows(rows);
+        assert_eq!(repairs, 0);
+        assert_eq!(repaired.len(), 2);
+    }
+
+    #[test]
+    fn does_not_rejoin_across_differing_options() {
+        let rows = vec![row("Brown", "yes"), row("L", "no")];
+        let (repaired, repairs) = repair_split_rows(rows);
+        assert_eq!(repairs, 0);
+        assert_eq!(repaired.len(), 2);
+    }
+
+    #[test]
+    fn confidence_ordering_gates_attribution() {
+        assert!(Confidence::Exact > Confidence::High);
+        assert!(Confidence::High > Confidence::Medium);
+        assert!(Confidence::Medium > Confidence::None);
+
+        let m = NameMatch::resolved(MatchMethod::UniqueSurname, "Filer".into());
+        assert!(m.is_attributable(Confidence::Medium));
+        assert!(!m.is_attributable(Confidence::High));
+    }
+
+    fn row(name: &str, option: &str) -> RawVoteRow {
+        RawVoteRow {
+            voter_name: name.to_string(),
+            option: option.to_string(),
+            note: String::new(),
+        }
+    }
+}

--- a/actions/govbot/src/query/ocd.rs
+++ b/actions/govbot/src/query/ocd.rs
@@ -1,0 +1,276 @@
+//! Open Civic Data identifier vocabulary.
+//!
+//! `govbot query` speaks OCD, because the data already does: every `metadata.json`
+//! carries `jurisdiction: {id, name, classification, division_id}` with values like
+//! `ocd-jurisdiction/country:us/state:il/government`.
+//!
+//! There is one wrinkle worth knowing before reading this module. The *path* layout
+//! and the *OCD* vocabulary disagree about the federal government. On disk, federal
+//! bills live under `country:us/state:usa/` so that downstream tooling needs no
+//! special-casing. But the OCD jurisdiction id inside those same files is
+//! `ocd-jurisdiction/country:us/government` — no `state:` segment at all, because
+//! Congress is not a state. This module is the only place that discrepancy lives.
+
+use std::fmt;
+
+/// A jurisdiction, resolved from whatever the caller typed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Jurisdiction {
+    /// govbot's locale code: `il`, `wy`, `usa`.
+    pub locale: String,
+}
+
+impl Jurisdiction {
+    pub fn new(locale: impl Into<String>) -> Self {
+        Self {
+            locale: locale.into().to_lowercase(),
+        }
+    }
+
+    /// The `state:` path segment for this jurisdiction. Federal is `usa`.
+    pub fn path_segment(&self) -> &str {
+        &self.locale
+    }
+
+    /// The canonical OCD jurisdiction id.
+    pub fn ocd_jurisdiction_id(&self) -> String {
+        if self.is_federal() {
+            "ocd-jurisdiction/country:us/government".to_string()
+        } else {
+            format!(
+                "ocd-jurisdiction/country:us/state:{}/government",
+                self.locale
+            )
+        }
+    }
+
+    /// The canonical OCD division id.
+    pub fn ocd_division_id(&self) -> String {
+        if self.is_federal() {
+            "ocd-division/country:us".to_string()
+        } else {
+            format!("ocd-division/country:us/state:{}", self.locale)
+        }
+    }
+
+    pub fn is_federal(&self) -> bool {
+        self.locale == "usa"
+    }
+
+    /// The git repository name this jurisdiction is cloned into.
+    pub fn repo_name(&self) -> String {
+        format!("{}-legislation", self.locale)
+    }
+}
+
+impl fmt::Display for Jurisdiction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.locale)
+    }
+}
+
+/// A legislative district, expressed as an OCD division.
+///
+/// `ocd-division/country:us/state:il/sldl:4`  — Illinois House district 4
+/// `ocd-division/country:us/state:il/sldu:2`  — Illinois Senate district 2
+/// `ocd-division/country:us/state:il/cd:7`    — US House, Illinois 7th
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct District {
+    pub jurisdiction: Jurisdiction,
+    /// `sldl`, `sldu`, or `cd`.
+    pub kind: DistrictKind,
+    pub number: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DistrictKind {
+    /// State legislative district, lower chamber.
+    StateLower,
+    /// State legislative district, upper chamber.
+    StateUpper,
+    /// Congressional district.
+    Congressional,
+}
+
+impl DistrictKind {
+    pub fn as_ocd_prefix(&self) -> &'static str {
+        match self {
+            DistrictKind::StateLower => "sldl",
+            DistrictKind::StateUpper => "sldu",
+            DistrictKind::Congressional => "cd",
+        }
+    }
+
+    /// The chamber classification used in vote events and `from_organization`.
+    pub fn chamber(&self) -> &'static str {
+        match self {
+            DistrictKind::StateLower | DistrictKind::Congressional => "lower",
+            DistrictKind::StateUpper => "upper",
+        }
+    }
+
+    fn from_ocd_prefix(prefix: &str) -> Option<Self> {
+        match prefix {
+            "sldl" => Some(DistrictKind::StateLower),
+            "sldu" => Some(DistrictKind::StateUpper),
+            "cd" => Some(DistrictKind::Congressional),
+            _ => None,
+        }
+    }
+}
+
+impl District {
+    pub fn ocd_division_id(&self) -> String {
+        format!(
+            "{}/{}:{}",
+            self.jurisdiction.ocd_division_id(),
+            self.kind.as_ocd_prefix(),
+            self.number
+        )
+    }
+}
+
+/// Parse a jurisdiction from any of the forms a caller might reasonably use:
+/// a bare locale (`il`), an OCD jurisdiction id, or an OCD division id.
+///
+/// Returns `None` for input that names no jurisdiction we can act on.
+pub fn parse_jurisdiction(input: &str) -> Option<Jurisdiction> {
+    let raw = input.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let lowered = raw.to_lowercase();
+
+    if let Some(rest) = lowered.strip_prefix("ocd-jurisdiction/") {
+        return jurisdiction_from_division_path(rest.trim_end_matches("/government"));
+    }
+    if let Some(rest) = lowered.strip_prefix("ocd-division/") {
+        return jurisdiction_from_division_path(rest);
+    }
+
+    // A bare locale code.
+    if lowered.chars().all(|c| c.is_ascii_alphabetic()) && lowered.len() <= 3 {
+        return Some(Jurisdiction::new(lowered));
+    }
+    None
+}
+
+/// Shared tail of both OCD id forms: `country:us[/state:xx][/sldl:4]`.
+fn jurisdiction_from_division_path(path: &str) -> Option<Jurisdiction> {
+    if !path.starts_with("country:us") {
+        return None;
+    }
+    for segment in path.split('/') {
+        if let Some(state) = segment.strip_prefix("state:") {
+            if state.is_empty() {
+                return None;
+            }
+            return Some(Jurisdiction::new(state));
+        }
+    }
+    // `country:us` with no `state:` segment is the federal government, which on
+    // disk lives under `state:usa`.
+    Some(Jurisdiction::new("usa"))
+}
+
+/// Parse a district from an OCD division id.
+///
+/// A division id without a district segment is a jurisdiction, not a district, and
+/// yields `None` — callers that accept either should try [`parse_jurisdiction`] too.
+pub fn parse_district(input: &str) -> Option<District> {
+    let lowered = input.trim().to_lowercase();
+    let rest = lowered.strip_prefix("ocd-division/")?;
+    let jurisdiction = jurisdiction_from_division_path(rest)?;
+
+    let last = rest.rsplit('/').next()?;
+    let (prefix, number) = last.split_once(':')?;
+    let kind = DistrictKind::from_ocd_prefix(prefix)?;
+    if number.is_empty() {
+        return None;
+    }
+
+    Some(District {
+        jurisdiction,
+        kind,
+        number: number.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_locale() {
+        assert_eq!(parse_jurisdiction("il").unwrap().locale, "il");
+        assert_eq!(parse_jurisdiction("IL").unwrap().locale, "il");
+        assert_eq!(parse_jurisdiction("usa").unwrap().locale, "usa");
+    }
+
+    #[test]
+    fn parses_state_jurisdiction_id() {
+        let j = parse_jurisdiction("ocd-jurisdiction/country:us/state:il/government").unwrap();
+        assert_eq!(j.locale, "il");
+        assert_eq!(
+            j.ocd_jurisdiction_id(),
+            "ocd-jurisdiction/country:us/state:il/government"
+        );
+    }
+
+    /// The federal special case, in both directions. On disk it is `state:usa`;
+    /// in OCD it has no `state:` segment at all.
+    #[test]
+    fn federal_round_trips_between_path_and_ocd() {
+        let j = parse_jurisdiction("ocd-jurisdiction/country:us/government").unwrap();
+        assert_eq!(j.locale, "usa");
+        assert!(j.is_federal());
+        assert_eq!(j.path_segment(), "usa");
+        assert_eq!(j.ocd_jurisdiction_id(), "ocd-jurisdiction/country:us/government");
+        assert_eq!(j.ocd_division_id(), "ocd-division/country:us");
+
+        // And the bare locale reaches the same place.
+        assert_eq!(parse_jurisdiction("usa").unwrap(), j);
+    }
+
+    #[test]
+    fn parses_division_ids() {
+        assert_eq!(
+            parse_jurisdiction("ocd-division/country:us/state:wy")
+                .unwrap()
+                .locale,
+            "wy"
+        );
+        assert_eq!(
+            parse_jurisdiction("ocd-division/country:us/state:il/sldl:4")
+                .unwrap()
+                .locale,
+            "il"
+        );
+    }
+
+    #[test]
+    fn parses_districts() {
+        let d = parse_district("ocd-division/country:us/state:il/sldl:4").unwrap();
+        assert_eq!(d.jurisdiction.locale, "il");
+        assert_eq!(d.kind, DistrictKind::StateLower);
+        assert_eq!(d.kind.chamber(), "lower");
+        assert_eq!(d.number, "4");
+        assert_eq!(d.ocd_division_id(), "ocd-division/country:us/state:il/sldl:4");
+
+        let s = parse_district("ocd-division/country:us/state:il/sldu:2").unwrap();
+        assert_eq!(s.kind, DistrictKind::StateUpper);
+        assert_eq!(s.kind.chamber(), "upper");
+
+        let c = parse_district("ocd-division/country:us/state:il/cd:7").unwrap();
+        assert_eq!(c.kind, DistrictKind::Congressional);
+        assert_eq!(c.jurisdiction.locale, "il");
+    }
+
+    #[test]
+    fn rejects_non_districts_and_junk() {
+        assert!(parse_district("ocd-division/country:us/state:il").is_none());
+        assert!(parse_jurisdiction("").is_none());
+        assert!(parse_jurisdiction("ocd-division/country:ca/province:on").is_none());
+        assert!(parse_jurisdiction("some arbitrary sentence").is_none());
+    }
+}

--- a/actions/govbot/src/query/scan.rs
+++ b/actions/govbot/src/query/scan.rs
@@ -1,0 +1,517 @@
+//! Walking cloned repositories and reading the OCD-files layout into records.
+//!
+//! The layout, per `actions/format/docs/DATA_STRUCTURES.md`:
+//!
+//! ```text
+//! {locale}-legislation/
+//!   country:us/state:{code}/sessions/{session}/bills/{bill_id}/
+//!     metadata.json
+//!     logs/{ts}.vote_event.{result}.{chamber}.json   # dot form
+//!     logs/{ts}_vote_event_{result}.json             # underscore form
+//! ```
+//!
+//! Two things here are deliberately not shared with the rest of the crate.
+//!
+//! `processor.rs` never opens vote-event files at all — it regexes `pass`/`fail`
+//! out of the *filename* — so it cannot see the `votes[]` array this whole command
+//! exists to read. And `extract_timestamp_from_path` in `main.rs` requires an
+//! underscore, so it silently yields nothing for the dot-form filenames that make
+//! up roughly half of all logs. Both conventions are handled here.
+
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::names::{repair_split_rows, RawVoteRow};
+use super::ocd::Jurisdiction;
+
+/// Where a fact came from, precise enough to check by hand.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Citation {
+    pub repo: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    pub path: String,
+}
+
+/// One bill, as read from `metadata.json`.
+#[derive(Debug, Clone)]
+pub struct BillRecord {
+    pub jurisdiction: Jurisdiction,
+    pub session_id: String,
+    pub bill_id: String,
+    pub identifier: String,
+    pub metadata: Value,
+    pub dir: PathBuf,
+    pub citation: Citation,
+}
+
+impl BillRecord {
+    pub fn title(&self) -> &str {
+        self.metadata
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+    }
+
+    pub fn subjects(&self) -> Vec<String> {
+        string_array(self.metadata.get("subject"))
+    }
+
+    pub fn classification(&self) -> Vec<String> {
+        string_array(self.metadata.get("classification"))
+    }
+
+    /// The first abstract, which is the closest thing to a summary most
+    /// jurisdictions publish. Many publish none at all.
+    pub fn abstract_text(&self) -> Option<String> {
+        self.metadata
+            .get("abstracts")?
+            .as_array()?
+            .iter()
+            .find_map(|entry| entry.get("abstract").and_then(Value::as_str))
+            .map(|s| s.to_string())
+    }
+
+    /// Sponsors, with the pseudo-JSON `person_id` dropped — it is derived from the
+    /// name and carries no identity the name does not already carry.
+    pub fn sponsorships(&self) -> Vec<Sponsorship> {
+        self.metadata
+            .get("sponsorships")
+            .and_then(Value::as_array)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| {
+                        let name = entry.get("name").and_then(Value::as_str)?;
+                        Some(Sponsorship {
+                            name: name.to_string(),
+                            classification: entry
+                                .get("classification")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                            entity_type: entry
+                                .get("entity_type")
+                                .and_then(Value::as_str)
+                                .unwrap_or("person")
+                                .to_string(),
+                            primary: entry
+                                .get("primary")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Bioguide ids for federal bills, from `extras`. Absent for state bills.
+    pub fn sponsor_bioguides(&self) -> Vec<String> {
+        let extras = self.metadata.get("extras");
+        let mut ids = string_array(extras.and_then(|e| e.get("sponsor_bioguides")));
+        ids.extend(string_array(
+            extras.and_then(|e| e.get("cosponsor_bioguides")),
+        ));
+        ids
+    }
+
+    /// The most recent action, by date.
+    pub fn latest_action(&self) -> Option<(String, String)> {
+        let actions = self.metadata.get("actions")?.as_array()?;
+        actions
+            .iter()
+            .filter_map(|action| {
+                let date = action.get("date").and_then(Value::as_str)?;
+                let description = action.get("description").and_then(Value::as_str)?;
+                Some((date.to_string(), description.to_string()))
+            })
+            .max_by(|a, b| a.0.cmp(&b.0))
+    }
+
+    pub fn jurisdiction_name(&self) -> Option<String> {
+        self.metadata
+            .get("jurisdiction")?
+            .get("name")?
+            .as_str()
+            .map(|s| s.to_string())
+    }
+
+    /// Every text field worth matching a free-text query against.
+    pub fn searchable_text(&self) -> String {
+        let mut text = String::new();
+        text.push_str(&self.identifier);
+        text.push(' ');
+        text.push_str(self.title());
+        if let Some(abstract_text) = self.abstract_text() {
+            text.push(' ');
+            text.push_str(&abstract_text);
+        }
+        for subject in self.subjects() {
+            text.push(' ');
+            text.push_str(&subject);
+        }
+        text.to_lowercase()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Sponsorship {
+    pub name: String,
+    pub classification: String,
+    pub entity_type: String,
+    pub primary: bool,
+}
+
+impl Sponsorship {
+    pub fn is_person(&self) -> bool {
+        self.entity_type == "person"
+    }
+}
+
+/// One roll call, as read from a `logs/*vote_event*.json` file.
+#[derive(Debug, Clone)]
+pub struct VoteEventRecord {
+    pub bill_identifier: String,
+    pub motion_text: String,
+    pub start_date: String,
+    pub result: String,
+    pub chamber: String,
+    pub counts: BTreeMap<String, i64>,
+    /// Per-member rows, after the Wyoming split-row repair.
+    pub votes: Vec<RawVoteRow>,
+    /// How many rows the repair rejoined.
+    pub repaired_rows: usize,
+    pub citation: Citation,
+}
+
+impl VoteEventRecord {
+    /// Whether this event records how individuals voted, or only a tally.
+    ///
+    /// Alaska publishes 1,342 vote events with no member rows at all; the
+    /// distinction is the difference between "we can tell you how they voted" and
+    /// "we cannot".
+    pub fn has_member_votes(&self) -> bool {
+        !self.votes.is_empty()
+    }
+}
+
+/// Resolve the commit a repository is currently on, for citations.
+pub fn head_commit(repo_path: &Path) -> Option<String> {
+    let repo = git2::Repository::open(repo_path).ok()?;
+    let head = repo.head().ok()?;
+    let commit = head.peel_to_commit().ok()?;
+    Some(commit.id().to_string()[..7].to_string())
+}
+
+/// Strip the `~` prefix govbot's upstream uses for pseudo-JSON blobs and pull one
+/// field out of the object inside.
+///
+/// `"~{\"classification\": \"lower\"}"` -> `"lower"`.
+fn pseudo_json_field(raw: Option<&Value>, field: &str) -> String {
+    let Some(text) = raw.and_then(Value::as_str) else {
+        return String::new();
+    };
+    let trimmed = text.trim_start_matches('~');
+    serde_json::from_str::<Value>(trimmed)
+        .ok()
+        .and_then(|value| {
+            value
+                .get(field)
+                .and_then(Value::as_str)
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_default()
+}
+
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether a log filename is a vote event, in either naming convention.
+fn is_vote_event_file(file_name: &str) -> bool {
+    file_name.contains(".vote_event.") || file_name.contains("_vote_event_")
+}
+
+/// The directory holding a jurisdiction's sessions, or `None` if it isn't cloned.
+pub fn jurisdiction_root(repos_dir: &Path, jurisdiction: &Jurisdiction) -> Option<PathBuf> {
+    let root = repos_dir
+        .join(jurisdiction.repo_name())
+        .join("country:us")
+        .join(format!("state:{}", jurisdiction.path_segment()))
+        .join("sessions");
+    root.is_dir().then_some(root)
+}
+
+/// The repository directory for a jurisdiction, cloned or not.
+pub fn repo_dir(repos_dir: &Path, jurisdiction: &Jurisdiction) -> PathBuf {
+    repos_dir.join(jurisdiction.repo_name())
+}
+
+/// Session ids present on disk for a jurisdiction.
+pub fn sessions(repos_dir: &Path, jurisdiction: &Jurisdiction) -> Vec<String> {
+    let Some(root) = jurisdiction_root(repos_dir, jurisdiction) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect();
+    ids.sort();
+    ids
+}
+
+/// Read every bill in a jurisdiction, optionally restricted to one session.
+///
+/// Bills stream through `visit` rather than accumulating, so a caller that only
+/// wants twenty rows out of Illinois' 12,780 bills never holds them all.
+pub fn for_each_bill<F>(
+    repos_dir: &Path,
+    jurisdiction: &Jurisdiction,
+    session_filter: Option<&str>,
+    mut visit: F,
+) -> Result<()>
+where
+    F: FnMut(BillRecord) -> Result<ControlFlow>,
+{
+    let Some(root) = jurisdiction_root(repos_dir, jurisdiction) else {
+        return Ok(());
+    };
+    let repo_name = jurisdiction.repo_name();
+    let commit = head_commit(&repo_dir(repos_dir, jurisdiction));
+
+    for session_id in sessions(repos_dir, jurisdiction) {
+        if let Some(wanted) = session_filter {
+            if session_id != wanted {
+                continue;
+            }
+        }
+        let bills_dir = root.join(&session_id).join("bills");
+        let Ok(entries) = std::fs::read_dir(&bills_dir) else {
+            continue;
+        };
+
+        let mut bill_dirs: Vec<PathBuf> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+        // Deterministic order, so output and snapshots are stable.
+        bill_dirs.sort();
+
+        for dir in bill_dirs {
+            let metadata_path = dir.join("metadata.json");
+            let Ok(raw) = std::fs::read_to_string(&metadata_path) else {
+                continue;
+            };
+            let Ok(metadata) = serde_json::from_str::<Value>(&raw) else {
+                continue;
+            };
+
+            let bill_id = dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            let identifier = metadata
+                .get("identifier")
+                .and_then(Value::as_str)
+                .unwrap_or(&bill_id)
+                .to_string();
+
+            let record = BillRecord {
+                jurisdiction: jurisdiction.clone(),
+                session_id: session_id.clone(),
+                bill_id,
+                identifier,
+                metadata,
+                dir: dir.clone(),
+                citation: Citation {
+                    repo: repo_name.clone(),
+                    commit: commit.clone(),
+                    path: relative_path(&dir.join("metadata.json"), repos_dir, &repo_name),
+                },
+            };
+
+            if visit(record)? == ControlFlow::Stop {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Whether a scan should keep going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlFlow {
+    Continue,
+    Stop,
+}
+
+/// Read the roll calls attached to one bill.
+pub fn vote_events(bill: &BillRecord, repos_dir: &Path) -> Vec<VoteEventRecord> {
+    let logs_dir = bill.dir.join("logs");
+    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
+        return Vec::new();
+    };
+
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(is_vote_event_file)
+        })
+        .collect();
+    paths.sort();
+
+    paths
+        .iter()
+        .filter_map(|path| read_vote_event(path, bill, repos_dir))
+        .collect()
+}
+
+fn read_vote_event(path: &Path, bill: &BillRecord, repos_dir: &Path) -> Option<VoteEventRecord> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
+
+    // The body is authoritative for `result`, not the filename.
+    let result = value
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let rows: Vec<RawVoteRow> = value
+        .get("votes")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| {
+                    let voter_name = entry.get("voter_name").and_then(Value::as_str)?;
+                    Some(RawVoteRow {
+                        voter_name: voter_name.to_string(),
+                        option: entry
+                            .get("option")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        note: entry
+                            .get("note")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let (votes, repaired_rows) = repair_split_rows(rows);
+
+    let mut counts = BTreeMap::new();
+    if let Some(entries) = value.get("counts").and_then(Value::as_array) {
+        for entry in entries {
+            let (Some(option), Some(count)) = (
+                entry.get("option").and_then(Value::as_str),
+                entry.get("value").and_then(Value::as_i64),
+            ) else {
+                continue;
+            };
+            counts.insert(option.to_string(), count);
+        }
+    }
+
+    Some(VoteEventRecord {
+        bill_identifier: value
+            .get("bill_identifier")
+            .and_then(Value::as_str)
+            .unwrap_or(&bill.identifier)
+            .to_string(),
+        motion_text: value
+            .get("motion_text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        start_date: value
+            .get("start_date")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        result,
+        chamber: pseudo_json_field(value.get("organization"), "classification"),
+        counts,
+        votes,
+        repaired_rows,
+        citation: Citation {
+            repo: bill.citation.repo.clone(),
+            commit: bill.citation.commit.clone(),
+            path: relative_path(path, repos_dir, &bill.citation.repo),
+        },
+    })
+}
+
+/// A path relative to the repository root, which is what a citation should show.
+fn relative_path(path: &Path, repos_dir: &Path, repo_name: &str) -> String {
+    let repo_root = repos_dir.join(repo_name);
+    path.strip_prefix(&repo_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_both_vote_event_filename_conventions() {
+        assert!(is_vote_event_file("20250522T105400Z.vote_event.pass.lower.json"));
+        assert!(is_vote_event_file("20250522T104600Z_vote_event_fail.json"));
+        assert!(!is_vote_event_file(
+            "20250129T022703Z_bill_number_assigned.json"
+        ));
+        assert!(!is_vote_event_file(
+            "20250131T030931Z.classification.introduction.lower.json"
+        ));
+    }
+
+    #[test]
+    fn unwraps_pseudo_json_organization_blobs() {
+        let value = serde_json::json!("~{\"classification\": \"lower\"}");
+        assert_eq!(pseudo_json_field(Some(&value), "classification"), "lower");
+
+        let value = serde_json::json!("~{\"name\": \"Appropriations\"}");
+        assert_eq!(pseudo_json_field(Some(&value), "name"), "Appropriations");
+
+        // Garbage in, empty string out — never a panic.
+        let value = serde_json::json!("not json at all");
+        assert_eq!(pseudo_json_field(Some(&value), "classification"), "");
+        assert_eq!(pseudo_json_field(None, "classification"), "");
+    }
+
+    #[test]
+    fn reads_string_arrays_defensively() {
+        let value = serde_json::json!(["Transportation", "Consumer Protection"]);
+        assert_eq!(string_array(Some(&value)).len(), 2);
+        assert!(string_array(None).is_empty());
+        assert!(string_array(Some(&serde_json::json!("not an array"))).is_empty());
+    }
+}

--- a/actions/govbot/src/query/scan.rs
+++ b/actions/govbot/src/query/scan.rs
@@ -199,11 +199,67 @@ impl VoteEventRecord {
 }
 
 /// Resolve the commit a repository is currently on, for citations.
+///
+/// Tries libgit2 first, then falls back to reading git's own files. The fallback
+/// is not redundant: libgit2 refuses to open a repository declaring an extension
+/// it does not recognise, and `--filter=blob:none` partial clones declare
+/// `extensions.partialClone`. Those clones are exactly what someone fetching a
+/// large jurisdiction ends up with, and a citation without a commit is a citation
+/// nobody can check.
 pub fn head_commit(repo_path: &Path) -> Option<String> {
+    if let Some(sha) = head_commit_via_libgit2(repo_path) {
+        return Some(sha);
+    }
+    head_commit_from_files(repo_path)
+}
+
+fn head_commit_via_libgit2(repo_path: &Path) -> Option<String> {
     let repo = git2::Repository::open(repo_path).ok()?;
     let head = repo.head().ok()?;
     let commit = head.peel_to_commit().ok()?;
-    Some(commit.id().to_string()[..7].to_string())
+    Some(short_sha(&commit.id().to_string()))
+}
+
+/// Read `HEAD` and resolve it through loose refs and then `packed-refs`.
+fn head_commit_from_files(repo_path: &Path) -> Option<String> {
+    let git_dir = repo_path.join(".git");
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+
+    // A detached HEAD holds the object id directly.
+    let Some(reference) = head.strip_prefix("ref: ") else {
+        return is_object_id(head).then(|| short_sha(head));
+    };
+
+    if let Ok(contents) = std::fs::read_to_string(git_dir.join(reference)) {
+        let sha = contents.trim();
+        if is_object_id(sha) {
+            return Some(short_sha(sha));
+        }
+    }
+
+    // Shallow and freshly cloned repositories usually keep refs packed.
+    let packed = std::fs::read_to_string(git_dir.join("packed-refs")).ok()?;
+    for line in packed.lines() {
+        if line.starts_with('#') || line.starts_with('^') {
+            continue;
+        }
+        let Some((sha, name)) = line.split_once(' ') else {
+            continue;
+        };
+        if name.trim() == reference && is_object_id(sha) {
+            return Some(short_sha(sha));
+        }
+    }
+    None
+}
+
+fn is_object_id(value: &str) -> bool {
+    value.len() >= 7 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
 }
 
 /// Strip the `~` prefix govbot's upstream uses for pseudo-JSON blobs and pull one
@@ -505,6 +561,46 @@ mod tests {
         let value = serde_json::json!("not json at all");
         assert_eq!(pseudo_json_field(Some(&value), "classification"), "");
         assert_eq!(pseudo_json_field(None, "classification"), "");
+    }
+
+    #[test]
+    fn recognises_object_ids() {
+        assert!(is_object_id("9be2e4f61f0000000000000000000000000000aa"));
+        assert!(is_object_id("598ea01"));
+        assert!(!is_object_id("ref: refs/heads/main"));
+        assert!(!is_object_id("abc"));
+        assert_eq!(short_sha("9be2e4f61f00000"), "9be2e4f");
+    }
+
+    /// The fallback exists because libgit2 will not open a partial clone, which is
+    /// what `--filter=blob:none` produces.
+    #[test]
+    fn reads_head_from_git_files_including_packed_refs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let git = dir.path().join(".git");
+        std::fs::create_dir_all(git.join("refs/heads")).expect("mkdir");
+
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").expect("write");
+        std::fs::write(
+            git.join("packed-refs"),
+            "# pack-refs with: peeled fully-peeled sorted\n\
+             9be2e4f61f0000000000000000000000000000aa refs/heads/main\n",
+        )
+        .expect("write");
+        assert_eq!(head_commit_from_files(dir.path()).as_deref(), Some("9be2e4f"));
+
+        // A loose ref wins over packed-refs.
+        std::fs::write(
+            git.join("refs/heads/main"),
+            "1111111000000000000000000000000000000000\n",
+        )
+        .expect("write");
+        assert_eq!(head_commit_from_files(dir.path()).as_deref(), Some("1111111"));
+
+        // Detached HEAD.
+        std::fs::write(git.join("HEAD"), "2222222000000000000000000000000000000000\n")
+            .expect("write");
+        assert_eq!(head_commit_from_files(dir.path()).as_deref(), Some("2222222"));
     }
 
     #[test]

--- a/actions/govbot/tests/snapshots/cli_example_snaps__snapshot@govbot_help.snap
+++ b/actions/govbot/tests/snapshots/cli_example_snaps__snapshot@govbot_help.snap
@@ -12,6 +12,7 @@ Usage: govbot [COMMAND]
 
 Commands:
   clone   Clone or pull data pipeline repositories (default: updates existing repos) Clones if repository doesn't exist, pulls if it does Use "govbot clone all" to clone all repos, or "govbot clone <repo>" for specific repos
+  query   Query cloned legislation and get back a bounded, cited JSON answer
   logs    Process and display pipeline log files
   delete  Delete data pipeline repositories Deletes local repository directories for specified locales
   load    Load bill metadata into a DuckDB database file Loads all metadata.json files from cloned repos into a DuckDB database for analysis. The database file is saved in the base govbot directory (e.g., ./govbot_data/govbot.duckdb)

--- a/actions/mcp/.gitignore
+++ b/actions/mcp/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/actions/mcp/.gitignore
+++ b/actions/mcp/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+govbot.mcpb

--- a/actions/mcp/README.md
+++ b/actions/mcp/README.md
@@ -1,0 +1,98 @@
+# govbot MCP
+
+Ask Claude Desktop about your representatives, using government data cloned to your
+own computer.
+
+> **Who are my reps, and how do they align to my values?**
+
+This is a thin adapter over the `govbot` command-line tool. It owns no database and
+no data model — every answer comes from `govbot`, so anything Claude tells you can
+be reproduced from a terminal in the same folder.
+
+## What it does
+
+1. Creates a **workspace** — a folder you own, holding your configuration and the
+   data cloned so far. It is a git repository from the start, so you can publish it.
+2. **Clones** legislation for the jurisdictions you care about, from public git
+   repositories. No account, no API key, and no record of what you look up.
+3. **Saves what you care about** as topic definitions in plain YAML you can edit.
+4. **Tags** bills against those topics with an AI model that runs on your machine.
+5. **Answers questions** with citations back to a repository, commit, and file path.
+
+## Requirements
+
+- Node 20+
+- The `govbot` CLI:
+  ```bash
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/chihacknight/govbot/main/actions/govbot/scripts/install-nightly.sh)"
+  ```
+
+## Install into Claude Desktop
+
+Add this to `claude_desktop_config.json` (Settings → Developer → Edit Config):
+
+```json
+{
+  "mcpServers": {
+    "govbot": {
+      "command": "node",
+      "args": ["/absolute/path/to/actions/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Then restart Claude Desktop and ask *"Who are my reps, and how do they align to my
+values?"* — or pick the **who_are_my_reps** prompt.
+
+### Configuration
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `GOVBOT_WORKSPACE` | Where the workspace folder lives | `~/govbot-workspace` |
+| `GOVBOT_BIN` | Path to the `govbot` binary | `~/.govbot/bin/govbot`, else `PATH` |
+
+## What it will not do
+
+**It never asks for your address.** Finding out who represents you means a district
+lookup, and doing that server-side would mean sending your home address to a
+geocoder. Instead Claude asks who your representatives are and points you at
+[openstates.org/find_your_legislator](https://openstates.org/find_your_legislator/)
+or [congress.gov](https://www.congress.gov/members/find-your-member).
+
+**It never invents a voting record.** Coverage is uneven and the tools say so:
+Massachusetts publishes over eleven thousand bills and *zero* roll-call votes, and
+Alaska publishes vote totals without recording how individuals voted. Every response
+carries a coverage report, so "no results" is never confused with "your
+representative did nothing".
+
+**It does not guess between two people with the same surname.** govbot has no
+legislator roster — sponsors and voters are names. Every match carries a confidence,
+`--min-confidence` gates what can be attributed, and an ambiguous name returns the
+candidates rather than a guess. Wyoming has two legislators named Brown; asking about
+"Brown" attributes nothing and asks you which one you meant.
+
+## Development
+
+```bash
+npm install
+npm run build
+npm test                # unit tests
+./render-snapshots.sh   # regenerate __snapshots__/
+```
+
+Drive the server by hand:
+
+```bash
+node scripts/mcp-session.mjs __snapshots__/requests-surface.jsonl
+```
+
+That script also enforces the rule everything else depends on: **stdout carries
+JSON-RPC frames and nothing else.** A stray `console.log` corrupts the transport and
+Claude Desktop disconnects without an error message. All diagnostics go to stderr.
+
+## Snapshots
+
+`__snapshots__/surface.json` is the full tool, resource, and prompt surface. The
+descriptions in it are shown to people when Claude asks permission to run something,
+so changes to that wording are worth reviewing — the snapshot makes them a diff.

--- a/actions/mcp/TESTING.md
+++ b/actions/mcp/TESTING.md
@@ -1,0 +1,87 @@
+# Testing govbot in Claude Desktop
+
+## It is already installed on this machine
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` now has a `govbot`
+entry (the previous file was backed up alongside it). **Quit Claude Desktop
+completely and reopen it** — it only reads that file at startup.
+
+You should then see govbot under Settings → Developer, and a 🔌 icon in the chat
+composer listing six tools.
+
+Two details in that config are deliberate, and are the usual reasons a local MCP
+server fails to start:
+
+- `command` is the **absolute path** to node. Claude Desktop launches servers with a
+  minimal environment, and a bare `node` is not found.
+- `env.PATH` is set so the server can find `git`, which `govbot clone` needs.
+
+## Try this first
+
+> **Who are my reps, and how do they align to my values?**
+
+Illinois and Congress are already cloned (`~/govbot-workspace/govbot_data`), and the
+local tagging model is already downloaded, so you should not have to wait.
+
+You can also pick **who_are_my_reps** from the prompt picker (the `+` in the
+composer) instead of typing.
+
+## Worth checking specifically
+
+These are the behaviours that matter more than the happy path.
+
+**1. It should never ask for your address.** Say *"I live at 123 Main St, Chicago"*
+and watch what it does. It should decline to use that and point you at
+openstates.org instead. Verify nothing sent it onward:
+
+```bash
+grep -ri "123 Main" ~/Library/Logs/Claude/mcp-server-govbot.log
+```
+
+**2. It should refuse to guess between two people with the same name.** Ask about a
+Wyoming legislator named **Brown** (clone Wyoming first: *"clone Wyoming"*). There
+are two. It should name both and ask which you meant, not pick one.
+
+**3. It should say when data does not exist, rather than implying inaction.** Clone
+Massachusetts and ask how one of your state representatives voted on something.
+Massachusetts publishes 11,287 bills and **zero** roll-call votes. The honest answer
+is "that state does not publish this", not "no votes found".
+
+**4. Every claim should carry a citation.** Ask it to show you where a claim came
+from. You should get a repository, a commit, and a path — check one:
+
+```bash
+cat ~/govbot-workspace/govbot_data/repos/il-legislation/country:us/state:il/sessions/104th/bills/SB3763/metadata.json
+```
+
+**5. The workspace should be yours.** Open `~/govbot-workspace/govbot.yml` after you
+have told it what you care about. It should describe your values in plain YAML you
+can edit. Change something and ask it to re-tag.
+
+## Running the same queries yourself
+
+Everything Claude does is reproducible from a terminal:
+
+```bash
+cd ~/govbot-workspace
+~/.govbot/bin/govbot query coverage
+~/.govbot/bin/govbot query bills --jurisdiction il --text "rent" --limit 10
+~/.govbot/bin/govbot query votes --jurisdiction il --person "Cunningham, Bill" --limit 5
+~/.govbot/bin/govbot logs | ~/.govbot/bin/govbot tag --overwrite
+```
+
+## If it does not start
+
+```bash
+tail -50 ~/Library/Logs/Claude/mcp-server-govbot.log
+```
+
+The server prints a `ready` line on startup. If you see nothing, the launch failed
+before that — usually node or the config path.
+
+## Testing the bundle instead
+
+`govbot.mcpb` (3.2 MB) is the one-file install a non-technical person would use.
+To test that path, first **remove the `govbot` entry from
+claude_desktop_config.json** so you are not running two copies, then open the
+bundle. It is unsigned, so macOS will warn.

--- a/actions/mcp/__snapshots__/requests-surface.jsonl
+++ b/actions/mcp/__snapshots__/requests-surface.jsonl
@@ -1,0 +1,5 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"snapshot","version":"1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"resources/list","params":{}}
+{"jsonrpc":"2.0","id":4,"method":"prompts/list","params":{}}

--- a/actions/mcp/__snapshots__/surface.json
+++ b/actions/mcp/__snapshots__/surface.json
@@ -139,7 +139,7 @@
                       "type": "array"
                     },
                     "threshold": {
-                      "description": "Score a bill must reach. Use 0.72; the 0.5 default tags everything.",
+                      "description": "Score a bill must reach. Use 0.72 with no negative_examples, or 0.55 with them \u2014 negative examples lower every score by about 0.17, so 0.72 alongside them matches nothing.",
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"

--- a/actions/mcp/__snapshots__/surface.json
+++ b/actions/mcp/__snapshots__/surface.json
@@ -1,0 +1,329 @@
+[
+  {
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+      "capabilities": {
+        "prompts": {
+          "listChanged": true
+        },
+        "resources": {
+          "listChanged": true
+        },
+        "tools": {
+          "listChanged": true
+        }
+      },
+      "instructions": "<5535 characters>",
+      "protocolVersion": "2025-06-18",
+      "serverInfo": {
+        "name": "govbot",
+        "version": "<version>"
+      }
+    }
+  },
+  {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+      "tools": [
+        {
+          "description": "Create a folder on this computer for tracking legislation. You own it \u2014 it holds the data cloned so far and a plain-text file describing the topics you care about, and it can be published to GitHub or deleted at any time.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "properties": {},
+            "type": "object"
+          },
+          "name": "setup_workspace",
+          "title": "Create your legislation workspace"
+        },
+        {
+          "description": "Report which jurisdictions have been cloned, how many bills and recorded votes each has, and what questions that data can and cannot answer.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "jurisdictions": {
+                "description": "Jurisdictions to report on, as locale codes (`il`, `usa`) or Open Civic Data ids. Omit for everything already cloned.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "name": "check_local_data",
+          "title": "See what data is on this computer"
+        },
+        {
+          "description": "Download legislation for one or more jurisdictions from public git repositories to this computer. No account, no API key, and no record of what you look up \u2014 every later question is answered from the local copy.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "jurisdictions": {
+                "description": "Jurisdictions to clone, as locale codes: two-letter state codes (`il`, `wy`), `usa` for Congress, or `dc`, `pr`, `gu`, `vi`, `mp`.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "jurisdictions"
+            ],
+            "type": "object"
+          },
+          "name": "clone_government_data",
+          "title": "Privately clone government data"
+        },
+        {
+          "description": "Write the topics you care about into your workspace as reusable definitions. They are saved as plain YAML you can read, edit, and re-run yourself.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "topics": {
+                "description": "The topics to save.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "What this topic covers. Embedded and compared against every bill.",
+                      "type": "string"
+                    },
+                    "examples": {
+                      "description": "Two or three sentences describing bills that should match.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "exclude_keywords": {
+                      "description": "Terms that disqualify a bill from this topic.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "include_keywords": {
+                      "description": "Distinctive terms. Keep this tight: one keyword hit alone lifts a bill to the threshold, so a loose list turns semantic matching into keyword matching.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "A short name for the topic, e.g. 'renter protections'.",
+                      "type": "string"
+                    },
+                    "negative_examples": {
+                      "description": "Bills on this subject but on the other side of it. This is what turns a subject into a position \u2014 include them whenever the person expressed a direction, not just an interest.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "threshold": {
+                      "description": "Score a bill must reach. Use 0.72; the 0.5 default tags everything.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "description"
+                  ],
+                  "type": "object"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "topics"
+            ],
+            "type": "object"
+          },
+          "name": "save_my_values",
+          "title": "Save what you care about"
+        },
+        {
+          "description": "Score bills against your saved topics using an AI model that runs on this computer. Your topics and the bill text never leave the machine, and there is no per-use cost.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "jurisdictions": {
+                "description": "Jurisdictions to score. Omit for everything cloned.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "limit": {
+                "description": "Bills to score per jurisdiction. Scoring runs at roughly 25 bills per second, so keep this in the hundreds for an interactive answer.",
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "name": "tag_with_local_ai",
+          "title": "Tag legislation with a local AI model"
+        },
+        {
+          "description": "Search the legislation on this computer: bills, roll-call votes, the people named in the data, or a report of what the data covers. Every result carries the repository, commit, and file path it came from.",
+          "execution": {
+            "taskSupport": "forbidden"
+          },
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "identifier": {
+                "description": "A single bill, e.g. `HB1234`.",
+                "type": "string"
+              },
+              "jurisdictions": {
+                "description": "Locale codes (`il`, `usa`) or Open Civic Data ids such as `ocd-jurisdiction/country:us/state:il/government` or `ocd-division/country:us/state:il/sldl:4`. Omit for everything cloned.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "limit": {
+                "description": "Rows to return (default 20).",
+                "exclusiveMinimum": 0,
+                "maximum": 100,
+                "type": "integer"
+              },
+              "min_confidence": {
+                "description": "How certain a name match must be before anything is attributed to that person. Defaults to medium.",
+                "enum": [
+                  "any",
+                  "medium",
+                  "high",
+                  "exact"
+                ],
+                "type": "string"
+              },
+              "min_score": {
+                "description": "Lowest topic score to include. Defaults to the topic's threshold.",
+                "type": "number"
+              },
+              "person": {
+                "description": "A legislator's name, matched against sponsors and voters. If it comes back ambiguous, ask which person is meant rather than choosing.",
+                "type": "string"
+              },
+              "session": {
+                "description": "A single legislative session.",
+                "type": "string"
+              },
+              "subject": {
+                "description": "A subject term the jurisdiction assigned.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "A topic from save_my_values. Ranks and filters results by score.",
+                "type": "string"
+              },
+              "text": {
+                "description": "Words that must all appear in the bill, matched as whole words.",
+                "type": "string"
+              },
+              "type": {
+                "description": "bills: legislation. votes: roll calls. people: the names present in the data. coverage: what the data can and cannot answer.",
+                "enum": [
+                  "bills",
+                  "votes",
+                  "people",
+                  "coverage"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "name": "query",
+          "title": "Search cloned legislation"
+        }
+      ]
+    }
+  },
+  {
+    "id": 3,
+    "jsonrpc": "2.0",
+    "result": {
+      "resources": [
+        {
+          "description": "The topics recorded as yours, and the jurisdictions being tracked. Open this to check whether it describes what you actually meant.",
+          "mimeType": "application/yaml",
+          "name": "values",
+          "title": "Your saved values",
+          "uri": "govbot://workspace/govbot.yml"
+        },
+        {
+          "description": "What this folder is, how to run it yourself, and how to publish it.",
+          "mimeType": "text/markdown",
+          "name": "readme",
+          "title": "About your workspace",
+          "uri": "govbot://workspace/README.md"
+        },
+        {
+          "description": "Which jurisdictions are cloned, how much legislation each has, and whether it publishes individual votes.",
+          "mimeType": "text/plain",
+          "name": "coverage",
+          "title": "What your local data covers",
+          "uri": "govbot://workspace/coverage"
+        }
+      ]
+    }
+  },
+  {
+    "id": 4,
+    "jsonrpc": "2.0",
+    "result": {
+      "prompts": [
+        {
+          "arguments": [
+            {
+              "description": "Your state, e.g. Illinois \u2014 optional, Claude will ask if omitted.",
+              "name": "state",
+              "required": false
+            },
+            {
+              "description": "What you care about, in your own words \u2014 optional.",
+              "name": "values",
+              "required": false
+            }
+          ],
+          "description": "Walk through finding your representatives and comparing their record against what you care about.",
+          "name": "who_are_my_reps",
+          "title": "Who represents me, and how do they vote?"
+        }
+      ]
+    }
+  }
+]

--- a/actions/mcp/action.yml
+++ b/actions/mcp/action.yml
@@ -1,0 +1,22 @@
+name: "govbot MCP"
+description: "Build and snapshot the govbot MCP server for Claude Desktop."
+inputs:
+  node-version:
+    description: "Node version to build with"
+    required: false
+    default: "20"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Install dependencies
+      shell: bash
+      run: npm ci --prefix actions/mcp || npm install --prefix actions/mcp
+    - name: Typecheck and build
+      shell: bash
+      run: npm run build --prefix actions/mcp
+    - name: Test
+      shell: bash
+      run: npm test --prefix actions/mcp

--- a/actions/mcp/mcpb/manifest.json
+++ b/actions/mcp/mcpb/manifest.json
@@ -1,0 +1,69 @@
+{
+  "manifest_version": "0.2",
+  "name": "govbot",
+  "display_name": "govbot — U.S. Legislation",
+  "version": "0.1.0",
+  "description": "Ask about your representatives using government data cloned to your own computer.",
+  "long_description": "govbot turns every U.S. legislature into a git repository you can clone. This extension lets you ask questions about it in plain language — who represents you, what they have sponsored, and how they have voted — answered from data on your own machine, with a citation back to the exact file for every claim.\n\nNothing you ask leaves your computer. There is no account, no API key, and no server keeping a record of what you looked up. You are never asked for your address.\n\nCoverage is uneven and the extension says so: some states publish every roll-call vote, some publish only totals, and some publish none at all. Where the data cannot answer a question, it tells you that instead of guessing.",
+  "author": {
+    "name": "Chi Hack Night",
+    "url": "https://github.com/chihacknight/govbot"
+  },
+  "homepage": "https://github.com/chihacknight/govbot",
+  "documentation": "https://github.com/chihacknight/govbot/tree/main/actions/mcp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chihacknight/govbot"
+  },
+  "keywords": ["legislation", "government", "congress", "civic", "local-first"],
+  "license": "MIT",
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.js"],
+      "env": {
+        "GOVBOT_WORKSPACE": "${user_config.workspace}",
+        "GOVBOT_BIN": "${user_config.govbot_binary}"
+      }
+    }
+  },
+  "tools": [
+    { "name": "setup_workspace", "description": "Create a folder on this computer for tracking legislation." },
+    { "name": "check_local_data", "description": "Report what data is cloned and what it can answer." },
+    { "name": "clone_government_data", "description": "Privately clone legislation for a jurisdiction." },
+    { "name": "save_my_values", "description": "Save the topics you care about to your workspace." },
+    { "name": "tag_with_local_ai", "description": "Score bills against your topics with a local AI model." },
+    { "name": "query", "description": "Search cloned legislation for bills, votes, and people." }
+  ],
+  "prompts": [
+    {
+      "name": "who_are_my_reps",
+      "description": "Find your representatives and compare their record against what you care about.",
+      "arguments": ["state", "values"],
+      "text": "I want to know who represents me and how their record lines up with what I care about."
+    }
+  ],
+  "user_config": {
+    "workspace": {
+      "type": "directory",
+      "title": "Workspace folder",
+      "description": "Where your configuration and the cloned legislation are kept. You own this folder and can publish or delete it at any time.",
+      "default": "${HOME}/govbot-workspace",
+      "required": false
+    },
+    "govbot_binary": {
+      "type": "string",
+      "title": "Path to the govbot command-line tool",
+      "description": "Leave blank to look in ~/.govbot/bin and then on PATH. Install it with the one-line installer at github.com/chihacknight/govbot.",
+      "default": "",
+      "required": false
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": { "node": ">=20.0.0" }
+  }
+}

--- a/actions/mcp/package-lock.json
+++ b/actions/mcp/package-lock.json
@@ -1,0 +1,1237 @@
+{
+  "name": "@govbot/mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@govbot/mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "yaml": "^2.6.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "govbot-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/actions/mcp/package.json
+++ b/actions/mcp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@govbot/mcp",
+  "version": "0.1.0",
+  "description": "Ask Claude Desktop about your representatives, using government data cloned to your own computer.",
+  "type": "module",
+  "license": "MIT",
+  "bin": { "govbot-mcp": "dist/index.js" },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "node --test dist/*.test.js",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "yaml": "^2.6.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": { "node": ">=20" }
+}

--- a/actions/mcp/render-snapshots.sh
+++ b/actions/mcp/render-snapshots.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Render the MCP server's snapshots.
+#
+# The tool surface is the contract with Claude Desktop, and the tool descriptions
+# are shown to the person being asked for permission. Snapshotting both means a
+# reworded description shows up as a reviewable diff rather than slipping out
+# unnoticed.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+OUT="${1:-__snapshots__}"
+
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..." >&2
+  npm install --silent
+fi
+npm run build --silent
+
+echo "Rendering tool surface..." >&2
+# A throwaway workspace, so snapshots never depend on the machine they ran on.
+GOVBOT_WORKSPACE="$(mktemp -d)" \
+  node scripts/mcp-session.mjs "$OUT/requests-surface.jsonl" \
+  | python3 scripts/normalize-snapshot.py > "$OUT/surface.json"
+
+echo "Wrote $OUT/surface.json" >&2

--- a/actions/mcp/scripts/build-bundle.sh
+++ b/actions/mcp/scripts/build-bundle.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build govbot.mcpb — the one-file install for Claude Desktop.
+#
+# The bundle has to run without an `npm install` on the far side, so production
+# dependencies are staged into it. Source maps and tests are left out; they only
+# make the download bigger.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+OUT="${1:-$ROOT/govbot.mcpb}"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Building..." >&2
+npm install --silent
+npm run build --silent
+
+mkdir -p "$STAGE/server"
+cp -R dist/. "$STAGE/server/"
+rm -f "$STAGE/server"/*.map "$STAGE/server"/*.test.js
+cp mcpb/manifest.json "$STAGE/manifest.json"
+cp package.json "$STAGE/server/package.json"
+
+echo "Staging production dependencies..." >&2
+(cd "$STAGE/server" && npm install --silent --omit=dev --no-package-lock)
+
+npx --yes @anthropic-ai/mcpb@2.1.2 validate "$STAGE/manifest.json"
+
+# A bundle that cannot answer tools/list is not worth shipping, so prove it runs
+# from the staging directory before packing it.
+echo "Verifying the staged server starts..." >&2
+# Collected rather than piped into grep: `grep -q` exits on its first match, and
+# under `pipefail` the resulting SIGPIPE on node would fail the whole pipeline.
+PROBE=$(printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"build","version":"1"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | GOVBOT_WORKSPACE="$(mktemp -d)" node "$STAGE/server/index.js" 2>/dev/null)
+
+case "$PROBE" in
+  *'"tools"'*) ;;
+  *) echo "The staged server did not answer tools/list." >&2; exit 1 ;;
+esac
+
+npx --yes @anthropic-ai/mcpb@2.1.2 pack "$STAGE" "$OUT"
+echo "Wrote $OUT" >&2

--- a/actions/mcp/scripts/mcp-session.mjs
+++ b/actions/mcp/scripts/mcp-session.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Drive the MCP server over stdio with a scripted sequence of JSON-RPC requests
+ * and print the responses.
+ *
+ * Used by render-snapshots.sh, and by hand when you want to see what a tool
+ * actually returns. Also the one place that checks the rule the whole transport
+ * depends on: stdout must carry JSON-RPC frames and nothing else.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const [, , requestsFile] = process.argv;
+if (!requestsFile) {
+  process.stderr.write("usage: mcp-session.mjs <requests.jsonl>\n");
+  process.exit(2);
+}
+
+const requests = readFileSync(requestsFile, "utf8").trimEnd();
+const child = spawn(process.execPath, ["dist/index.js"], {
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stdout = "";
+child.stdout.on("data", (chunk) => (stdout += chunk));
+child.stderr.on("data", () => {
+  // Diagnostics belong on stderr and are deliberately not part of the snapshot.
+});
+
+child.stdin.end(requests + "\n");
+
+child.on("close", () => {
+  const lines = stdout.split("\n").filter((line) => line.trim());
+  const impure = [];
+  const messages = [];
+
+  for (const line of lines) {
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      impure.push(line);
+    }
+  }
+
+  if (impure.length) {
+    process.stderr.write(
+      `stdout carried ${impure.length} line(s) that are not JSON-RPC:\n` +
+        impure.map((l) => `  ${l.slice(0, 200)}`).join("\n") +
+        "\nThis corrupts the MCP transport and disconnects the client.\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(JSON.stringify(messages, null, 2) + "\n");
+});

--- a/actions/mcp/scripts/normalize-snapshot.py
+++ b/actions/mcp/scripts/normalize-snapshot.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Strip machine- and release-specific values out of a captured MCP session.
+
+Snapshots exist to make changes to the tool surface reviewable. Anything that
+varies between runs — a version number, a temp path, the length of the
+instructions blob — is noise that would make every diff unreadable, so it is
+replaced with a placeholder here.
+"""
+
+import json
+import sys
+
+
+def normalize(messages: list) -> list:
+    for message in messages:
+        result = message.get("result")
+        if not isinstance(result, dict):
+            continue
+        if "serverInfo" in result:
+            result["serverInfo"]["version"] = "<version>"
+            instructions = result.get("instructions", "")
+            result["instructions"] = f"<{len(instructions)} characters>"
+    return messages
+
+
+if __name__ == "__main__":
+    json.dump(normalize(json.load(sys.stdin)), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")

--- a/actions/mcp/src/govbot.ts
+++ b/actions/mcp/src/govbot.ts
@@ -1,0 +1,198 @@
+/**
+ * Running the `govbot` CLI as a child process.
+ *
+ * This server owns no data model of its own. Everything it reports comes from
+ * `govbot`, so that terminal users and Claude Desktop users see the same
+ * answers from the same code.
+ *
+ * One hard rule runs through this file: **nothing here may write to stdout.**
+ * Stdout is the MCP transport, and a single stray byte on it corrupts the
+ * JSON-RPC stream and disconnects the client with no visible error. All
+ * diagnostics go to stderr.
+ */
+
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** How a `govbot` invocation ended. */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Raised when the CLI is missing, failed, or produced something unreadable. */
+export class GovbotError extends Error {
+  constructor(
+    message: string,
+    readonly detail?: string,
+  ) {
+    super(message);
+    this.name = "GovbotError";
+  }
+}
+
+/**
+ * Locate the `govbot` binary.
+ *
+ * Checked in order: an explicit override, the default install location used by
+ * `install-nightly.sh`, a local release build, then whatever is on `PATH`.
+ */
+export function resolveBinary(): string {
+  const override = process.env.GOVBOT_BIN;
+  if (override) return override;
+
+  const candidates = [
+    join(homedir(), ".govbot", "bin", "govbot"),
+    join(homedir(), ".cargo", "bin", "govbot"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next one; falling through to PATH is fine.
+    }
+  }
+  return "govbot";
+}
+
+/** Long enough for a clone of a large jurisdiction, which can take minutes. */
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+
+export interface RunOptions {
+  cwd?: string;
+  timeoutMs?: number;
+  /** Fed to the process on stdin, for `govbot tag`. */
+  stdin?: string;
+  /** Called with each chunk of stderr, for progress reporting. */
+  onProgress?: (chunk: string) => void;
+}
+
+/**
+ * Run `govbot` and collect its output.
+ *
+ * Resolves even when the command fails, so callers can decide what a non-zero
+ * exit means; only a missing binary or a timeout rejects.
+ */
+export function run(args: string[], options: RunOptions = {}): Promise<CommandResult> {
+  const binary = resolveBinary();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, args, {
+      cwd: options.cwd,
+      // Inherit the environment so GOVBOT_DIR and friends keep working, but
+      // never a TTY — govbot's wizard is interactive when stdin is a terminal.
+      env: { ...process.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(
+        new GovbotError(
+          `\`govbot ${args[0] ?? ""}\` did not finish within ${Math.round(timeoutMs / 1000)}s.`,
+          stderr.slice(-2000),
+        ),
+      );
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      options.onProgress?.(text);
+    });
+
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error.code === "ENOENT") {
+        reject(
+          new GovbotError(
+            `The govbot command-line tool was not found (looked for "${binary}").`,
+            "Install it with:\n" +
+              '  sh -c "$(curl -fsSL https://raw.githubusercontent.com/chihacknight/govbot/main/actions/govbot/scripts/install-nightly.sh)"\n' +
+              "Or set GOVBOT_BIN to its full path.",
+          ),
+        );
+        return;
+      }
+      reject(new GovbotError(`Could not run govbot: ${error.message}`));
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code: code ?? -1 });
+    });
+
+    // The child may exit before consuming all of stdin — `govbot tag` bails out
+    // early on a bad config, for instance. Without this handler the resulting
+    // EPIPE is an unhandled 'error' event, which takes down the whole server and
+    // disconnects Claude Desktop with no explanation.
+    child.stdin.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code !== "EPIPE") {
+        options.onProgress?.(`stdin error: ${error.message}`);
+      }
+    });
+
+    if (options.stdin !== undefined) {
+      child.stdin.end(options.stdin);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+/**
+ * Run a `govbot` subcommand that prints JSON, and parse it.
+ *
+ * A non-zero exit is surfaced with the CLI's own stderr attached, because that
+ * message is usually the actionable one ("run `govbot clone` first").
+ */
+export async function runJson<T = unknown>(
+  args: string[],
+  options: RunOptions = {},
+): Promise<T> {
+  const result = await run(args, options);
+
+  if (result.code !== 0) {
+    throw new GovbotError(
+      `\`govbot ${args.join(" ")}\` failed.`,
+      result.stderr.trim() || result.stdout.trim() || `Exit code ${result.code}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new GovbotError(
+      `\`govbot ${args[0] ?? ""}\` did not return readable JSON.`,
+      result.stdout.slice(0, 500),
+    );
+  }
+}
+
+/** The installed CLI version, or `null` if it could not be run at all. */
+export async function version(): Promise<string | null> {
+  try {
+    const result = await run(["--version"], { timeoutMs: 10_000 });
+    return result.code === 0 ? result.stdout.trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/actions/mcp/src/index.ts
+++ b/actions/mcp/src/index.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+/**
+ * govbot for Claude Desktop.
+ *
+ * A thin adapter over the `govbot` command-line tool. It owns no data model and
+ * no index; everything it reports comes from the CLI, so a person can reproduce
+ * any answer from a terminal in the same workspace folder.
+ *
+ * Stdout belongs to the MCP transport. Nothing in this process may print to it.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+import { SERVER_INSTRUCTIONS } from "./instructions.js";
+import * as tools from "./tools.js";
+import * as workspace from "./workspace.js";
+
+const VERSION = "0.1.0";
+
+/** Diagnostics go to stderr. Writing to stdout would corrupt the transport. */
+function log(message: string): void {
+  process.stderr.write(`[govbot-mcp] ${message}\n`);
+}
+
+const server = new McpServer(
+  { name: "govbot", version: VERSION },
+  { instructions: SERVER_INSTRUCTIONS },
+);
+
+/** Turn a tool result into MCP content, and never throw out of a handler. */
+function respond(output: tools.ToolOutput) {
+  return {
+    content: [{ type: "text" as const, text: output.text }],
+    ...(output.isError ? { isError: true } : {}),
+  };
+}
+
+function failure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  log(`tool error: ${message}`);
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "setup_workspace",
+  {
+    title: "Create your legislation workspace",
+    description:
+      "Create a folder on this computer for tracking legislation. You own it — it holds " +
+      "the data cloned so far and a plain-text file describing the topics you care about, " +
+      "and it can be published to GitHub or deleted at any time.",
+    inputSchema: tools.setupWorkspaceSchema,
+  },
+  async () => {
+    try {
+      return respond(await tools.setupWorkspace());
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+server.registerTool(
+  "check_local_data",
+  {
+    title: "See what data is on this computer",
+    description:
+      "Report which jurisdictions have been cloned, how many bills and recorded votes " +
+      "each has, and what questions that data can and cannot answer.",
+    inputSchema: tools.checkLocalDataSchema,
+  },
+  async (args) => {
+    try {
+      return respond(await tools.checkLocalData(args));
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+server.registerTool(
+  "clone_government_data",
+  {
+    title: "Privately clone government data",
+    description:
+      "Download legislation for one or more jurisdictions from public git repositories " +
+      "to this computer. No account, no API key, and no record of what you look up — " +
+      "every later question is answered from the local copy.",
+    inputSchema: tools.cloneSchema,
+  },
+  async (args, extra) => {
+    try {
+      return respond(
+        await tools.clone(args, (message) => {
+          extra.sendNotification?.({
+            method: "notifications/message",
+            params: { level: "info", data: message },
+          }).catch(() => {
+            // Progress is best-effort; a client that does not accept it is fine.
+          });
+        }),
+      );
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+server.registerTool(
+  "save_my_values",
+  {
+    title: "Save what you care about",
+    description:
+      "Write the topics you care about into your workspace as reusable definitions. " +
+      "They are saved as plain YAML you can read, edit, and re-run yourself.",
+    inputSchema: tools.saveValuesSchema,
+  },
+  async (args) => {
+    try {
+      return respond(await tools.saveValues(args));
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+server.registerTool(
+  "tag_with_local_ai",
+  {
+    title: "Tag legislation with a local AI model",
+    description:
+      "Score bills against your saved topics using an AI model that runs on this " +
+      "computer. Your topics and the bill text never leave the machine, and there is " +
+      "no per-use cost.",
+    inputSchema: tools.tagSchemaInput,
+  },
+  async (args, extra) => {
+    try {
+      return respond(
+        await tools.tagWithLocalAi(args, (message) => {
+          extra.sendNotification?.({
+            method: "notifications/message",
+            params: { level: "info", data: message },
+          }).catch(() => {});
+        }),
+      );
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+server.registerTool(
+  "query",
+  {
+    title: "Search cloned legislation",
+    description:
+      "Search the legislation on this computer: bills, roll-call votes, the people " +
+      "named in the data, or a report of what the data covers. Every result carries the " +
+      "repository, commit, and file path it came from.",
+    inputSchema: tools.querySchema,
+  },
+  async (args) => {
+    try {
+      return respond(await tools.query(args));
+    } catch (error) {
+      return failure(error);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Resources — the workspace, so a person can inspect what was decided for them
+// ---------------------------------------------------------------------------
+
+server.registerResource(
+  "values",
+  "govbot://workspace/govbot.yml",
+  {
+    title: "Your saved values",
+    description:
+      "The topics recorded as yours, and the jurisdictions being tracked. Open this to " +
+      "check whether it describes what you actually meant.",
+    mimeType: "application/yaml",
+  },
+  async (uri) => {
+    const text = await readFile(workspace.configPath(), "utf8").catch(
+      () => "# No workspace yet. Ask Claude to set one up.\n",
+    );
+    return { contents: [{ uri: uri.href, mimeType: "application/yaml", text }] };
+  },
+);
+
+server.registerResource(
+  "readme",
+  "govbot://workspace/README.md",
+  {
+    title: "About your workspace",
+    description: "What this folder is, how to run it yourself, and how to publish it.",
+    mimeType: "text/markdown",
+  },
+  async (uri) => {
+    const text = await readFile(
+      `${workspace.workspacePath()}/README.md`,
+      "utf8",
+    ).catch(() => "# No workspace yet. Ask Claude to set one up.\n");
+    return { contents: [{ uri: uri.href, mimeType: "text/markdown", text }] };
+  },
+);
+
+server.registerResource(
+  "coverage",
+  "govbot://workspace/coverage",
+  {
+    title: "What your local data covers",
+    description:
+      "Which jurisdictions are cloned, how much legislation each has, and whether it " +
+      "publishes individual votes.",
+    mimeType: "text/plain",
+  },
+  async (uri) => {
+    const output = await tools.checkLocalData({});
+    return { contents: [{ uri: uri.href, mimeType: "text/plain", text: output.text }] };
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Prompt — so the flow is one click for someone who does not know what to type
+// ---------------------------------------------------------------------------
+
+server.registerPrompt(
+  "who_are_my_reps",
+  {
+    title: "Who represents me, and how do they vote?",
+    description:
+      "Walk through finding your representatives and comparing their record against " +
+      "what you care about.",
+    argsSchema: {
+      state: z
+        .string()
+        .optional()
+        .describe("Your state, e.g. Illinois — optional, Claude will ask if omitted."),
+      values: z
+        .string()
+        .optional()
+        .describe("What you care about, in your own words — optional."),
+    },
+  },
+  ({ state, values }) => ({
+    messages: [
+      {
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: [
+            "I want to know who represents me and how their record lines up with what I care about.",
+            state ? `I live in ${state}.` : "",
+            values ? `What I care about: ${values}` : "",
+            "",
+            "Please start by checking what data is already on this computer, then ask me for",
+            "anything you need. Don't ask for my address — point me at a lookup site instead.",
+            "Tell me plainly where the data can't answer a question rather than guessing.",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      },
+    ],
+  }),
+);
+
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log(`ready (v${VERSION}, workspace ${workspace.workspacePath()})`);
+}
+
+main().catch((error) => {
+  log(`fatal: ${error instanceof Error ? error.stack : String(error)}`);
+  process.exit(1);
+});

--- a/actions/mcp/src/instructions.ts
+++ b/actions/mcp/src/instructions.ts
@@ -1,0 +1,116 @@
+/**
+ * What the model driving these tools needs to know.
+ *
+ * This text is sent in the `initialize` response and is the only place the
+ * server can teach a client two things it cannot learn from tool schemas: how
+ * to author a topic definition that actually works, and what it must never
+ * claim about legislative data.
+ */
+
+export const SERVER_INSTRUCTIONS = `
+govbot answers questions about US legislation from public git repositories cloned
+to this computer. It covers all 50 states, Congress, DC, and five territories.
+
+## The usual flow
+
+1. \`check_local_data\` — see what is already here.
+2. Ask the person which state they are in, and who represents them. **Never ask for
+   a street address, and never send one anywhere.** If they do not know their
+   representatives, point them at https://openstates.org/find_your_legislator/ for
+   state legislators and districts, or https://www.congress.gov/members/find-your-member
+   for Congress. Say why you are asking rather than looking it up: it means their
+   address never leaves their computer.
+3. \`clone_government_data\` for their state and, usually, \`usa\` for Congress.
+4. \`save_my_values\` — turn what they care about into topic definitions.
+5. \`tag_with_local_ai\` — score bills against those topics.
+6. \`query\` — pull the bills and votes, then read them and judge for yourself.
+
+## What you must not do
+
+**Never state how someone voted without a row from \`query\` to back it.** Every
+result carries a citation and, where a person was matched by name, a confidence.
+Cite the bill identifier when you make a claim.
+
+**Coverage is uneven, and the difference matters.** Every response carries a
+\`coverage\` block. If \`roll_call_data\` is \`"none"\`, that jurisdiction publishes no
+roll-call votes at all — Massachusetts has over eleven thousand bills and zero
+recorded votes. Say the data does not exist. Do not say the legislator has not
+voted on something, and do not let silence imply it. If it is \`"counts_only"\`,
+report the tallies and attribute nothing to any individual.
+
+**Read the \`caveats\` on every response and act on them.** They are written for you,
+not for the user, and they describe what this particular answer cannot support.
+
+**govbot has no legislator roster.** People are matched by name against the names in
+the data. A \`match.confidence\` below \`high\` means a name match, not a verified
+identity — say so. If a match comes back \`ambiguous\`, the tool has deliberately
+attributed nothing and listed the candidates; ask which person is meant rather than
+picking one.
+
+**An empty result is not evidence of inaction.** "We found no matching bills" and
+"this jurisdiction publishes no such data" are different claims. The caveats tell
+you which one you have.
+
+**Judge stance yourself.** The tagger finds bills that are *about* a topic; it has
+no notion of for or against. Read the title, the abstract, and the person's actual
+vote before saying whether something aligns with what they told you.
+
+## Writing topic definitions
+
+\`save_my_values\` takes topics you write. A definition scores every bill from 0 to 1
+and keeps those at or above its threshold.
+
+Two things about how this actually behaves, measured against real Illinois bills —
+they are not what the field names suggest:
+
+- **\`include_keywords\` carries almost all the signal.** Bill titles are terse
+  ("MOBILE HOME RENT CAP"), so the embedding barely separates on-topic from
+  off-topic: a rent bill scored 0.606 and an unrelated drinking-age bill scored
+  0.596. A keyword hit, by contrast, lifts a bill straight to the threshold. Choose
+  keywords that are distinctive and unambiguous, and expect them — not the prose —
+  to decide what matches.
+- **\`negative_examples\` shift every score down by roughly the same amount** rather
+  than separating bills that are for a thing from bills that are against it. On the
+  bills above they cost about 0.17 uniformly. They do not give you a stance filter.
+
+So:
+
+- **description** (required) — what the topic covers, in a sentence or three.
+- **examples** — two or three sentences describing matching bills, phrased the way
+  a bill summary would be.
+- **include_keywords** — the load-bearing field. Distinctive terms only.
+- **exclude_keywords** — a hard filter: any hit scores the bill zero. This is the
+  one reliable way to keep a category of bill out.
+- **threshold** — **0.72 when you have no negative_examples.** If you do include
+  negative_examples, use **0.55**, because 0.72 minus their penalty is unreachable
+  and the topic will silently match nothing at all.
+
+A worked example:
+
+    name: renter protections
+    description: |
+      Bills that strengthen the position of tenants — rent stabilization, limits on
+      rent increases, just-cause eviction requirements, security deposit caps, and
+      habitability enforcement.
+    examples:
+      - "Caps annual rent increases and requires just cause for eviction"
+      - "Extends the notice a landlord must give before terminating a tenancy"
+    include_keywords: [tenant, eviction, rent control, habitability, security deposit]
+    threshold: 0.72
+
+**Because the tagger is coarse, prefer \`query\` with \`text\` for precision.** A text
+search matches whole words against the identifier, title, abstract, and subjects,
+and is usually the better way to find the bills relevant to someone's values.
+Use the tagger to rank and to catch wording you did not think of, then read the
+results and judge for yourself which side of an issue each bill is on. That
+judgment is yours — no threshold can make it.
+
+Show the person the topics you wrote and offer to adjust them. They are saved in
+the workspace as plain YAML they can edit.
+
+## The workspace
+
+Everything lives in one folder the person owns. Tell them where it is, and that
+they can open \`govbot.yml\` to see exactly what you decided their values were,
+change it, re-run it from a terminal, or publish the folder to GitHub.
+`.trim();

--- a/actions/mcp/src/tools.test.ts
+++ b/actions/mcp/src/tools.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the pure helpers in the tool layer.
+ *
+ * The parts that shell out to `govbot` are covered by the snapshot session in
+ * `render-snapshots.sh`; what is worth unit-testing here are the small decisions
+ * that would fail silently and wrongly.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { detectTaggingMode, normalizeLocale } from "./tools.js";
+
+test("keyword fallback is detected rather than passed off as AI tagging", () => {
+  // govbot falls back to keyword matching when the model cannot be loaded, and
+  // says so only on stderr. Reporting those results as AI-tagged would be an
+  // accuracy regression the person cannot see.
+  assert.equal(
+    detectTaggingMode("Embedding files not available; using keyword-based matching."),
+    "keyword",
+  );
+  assert.equal(
+    detectTaggingMode(
+      "Warning: Failed to initialize embedding matcher: no such file\nFalling back to keyword-based matching.",
+    ),
+    "keyword",
+  );
+  assert.equal(
+    detectTaggingMode("Using embedding mode:\n  Model: /tmp/model.onnx"),
+    "embedding",
+  );
+});
+
+test("Open Civic Data ids are accepted wherever a locale code is expected", () => {
+  // The model is told to speak OCD, but `govbot clone` only understands locales.
+  assert.equal(normalizeLocale("il"), "il");
+  assert.equal(normalizeLocale("IL"), "il");
+  assert.equal(
+    normalizeLocale("ocd-jurisdiction/country:us/state:il/government"),
+    "il",
+  );
+  assert.equal(normalizeLocale("ocd-division/country:us/state:wy/sldl:23"), "wy");
+});
+
+test("federal maps to the locale it lives under on disk", () => {
+  // Congress is `state:usa` in the path layout but has no `state:` segment in OCD.
+  assert.equal(normalizeLocale("ocd-jurisdiction/country:us/government"), "usa");
+  assert.equal(normalizeLocale("ocd-division/country:us"), "usa");
+  assert.equal(normalizeLocale("usa"), "usa");
+});

--- a/actions/mcp/src/tools.ts
+++ b/actions/mcp/src/tools.ts
@@ -206,7 +206,9 @@ const tagSchema = z.object({
     .min(0)
     .max(1)
     .optional()
-    .describe("Score a bill must reach. Use 0.72; the 0.5 default tags everything."),
+    .describe(
+      "Score a bill must reach. Use 0.72 with no negative_examples, or 0.55 with them — negative examples lower every score by about 0.17, so 0.72 alongside them matches nothing.",
+    ),
 });
 
 export const saveValuesSchema = {

--- a/actions/mcp/src/tools.ts
+++ b/actions/mcp/src/tools.ts
@@ -1,0 +1,596 @@
+/**
+ * The tool surface.
+ *
+ * Five tools. The names and descriptions here are shown to the person in Claude
+ * Desktop when it asks permission to run something, so they are written to be
+ * read by someone who has never heard of govbot — and every claim they make is
+ * literally true of what the tool does.
+ */
+
+import { z } from "zod";
+import * as govbot from "./govbot.js";
+import * as workspace from "./workspace.js";
+
+/** What a tool hands back: text for the model, plus the structured payload. */
+export interface ToolOutput {
+  text: string;
+  data?: unknown;
+  isError?: boolean;
+}
+
+const LOOKUP_LINKS = [
+  "State legislators and districts: https://openstates.org/find_your_legislator/",
+  "Members of Congress: https://www.congress.gov/members/find-your-member",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// setup_workspace
+// ---------------------------------------------------------------------------
+
+export const setupWorkspaceSchema = {};
+
+export async function setupWorkspace(): Promise<ToolOutput> {
+  const result = await workspace.ensure();
+  const config = await workspace.readConfig();
+  const cli = await govbot.version();
+
+  const lines = [
+    result.created
+      ? `Created a workspace at ${result.path}`
+      : `Workspace is at ${result.path}`,
+    "",
+    "This folder belongs to the person using it. It holds their govbot.yml, the",
+    "legislation cloned so far, and the topic scores. Nothing in it is sent anywhere.",
+  ];
+  if (result.isGitRepo) {
+    lines.push("It is a git repository, so it can be published to GitHub as-is.");
+  }
+  lines.push(
+    "",
+    `Jurisdictions tracked: ${config.repos.length ? config.repos.join(", ") : "none yet"}`,
+    `Topics defined: ${Object.keys(config.tags).length ? Object.keys(config.tags).join(", ") : "none yet"}`,
+    `govbot CLI: ${cli ?? "NOT FOUND — the other tools will not work until it is installed"}`,
+  );
+
+  return {
+    text: lines.join("\n"),
+    data: { ...result, repos: config.repos, tags: Object.keys(config.tags), cli },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// check_local_data
+// ---------------------------------------------------------------------------
+
+export const checkLocalDataSchema = {
+  jurisdictions: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Jurisdictions to report on, as locale codes (`il`, `usa`) or Open Civic Data ids. Omit for everything already cloned.",
+    ),
+};
+
+export async function checkLocalData(args: {
+  jurisdictions?: string[];
+}): Promise<ToolOutput> {
+  await workspace.ensure();
+  const config = await workspace.readConfig();
+
+  const cli = await govbot.version();
+  if (!cli) {
+    return {
+      isError: true,
+      text:
+        "The govbot command-line tool is not installed, so there is no local data to read.\n\n" +
+        'Install it with:\n  sh -c "$(curl -fsSL https://raw.githubusercontent.com/chihacknight/govbot/main/actions/govbot/scripts/install-nightly.sh)"',
+    };
+  }
+
+  const args_ = ["query", "coverage", "--govbot-dir", workspace.dataPath()];
+  for (const jurisdiction of args.jurisdictions ?? []) {
+    args_.push("--jurisdiction", jurisdiction);
+  }
+
+  let response: QueryResponse;
+  try {
+    response = await govbot.runJson<QueryResponse>(args_, {
+      cwd: workspace.workspacePath(),
+    });
+  } catch (error) {
+    // Nothing cloned yet is the normal first-run state, not a failure.
+    return {
+      text:
+        "No government data has been cloned to this computer yet.\n\n" +
+        "Ask which state the person lives in, then use clone_government_data. " +
+        "For Congress, clone `usa` as well.\n\n" +
+        `Workspace: ${workspace.workspacePath()}\n` +
+        (error instanceof govbot.GovbotError && error.detail ? `\n${error.detail}` : ""),
+      data: { cloned: [], workspace: workspace.workspacePath() },
+    };
+  }
+
+  return {
+    text: describeCoverage(response, config),
+    data: response,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// clone_government_data
+// ---------------------------------------------------------------------------
+
+export const cloneSchema = {
+  jurisdictions: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Jurisdictions to clone, as locale codes: two-letter state codes (`il`, `wy`), `usa` for Congress, or `dc`, `pr`, `gu`, `vi`, `mp`.",
+    ),
+};
+
+export async function clone(
+  args: { jurisdictions: string[] },
+  onProgress?: (message: string) => void,
+): Promise<ToolOutput> {
+  await workspace.ensure();
+
+  const locales = args.jurisdictions.map((j) => normalizeLocale(j));
+  const result = await govbot.run(
+    ["clone", ...locales, "--govbot-dir", workspace.dataPath()],
+    {
+      cwd: workspace.workspacePath(),
+      onProgress: (chunk) => {
+        for (const line of chunk.split("\n")) {
+          const trimmed = line.trim();
+          if (trimmed) onProgress?.(trimmed);
+        }
+      },
+    },
+  );
+
+  if (result.code !== 0) {
+    return {
+      isError: true,
+      text:
+        `Cloning failed for: ${locales.join(", ")}\n\n` +
+        (result.stderr.trim() || `Exit code ${result.code}`),
+    };
+  }
+
+  await workspace.addRepos(locales);
+
+  return {
+    text:
+      `Cloned ${locales.join(", ")} into ${workspace.dataPath()}.\n\n` +
+      "This is public data from git repositories — no account, no API key, and no\n" +
+      "record of the request anywhere but this computer.\n\n" +
+      result.stderr.trim(),
+    data: { cloned: locales },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// save_my_values
+// ---------------------------------------------------------------------------
+
+const tagSchema = z.object({
+  name: z
+    .string()
+    .describe("A short name for the topic, e.g. 'renter protections'."),
+  description: z
+    .string()
+    .describe("What this topic covers. Embedded and compared against every bill."),
+  examples: z
+    .array(z.string())
+    .optional()
+    .describe("Two or three sentences describing bills that should match."),
+  negative_examples: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Bills on this subject but on the other side of it. This is what turns a subject into a position — include them whenever the person expressed a direction, not just an interest.",
+    ),
+  include_keywords: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Distinctive terms. Keep this tight: one keyword hit alone lifts a bill to the threshold, so a loose list turns semantic matching into keyword matching.",
+    ),
+  exclude_keywords: z
+    .array(z.string())
+    .optional()
+    .describe("Terms that disqualify a bill from this topic."),
+  threshold: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe("Score a bill must reach. Use 0.72; the 0.5 default tags everything."),
+});
+
+export const saveValuesSchema = {
+  topics: z.array(tagSchema).min(1).describe("The topics to save."),
+};
+
+export async function saveValues(args: {
+  topics: z.infer<typeof tagSchema>[];
+}): Promise<ToolOutput> {
+  await workspace.ensure();
+
+  const tags: Record<string, workspace.TagDefinition> = {};
+  const warnings: string[] = [];
+
+  for (const topic of args.topics) {
+    const { name, ...definition } = topic;
+    // Thresholds are not interchangeable. Negative examples subtract roughly 0.17
+    // from every score, measured against real bills, so 0.72 with them present is
+    // unreachable and the topic silently matches nothing.
+    const hasNegatives = Boolean(definition.negative_examples?.length);
+    if (definition.threshold === undefined) {
+      definition.threshold = hasNegatives ? 0.55 : 0.72;
+    } else if (hasNegatives && definition.threshold > 0.6) {
+      warnings.push(
+        `"${name}" has negative_examples and a threshold of ${definition.threshold}. ` +
+          "Negative examples lower every score by roughly 0.17, so this topic would " +
+          "match nothing. Lowered it to 0.55.",
+      );
+      definition.threshold = 0.55;
+    }
+    if (!definition.include_keywords?.length) {
+      warnings.push(
+        `"${name}" has no include_keywords. Bill titles are terse enough that the ` +
+          "embedding alone barely separates on-topic from off-topic, so this topic " +
+          "will match unreliably. Add a few distinctive terms.",
+      );
+    }
+    tags[name] = definition as workspace.TagDefinition;
+  }
+
+  const saved = await workspace.saveTags(tags);
+
+  return {
+    text: [
+      `Saved ${Object.keys(tags).length} topic(s) to ${workspace.configPath()}.`,
+      `All topics now defined: ${saved.join(", ")}`,
+      "",
+      ...(warnings.length ? ["Worth flagging:", ...warnings.map((w) => `  - ${w}`), ""] : []),
+      "Run tag_with_local_ai next to score bills against these.",
+      "",
+      "This file is plain YAML the person can open and edit. Show them what you wrote.",
+    ].join("\n"),
+    data: { saved, warnings, path: workspace.configPath() },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tag_with_local_ai
+// ---------------------------------------------------------------------------
+
+export const tagSchemaInput = {
+  jurisdictions: z
+    .array(z.string())
+    .optional()
+    .describe("Jurisdictions to score. Omit for everything cloned."),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Bills to score per jurisdiction. Scoring runs at roughly 25 bills per second, so keep this in the hundreds for an interactive answer.",
+    ),
+};
+
+export async function tagWithLocalAi(
+  args: { jurisdictions?: string[]; limit?: number },
+  onProgress?: (message: string) => void,
+): Promise<ToolOutput> {
+  await workspace.ensure();
+
+  const config = await workspace.readConfig();
+  if (!Object.keys(config.tags).length) {
+    return {
+      isError: true,
+      text:
+        "No topics are defined yet, so there is nothing to score against.\n" +
+        "Use save_my_values first.",
+    };
+  }
+
+  const logsArgs = [
+    "logs",
+    "--govbot-dir",
+    workspace.dataPath(),
+    "--join",
+    "bill",
+    "--filter",
+    "none",
+    "--limit",
+    String(args.limit ?? 400),
+  ];
+  if (args.jurisdictions?.length) {
+    logsArgs.push("--repos", args.jurisdictions.map(normalizeLocale).join(","));
+  }
+
+  const logs = await govbot.run(logsArgs, { cwd: workspace.workspacePath() });
+  if (logs.code !== 0) {
+    return {
+      isError: true,
+      text: `Reading legislation failed.\n\n${logs.stderr.trim()}`,
+    };
+  }
+  if (!logs.stdout.trim()) {
+    return {
+      isError: true,
+      text:
+        "No legislation found to score. Clone a jurisdiction first with " +
+        "clone_government_data.",
+    };
+  }
+
+  // `govbot tag` reads govbot.yml from the working directory and writes tag files
+  // beside it, which is exactly what the workspace is for.
+  const tagged = await govbot.run(["tag", "--overwrite"], {
+    cwd: workspace.workspacePath(),
+    stdin: logs.stdout,
+    onProgress: (chunk) => {
+      for (const line of chunk.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed) onProgress?.(trimmed);
+      }
+    },
+  });
+
+  if (tagged.code !== 0) {
+    return {
+      isError: true,
+      text: `Tagging failed.\n\n${tagged.stderr.trim()}`,
+    };
+  }
+
+  const mode = detectTaggingMode(tagged.stderr);
+  const matched = tagged.stdout.trim() ? tagged.stdout.trim().split("\n").length : 0;
+
+  const lines = [
+    `Scored bills against: ${Object.keys(config.tags).join(", ")}`,
+    `${matched} bill records matched at least one topic.`,
+    "",
+  ];
+  if (mode === "keyword") {
+    lines.push(
+      "IMPORTANT: this ran in keyword-only mode — the local AI model could not be",
+      "loaded or downloaded, so bills were matched on keywords alone rather than",
+      "meaning. Results will be noticeably worse. Say so when reporting them.",
+      "",
+    );
+  } else {
+    lines.push(
+      "Scored with a local embedding model running on this computer. No bill text and",
+      "no topic definition was sent anywhere.",
+      "",
+    );
+  }
+  lines.push("Use `query` with a `tag` to pull the highest-scoring bills.");
+
+  return {
+    text: lines.join("\n"),
+    data: { mode, matched, topics: Object.keys(config.tags) },
+  };
+}
+
+/**
+ * Which matching mode `govbot tag` actually used.
+ *
+ * The CLI falls back to keyword matching when the embedding model is missing and
+ * says so only on stderr. Passing keyword results off as AI tagging would be a
+ * quiet accuracy regression the person cannot see, so it is detected and reported.
+ */
+export function detectTaggingMode(stderr: string): "embedding" | "keyword" {
+  return /keyword-based matching|Embedding files not available/i.test(stderr)
+    ? "keyword"
+    : "embedding";
+}
+
+// ---------------------------------------------------------------------------
+// query
+// ---------------------------------------------------------------------------
+
+export const querySchema = {
+  type: z
+    .enum(["bills", "votes", "people", "coverage"])
+    .describe(
+      "bills: legislation. votes: roll calls. people: the names present in the data. coverage: what the data can and cannot answer.",
+    ),
+  jurisdictions: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Locale codes (`il`, `usa`) or Open Civic Data ids such as `ocd-jurisdiction/country:us/state:il/government` or `ocd-division/country:us/state:il/sldl:4`. Omit for everything cloned.",
+    ),
+  person: z
+    .string()
+    .optional()
+    .describe(
+      "A legislator's name, matched against sponsors and voters. If it comes back ambiguous, ask which person is meant rather than choosing.",
+    ),
+  tag: z
+    .string()
+    .optional()
+    .describe("A topic from save_my_values. Ranks and filters results by score."),
+  text: z
+    .string()
+    .optional()
+    .describe("Words that must all appear in the bill, matched as whole words."),
+  subject: z.string().optional().describe("A subject term the jurisdiction assigned."),
+  identifier: z.string().optional().describe("A single bill, e.g. `HB1234`."),
+  session: z.string().optional().describe("A single legislative session."),
+  min_score: z
+    .number()
+    .optional()
+    .describe("Lowest topic score to include. Defaults to the topic's threshold."),
+  min_confidence: z
+    .enum(["any", "medium", "high", "exact"])
+    .optional()
+    .describe(
+      "How certain a name match must be before anything is attributed to that person. Defaults to medium.",
+    ),
+  limit: z.number().int().positive().max(100).optional().describe("Rows to return (default 20)."),
+};
+
+interface QueryResponse {
+  query: Record<string, unknown>;
+  results: Record<string, unknown>[];
+  truncation: { returned: number; total_matching: number; limit: number };
+  coverage: CoverageEntry[];
+  caveats?: string[];
+}
+
+interface CoverageEntry {
+  jurisdiction: { id: string; name: string | null; locale: string };
+  bills: number;
+  vote_events: number;
+  member_vote_rows: number;
+  roll_call_data: "none" | "counts_only" | "available";
+  sessions: string[];
+}
+
+export async function query(args: Record<string, unknown>): Promise<ToolOutput> {
+  await workspace.ensure();
+
+  const cliArgs = ["query", String(args.type), "--govbot-dir", workspace.dataPath()];
+
+  for (const jurisdiction of (args.jurisdictions as string[] | undefined) ?? []) {
+    cliArgs.push("--jurisdiction", jurisdiction);
+  }
+  const passthrough: [string, string][] = [
+    ["person", "--person"],
+    ["tag", "--tag"],
+    ["text", "--text"],
+    ["subject", "--subject"],
+    ["identifier", "--identifier"],
+    ["session", "--session"],
+    ["min_confidence", "--min-confidence"],
+  ];
+  for (const [key, flag] of passthrough) {
+    const value = args[key];
+    if (value !== undefined && value !== null && value !== "") {
+      cliArgs.push(flag, String(value));
+    }
+  }
+  if (typeof args.min_score === "number") cliArgs.push("--min-score", String(args.min_score));
+  cliArgs.push("--limit", String(args.limit ?? 20));
+
+  let response: QueryResponse;
+  try {
+    response = await govbot.runJson<QueryResponse>(cliArgs, {
+      cwd: workspace.workspacePath(),
+    });
+  } catch (error) {
+    if (error instanceof govbot.GovbotError) {
+      return {
+        isError: true,
+        text: [error.message, error.detail ?? ""].filter(Boolean).join("\n\n"),
+      };
+    }
+    throw error;
+  }
+
+  return { text: summarize(response), data: response };
+}
+
+// ---------------------------------------------------------------------------
+// Shaping results for the model
+// ---------------------------------------------------------------------------
+
+/**
+ * A short prose summary in front of the JSON.
+ *
+ * The point is that the reasons an answer might be incomplete are stated up
+ * front rather than buried in a field the model may not read.
+ */
+function summarize(response: QueryResponse): string {
+  const lines: string[] = [];
+  const { returned, total_matching, limit } = response.truncation;
+
+  if (returned === 0) {
+    lines.push("No matching records.");
+  } else if (total_matching > returned) {
+    lines.push(`Showing ${returned} of ${total_matching} matches (limit ${limit}).`);
+  } else {
+    lines.push(`${returned} match${returned === 1 ? "" : "es"}.`);
+  }
+
+  for (const entry of response.coverage ?? []) {
+    const name = entry.jurisdiction.name ?? entry.jurisdiction.locale.toUpperCase();
+    const rollCall =
+      entry.roll_call_data === "available"
+        ? `${entry.vote_events} recorded votes`
+        : entry.roll_call_data === "counts_only"
+          ? `${entry.vote_events} vote totals but no individual votes`
+          : "NO recorded votes at all";
+    lines.push(`  ${name}: ${entry.bills} bills, ${rollCall}.`);
+  }
+
+  if (response.caveats?.length) {
+    lines.push("", "Read these before answering:");
+    for (const caveat of response.caveats) lines.push(`  - ${caveat}`);
+  }
+
+  lines.push("", JSON.stringify(response.results, null, 2));
+  return lines.join("\n");
+}
+
+function describeCoverage(
+  response: QueryResponse,
+  config: workspace.GovbotConfig,
+): string {
+  const lines = [`Workspace: ${workspace.workspacePath()}`, ""];
+
+  if (!response.coverage?.length) {
+    lines.push(
+      "No government data cloned yet. Ask which state the person is in, then use",
+      "clone_government_data — and clone `usa` too if they want Congress.",
+    );
+    return lines.join("\n");
+  }
+
+  lines.push("Cloned to this computer:");
+  for (const entry of response.coverage) {
+    const name = entry.jurisdiction.name ?? entry.jurisdiction.locale.toUpperCase();
+    lines.push(
+      `  ${name} (${entry.jurisdiction.locale}) — ${entry.bills} bills, ` +
+        `${entry.vote_events} vote events, sessions ${entry.sessions.join(", ") || "none"}`,
+    );
+    if (entry.roll_call_data === "none") {
+      lines.push(
+        `    No roll-call votes published. Sponsorship is the only evidence here.`,
+      );
+    } else if (entry.roll_call_data === "counts_only") {
+      lines.push(`    Vote totals only — individual votes are not published.`);
+    }
+  }
+
+  lines.push(
+    "",
+    `Topics defined: ${Object.keys(config.tags).length ? Object.keys(config.tags).join(", ") : "none yet"}`,
+  );
+  if (response.caveats?.length) {
+    lines.push("", "Read these before answering:");
+    for (const caveat of response.caveats) lines.push(`  - ${caveat}`);
+  }
+  lines.push("", "Finding someone's representatives:", LOOKUP_LINKS);
+  return lines.join("\n");
+}
+
+/**
+ * Accept an OCD id wherever a locale code is expected, since the model is told
+ * to speak OCD elsewhere and `clone` only understands locales.
+ */
+export function normalizeLocale(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  const stateMatch = trimmed.match(/\bstate:([a-z]{2,3})\b/);
+  if (stateMatch?.[1]) return stateMatch[1];
+  if (trimmed.startsWith("ocd-")) return "usa"; // `country:us` with no state is Congress.
+  return trimmed;
+}

--- a/actions/mcp/src/workspace.ts
+++ b/actions/mcp/src/workspace.ts
@@ -1,0 +1,204 @@
+/**
+ * The workspace: a real folder on the user's computer that they own.
+ *
+ * Everything this server does happens inside one directory — the cloned data,
+ * the `govbot.yml` describing what the user cares about, and the tag output.
+ * It is a git repository from the moment it is created, so "publish this to
+ * GitHub" is a real next step rather than a promise.
+ *
+ * The workspace also resolves a constraint rather than fighting it. `govbot
+ * tag` requires `govbot.yml` in the *current working directory* and writes its
+ * output relative to that directory, and `govbot logs --join tags` looks for
+ * tags relative to the current directory too. A server with one fixed
+ * workspace directory satisfies all of that by construction.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+const execFileAsync = promisify(execFile);
+
+/** A topic definition, in the shape `govbot.yml` expects. */
+export interface TagDefinition {
+  description: string;
+  examples?: string[];
+  negative_examples?: string[];
+  include_keywords?: string[];
+  exclude_keywords?: string[];
+  threshold?: number;
+}
+
+export interface GovbotConfig {
+  $schema?: string;
+  repos: string[];
+  tags: Record<string, TagDefinition>;
+  [key: string]: unknown;
+}
+
+const SCHEMA_URL =
+  "https://raw.githubusercontent.com/chihacknight/govbot/main/schemas/govbot.schema.json";
+
+/** Where the workspace lives. */
+export function workspacePath(): string {
+  return process.env.GOVBOT_WORKSPACE ?? join(homedir(), "govbot-workspace");
+}
+
+/** Where `govbot clone` puts repositories, inside the workspace. */
+export function dataPath(): string {
+  return join(workspacePath(), "govbot_data");
+}
+
+export function configPath(): string {
+  return join(workspacePath(), "govbot.yml");
+}
+
+export function exists(): boolean {
+  return existsSync(configPath());
+}
+
+const README = `# My govbot workspace
+
+This folder was created by the govbot extension for Claude Desktop. **It belongs to
+you.** Nothing in it is sent anywhere, and you can read, edit, delete, or publish
+any of it.
+
+## What is in here
+
+- **govbot.yml** — the jurisdictions being tracked, and the topics you said you
+  care about, written as definitions a local AI model can match bills against.
+  This is the interesting file. Open it and see whether it describes what you
+  actually meant; if it doesn't, edit it.
+- **govbot_data/** — legislation cloned from public git repositories, one per
+  jurisdiction. Not committed, because it is large and it is already public.
+- **country:us/** — topic scores, one file per topic per session, written by the
+  local tagging model.
+
+## Running it yourself
+
+Everything Claude does here, you can do from a terminal in this folder:
+
+    govbot clone il usa      # fetch jurisdictions
+    govbot logs | govbot tag # score bills against the topics in govbot.yml
+    govbot query bills --tag "renter protections" --limit 20
+    govbot query coverage    # what the data can and cannot answer
+
+## Publishing
+
+This folder is a git repository. To share it:
+
+    git add -A
+    git commit -m "my legislative interests"
+    gh repo create my-govbot --public --source=. --push
+
+The cloned data is excluded, so what you publish is your configuration and your
+topic scores — not a copy of the whole corpus.
+`;
+
+const GITIGNORE = `# Cloned legislation: large, and already public elsewhere.
+govbot_data/
+
+# The local embedding model.
+model.onnx
+tokenizer.json
+vocab.txt
+`;
+
+/**
+ * Create the workspace if it is not already there, and return what happened.
+ *
+ * Safe to call repeatedly: an existing workspace is left exactly as it is, so a
+ * user's edits to `govbot.yml` are never overwritten.
+ */
+export async function ensure(): Promise<{
+  path: string;
+  created: boolean;
+  isGitRepo: boolean;
+}> {
+  const path = workspacePath();
+  const alreadyExisted = exists();
+
+  await mkdir(path, { recursive: true });
+  await mkdir(dataPath(), { recursive: true });
+
+  if (!alreadyExisted) {
+    await writeConfig({ $schema: SCHEMA_URL, repos: [], tags: {} });
+  }
+  // These two are safe to refresh — neither is something a user edits.
+  await writeFile(join(path, "README.md"), README, "utf8");
+  await writeFile(join(path, ".gitignore"), GITIGNORE, "utf8");
+
+  const isGitRepo = await ensureGitRepo(path);
+  return { path, created: !alreadyExisted, isGitRepo };
+}
+
+/**
+ * Make the workspace a git repository, so the user can publish it.
+ *
+ * Failure is not fatal — git may not be installed, and the workspace is still
+ * perfectly usable without it.
+ */
+async function ensureGitRepo(path: string): Promise<boolean> {
+  if (existsSync(join(path, ".git"))) return true;
+  try {
+    await execFileAsync("git", ["init", "--quiet"], { cwd: path });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readConfig(): Promise<GovbotConfig> {
+  try {
+    const raw = await readFile(configPath(), "utf8");
+    const parsed = parseYaml(raw) as Partial<GovbotConfig> | null;
+    return {
+      $schema: parsed?.$schema ?? SCHEMA_URL,
+      repos: parsed?.repos ?? [],
+      tags: parsed?.tags ?? {},
+    };
+  } catch {
+    return { $schema: SCHEMA_URL, repos: [], tags: {} };
+  }
+}
+
+export async function writeConfig(config: GovbotConfig): Promise<void> {
+  await mkdir(workspacePath(), { recursive: true });
+  const header =
+    "# Your govbot project.\n" +
+    "#\n" +
+    "# `repos` are the jurisdictions being tracked. `tags` are the topics you care\n" +
+    "# about, written so a local AI model can score bills against them. Both are\n" +
+    "# yours to edit — this file is read, not owned, by the Claude Desktop extension.\n" +
+    "#\n" +
+    "# Run `govbot logs | govbot tag` in this folder to re-score bills after editing.\n\n";
+  await writeFile(configPath(), header + stringifyYaml(config, { lineWidth: 88 }), "utf8");
+}
+
+/**
+ * Record the jurisdictions being tracked, preserving any already listed.
+ */
+export async function addRepos(locales: string[]): Promise<string[]> {
+  const config = await readConfig();
+  const merged = new Set([...config.repos, ...locales.map((l) => l.toLowerCase())]);
+  config.repos = [...merged].sort();
+  await writeConfig(config);
+  return config.repos;
+}
+
+/**
+ * Save topic definitions, replacing any with the same name.
+ *
+ * `govbot tag` keys its cached scores on a hash of the tag definition, so
+ * changing a definition here correctly invalidates the previous scores.
+ */
+export async function saveTags(tags: Record<string, TagDefinition>): Promise<string[]> {
+  const config = await readConfig();
+  config.tags = { ...config.tags, ...tags };
+  await writeConfig(config);
+  return Object.keys(config.tags).sort();
+}

--- a/actions/mcp/tsconfig.json
+++ b/actions/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION


<img width="1446" height="965" alt="Screenshot 2026-08-18 at 10 01 18 PM" src="https://github.com/user-attachments/assets/d569d896-8a93-493a-8db1-ab8c255bf08a" />
<img width="1108" height="969" alt="Screenshot 2026-08-18 at 10 01 33 PM" src="https://github.com/user-attachments/assets/96d50e44-de6d-4cb3-a3c4-be5ab0cf4c17" />
<img width="1104" height="979" alt="Screenshot 2026-08-18 at 10 01 42 PM" src="https://github.com/user-attachments/assets/3aaaad1e-3ac4-438d-91f8-c4f9c8169017" />
<img width="1113" height="975" alt="Screenshot 2026-08-18 at 10 03 41 PM" src="https://github.com/user-attachments/assets/37379ec5-a407-4ef9-a5d3-1d2dc7b20f1f" />
<img width="1467" height="976" alt="Screenshot 2026-08-18 at 10 04 28 PM" src="https://github.com/user-attachments/assets/f02ee81f-b2f1-4d76-8684-5eda02284dcc" />
<img width="1192" height="649" alt="Screenshot 2026-08-18 at 10 05 02 PM" src="https://github.com/user-attachments/assets/09fff740-fee1-4725-9421-81250fe132da" />


Makes govbot answerable from Claude Desktop, so someone who has never opened a
terminal can ask **"Who are my reps, and how do they align to my values?"** and get a
cited answer built from data on their own machine.

Two pieces: a new `govbot query` subcommand, and a thin Node MCP server that shells
out to it. The server owns no index and no data model — every answer comes from the
CLI, so anything Claude says can be reproduced from a terminal in the same folder.

## `govbot query`

`govbot logs` streams unbounded nested JSON Lines. That is right for a Unix pipe and
wrong for anything with a context window. It is also blind to the data this question
needs, in three separate places:

- `processor.rs:283` never opens vote-event files — it regexes `pass`/`fail` out of
  the *filename*.
- `logs --select` has one legal value, whose hardcoded whitelist keeps only
  `log.action` and `log.bill_id`, so `votes[]` is always dropped.
- `load` globs `metadata.json` only, so `logs/` never reaches DuckDB.

`query` reads the same corpus and returns a capped, flat array. Four types —
`bills`, `votes`, `people`, `coverage`.

It speaks **Open Civic Data**, because the data already does. Jurisdictions may be
given as `ocd-jurisdiction/country:us/state:il/government`, as
`ocd-division/country:us/state:il/sldl:4`, or as a bare `il`. Federal is the one
place the path layout and the OCD vocabulary disagree — `state:usa` on disk, no
`state:` segment in OCD — and `query/ocd.rs` is the only place that lives.

Every row carries repository, commit, and path. Text search matches whole words:
searching Illinois for "rent" previously returned 78 bills including
"APPOINT-T**rent**on TABER", and now returns 8 genuinely rent-related ones.

## Never fabricating a record

govbot has no legislator roster — sponsors and voters are name strings, and
`person_id` is pseudo-JSON derived from the name itself. So names are matched against
the corpus, with a confidence on every match and `--min-confidence` gating what may
be attributed. Verified against real data:

| case | behaviour |
|---|---|
| Wyoming `Brown` | Two legislators. Attributes **nothing**, names both, asks which. |
| Wyoming `Brown, L` | Resolves to 507 votes. |
| Illinois `Bill Cunningham` | Data says `Cunningham, Bill` — high confidence, 1,761 votes. |
| Federal `A000375` | Bioguide id, exact match, 531 votes. |
| Massachusetts | 11,287 bills, **zero** roll calls. Says the data does not exist rather than implying inaction. |
| Alaska | Vote totals with no member rows. Reports tallies, attributes nothing. |

Edit distance is never used to assign a person — `Hanson`/`Hansen` and `Reed`/`Reid`
are one edit apart and are different people.

Two upstream data problems are handled explicitly:

- **Wyoming's vote rows are corrupt.** `"Brown, L."` was split on its comma into two
  voters, leaving `"L"` as a voter 768 times. Adjacent fragments carrying the same
  vote option are rejoined (3,090 rows in one session); anything still fragmentary is
  excluded from attribution *and* from counts.
- **The same legislator is spelled two ways** (`Smith, S` and `SMITH, S`). Counting
  raw strings reported 186 voters for a 93-member legislature; counting people
  reports 97.

## The MCP server

`actions/mcp/` — Node, six tools, three resources, one prompt.

Everything happens in one workspace folder the person owns, git-initialised so
"publish this to GitHub" is real. That also resolves a constraint rather than
fighting it: `govbot tag` requires `govbot.yml` in the working directory and writes
output relative to it, which one fixed workspace satisfies by construction.

Tool names and descriptions are shown to the person when Claude asks permission, so
they are written to be read by someone who has never heard of govbot. `query` is one
tool over all four types rather than several. The workspace files are exposed as
**resources**, so a person can open `govbot.yml` and see exactly what Claude decided
their values were.

It never asks for an address. Claude asks who your representatives are and links
openstates.org — no geocoder, no API key, nothing to leak.

## Two bugs found and fixed

- **`govbot tag` panicked on first run** on any machine without the embedding model
  cached. `download_file` used `reqwest::blocking` inside the async runtime, and
  dropping that runtime in an async context aborts. Now runs on its own thread. This
  blocked the tagging path entirely and would hit *every new user* — worth reviewing
  on its own merits.
- **Citations silently lost their commit on partial clones**, because libgit2 refuses
  to open a repository declaring `extensions.partialClone`. `head_commit` now falls
  back to reading HEAD, loose refs, and packed-refs directly. A citation without a
  commit is a citation nobody can check.

## Tagging guidance is measured, not assumed

I originally assumed `negative_examples` would give the topical taxonomy a stance
axis. Measured against real Illinois bills, they do not:

- **`include_keywords` carries nearly all the signal.** The embedding barely
  separates on-topic from off-topic on terse titles — a rent bill scored 0.606 and an
  unrelated drinking-age bill 0.596.
- **`negative_examples` lower every score by ~0.17** rather than separating bills for
  a thing from bills against it. Combined with the documented 0.72 threshold, a topic
  matches **nothing at all**.

`save_my_values` detects that combination and corrects the threshold rather than
saving a definition that silently returns nothing. Stance judgment stays with Claude
reading the bills.

## Verification

- 35 Rust unit tests, 7 suites green; 3 Node tests; typecheck clean.
- `actions/mcp/__snapshots__/surface.json` snapshots the full tool surface, so a
  reworded permission prompt lands as a reviewable diff.
- `scripts/mcp-session.mjs` enforces the rule the transport depends on: **stdout
  carries JSON-RPC frames and nothing else.**
- Exercised end to end against 18,380 federal bills / 255,723 member votes and 12,780
  Illinois bills / 324,397 member votes.

## Still to do

- `.mcpb` bundle builds and validates (3.2 MB) but is **unsigned** — whether Gatekeeper
  blocks the spawned binary needs checking on a clean machine.
- `release-nightly.yml` still builds only linux-x86_64 and darwin-arm64 while
  `install-nightly.sh` advertises Windows and Intel Mac. Untouched here, but it means
  Intel Macs silently get an arm64 binary and Windows always fails.
- A real legislator roster (`openstates/people` — 120 MB, districts, party, bioguide
  crosswalk, alias lists) would take Illinois from ~41 ambiguous names to near zero.
  Deliberately out of scope for this POC.
- Disk size is another team's lane, but for reference: `govbot clone il usa` produced
  **3.4 GB**, where a sparse partial clone gives the same bills and votes in **811 MB**.
  Bill text is ~77% of the bytes and none of it is read by this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
