### PR TITLE
Dashboard polish: white details-modal text + 250th fireworks on hearings

### DIFF
--- a/docs/src/dashboard/hearings.html
+++ b/docs/src/dashboard/hearings.html
@@ -123,13 +123,33 @@
     display: flex; align-items: center; justify-content: space-between;
     gap: 12px; margin-bottom: 16px;
   }
+  /* Celebratory night-sky brand bar: a canvas fireworks show (America's 250th)
+     plays behind the logo. Dark in both themes so the fireworks read, with the
+     logo + wordmark lifted above it. */
+  .brandbar.celebrate {
+    position: relative; overflow: hidden;
+    min-height: 110px; padding: 14px 18px; border-radius: 16px;
+    background:
+      radial-gradient(120% 150% at 25% -30%, #1b2c4f 0%, transparent 55%),
+      linear-gradient(180deg, #0a1428 0%, #0b1836 55%, #0a1024 100%);
+    border: 1px solid rgba(255,255,255,0.10);
+  }
+  .fw-canvas {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    z-index: 0; pointer-events: none; display: block;
+  }
+  .brandbar.celebrate .brand,
+  .brandbar.celebrate .theme-toggle { position: relative; z-index: 2; }
+  .brandbar.celebrate .brand-name { color: #fff; text-shadow: 0 2px 10px rgba(0,0,0,0.55); }
+  .brandbar.celebrate .brand-name .bot { color: #ffd54a; }
+  .brandbar.celebrate .brand-logo { box-shadow: 0 2px 14px rgba(0,0,0,0.45); }
   .brand {
     display: inline-flex; align-items: center; gap: 9px;
     text-decoration: none; color: var(--text-primary);
   }
   .brand .brand-logo {
-    flex: none; display: block; width: 40px; height: 40px;
-    border-radius: 9px; border: 1px solid var(--border);
+    flex: none; display: block; width: 48px; height: 48px;
+    border-radius: 10px; border: 1px solid var(--border);
   }
   .brand .brand-name { font-size: 19px; font-weight: 700; letter-spacing: -0.01em; }
   .brand .brand-name .bot { color: var(--series-1); }
@@ -430,27 +450,6 @@
     .hgroup-portal { margin-left: 0; }
   }
 
-  /* ---------- fireworks logo ---------- */
-  :root { --fw1: #29ABE2; --fw2: #ED2E38; --fw3: #1B87B8; --fw4: #eda100; }
-  .brand-logo-fx { position: relative; display: inline-flex; width: 40px; height: 40px; flex: none; }
-  .brand-logo-fx .brand-logo { position: relative; z-index: 1; width: 40px; height: 40px;
-    border-radius: 9px; border: 1px solid var(--border); display: block; }
-  .fireworks { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
-  .fireworks i {
-    position: absolute; top: 50%; left: 50%; width: 4px; height: 4px; margin: -2px 0 0 -2px;
-    border-radius: 50%; background: var(--c);
-    transform: rotate(var(--a)) translateY(0) scale(0.2); opacity: 0;
-    animation: fw-burst 2.6s var(--d) infinite ease-out;
-  }
-  @keyframes fw-burst {
-    0%   { transform: rotate(var(--a)) translateY(-2px)  scale(0.2); opacity: 0; }
-    12%  { opacity: 1; }
-    55%  { transform: rotate(var(--a)) translateY(-24px) scale(1);   opacity: 0.9; }
-    75%  { transform: rotate(var(--a)) translateY(-30px) scale(0.7); opacity: 0; }
-    100% { transform: rotate(var(--a)) translateY(-30px) scale(0.4); opacity: 0; }
-  }
-  @media (prefers-reduced-motion: reduce) { .fireworks { display: none; } }
-
   /* ---------- participation directory ---------- */
   .p-search {
     align-self: center; min-width: 180px; padding: 7px 11px;
@@ -504,23 +503,10 @@
     <a class="tab tab-hearings" href="hearings.html" aria-current="page">Committee Hearings &amp; Witness Slips</a>
   </nav>
   <header class="top">
-    <div class="brandbar">
+    <div class="brandbar celebrate">
+      <canvas class="fw-canvas" id="fw-canvas" aria-hidden="true"></canvas>
       <a class="brand" href="../index.html" aria-label="govbot home">
-        <span class="brand-logo-fx" aria-hidden="true">
-          <span class="fireworks">
-            <i style="--a:0deg;--c:var(--fw1);--d:0s"></i>
-            <i style="--a:36deg;--c:var(--fw2);--d:.1s"></i>
-            <i style="--a:72deg;--c:var(--fw3);--d:.2s"></i>
-            <i style="--a:108deg;--c:var(--fw4);--d:.3s"></i>
-            <i style="--a:144deg;--c:var(--fw1);--d:.4s"></i>
-            <i style="--a:180deg;--c:var(--fw2);--d:.5s"></i>
-            <i style="--a:216deg;--c:var(--fw3);--d:.15s"></i>
-            <i style="--a:252deg;--c:var(--fw4);--d:.25s"></i>
-            <i style="--a:288deg;--c:var(--fw1);--d:.35s"></i>
-            <i style="--a:324deg;--c:var(--fw2);--d:.45s"></i>
-          </span>
-          <img class="brand-logo" src="govbot-logo.png" width="40" height="40" alt="">
-        </span>
+        <img class="brand-logo" src="govbot-logo.png" width="48" height="48" alt="">
         <span class="brand-name">gov<span class="bot">bot</span></span>
       </a>
       <div class="theme-toggle" role="group" aria-label="Color theme">
@@ -1030,6 +1016,201 @@
         url: new URL("hearings.xml", location.href).href,
       });
     });
+  })();
+
+  /* ---------- 250th fireworks (canvas) ----------
+     A 4th-of-July fireworks show behind the brand: ambient bursts, plus a
+     recurring shell that flies up and settles its sparks into the word "250th"
+     (America's Semiquincentennial), holds, then falls. Self-contained; degrades
+     to a static "250th" when the viewer prefers reduced motion. */
+  (function initFireworks() {
+    const canvas = document.getElementById("fw-canvas");
+    if (!canvas || !canvas.getContext) return;
+    const ctx = canvas.getContext("2d");
+    const RED = [237, 46, 56], WHITE = [255, 255, 255], BLUE = [74, 163, 255],
+          GOLD = [255, 213, 74], GREEN = [46, 230, 166], PINK = [255, 122, 217];
+    const PALETTE = [RED, WHITE, BLUE, GOLD, GREEN, PINK];
+    const rgba = (c, a) => "rgba(" + c[0] + "," + c[1] + "," + c[2] + "," + a + ")";
+    const pick = (a) => a[(Math.random() * a.length) | 0];
+    const reduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    let W = 0, H = 0, dpr = 1;
+    function fit() {
+      dpr = Math.min(2, window.devicePixelRatio || 1);
+      W = canvas.clientWidth; H = canvas.clientHeight;
+      canvas.width = Math.max(1, Math.round(W * dpr));
+      canvas.height = Math.max(1, Math.round(H * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    fit();
+    if (window.ResizeObserver) new ResizeObserver(fit).observe(canvas);
+    else window.addEventListener("resize", fit);
+
+    // Sample the word "250th" into target points scaled to the canvas.
+    function wordPoints() {
+      if (!W || !H) return [];
+      const off = document.createElement("canvas");
+      off.width = W; off.height = H;
+      const c = off.getContext("2d");
+      c.textAlign = "center"; c.textBaseline = "middle";
+      let fs = H * 0.72;
+      c.font = "900 " + fs + "px system-ui, 'Segoe UI', sans-serif";
+      const maxW = W * 0.6;
+      const w = c.measureText("250th").width;
+      if (w > maxW) { fs *= maxW / w; c.font = "900 " + fs + "px system-ui, 'Segoe UI', sans-serif"; }
+      c.fillStyle = "#fff";
+      c.fillText("250th", W / 2, H / 2 + 2);
+      const data = c.getImageData(0, 0, W, H).data;
+      const step = Math.max(3, Math.round(fs / 20));
+      const pts = [];
+      for (let y = 0; y < H; y += step)
+        for (let x = 0; x < W; x += step)
+          if (data[(y * W + x) * 4 + 3] > 128) pts.push({ x: x, y: y });
+      // Cap the point count so the word stays cheap to animate.
+      const MAX = 240;
+      if (pts.length > MAX) {
+        const keep = [], s = pts.length / MAX;
+        for (let i = 0; i < MAX; i++) keep.push(pts[(i * s) | 0]);
+        return keep;
+      }
+      return pts;
+    }
+
+    if (reduced) {
+      // Static celebratory word, no animation.
+      const draw = () => {
+        fit(); ctx.clearRect(0, 0, W, H);
+        let fs = H * 0.72;
+        ctx.font = "900 " + fs + "px system-ui, 'Segoe UI', sans-serif";
+        const maxW = W * 0.6, w = ctx.measureText("250th").width;
+        if (w > maxW) { fs *= maxW / w; ctx.font = "900 " + fs + "px system-ui, 'Segoe UI', sans-serif"; }
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.shadowColor = "rgba(255,213,74,0.8)"; ctx.shadowBlur = 18;
+        ctx.fillStyle = "#ffd54a";
+        ctx.fillText("250th", W / 2, H / 2 + 2);
+        ctx.shadowBlur = 0;
+      };
+      draw();
+      window.addEventListener("resize", draw);
+      return;
+    }
+
+    const sparks = [];    // ambient explosion particles
+    const rockets = [];   // rising shells
+    let word = null;      // {parts, phase, clock}
+    let rocketTimer = 300, wordTimer = 900;
+
+    function explode(x, y, color) {
+      const n = 26 + (Math.random() * 12 | 0);
+      for (let i = 0; i < n; i++) {
+        const a = (i / n) * Math.PI * 2 + Math.random() * 0.25;
+        const sp = 0.6 + Math.random() * 3.0;
+        sparks.push({ x: x, y: y, px: x, py: y,
+          vx: Math.cos(a) * sp, vy: Math.sin(a) * sp,
+          life: 1, decay: 0.012 + Math.random() * 0.012,
+          color: Math.random() < 0.25 ? WHITE : color });
+      }
+    }
+    function launch() {
+      const x = W * (0.12 + Math.random() * 0.76);
+      rockets.push({ x: x, y: H + 4, vy: -(2.4 + Math.random() * 1.3),
+        ty: H * (0.16 + Math.random() * 0.34), color: pick(PALETTE) });
+    }
+    function startWord() {
+      const pts = wordPoints();
+      if (!pts.length) { wordTimer = 1500; return; }
+      const sx = W / 2 + (Math.random() - 0.5) * 30;
+      word = { phase: "in", clock: 0, parts: pts.map((p) => ({
+        sx: sx, sy: H + 8, x: sx, y: H + 8, px: sx, py: H + 8,
+        tx: p.x, ty: p.y, t: Math.random() * 0.12, life: 1,
+        color: Math.random() < 0.5 ? GOLD : WHITE })) };
+    }
+
+    const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+
+    function updateWord(dt) {
+      if (!word) return;
+      const P = word.parts;
+      if (word.phase === "in") {
+        let done = true;
+        for (const p of P) {
+          p.t += dt / 820;
+          const e = easeOut(Math.min(1, p.t));
+          p.px = p.x; p.py = p.y;
+          p.x = p.sx + (p.tx - p.sx) * e;
+          p.y = p.sy + (p.ty - p.sy) * e;
+          if (p.t < 1) done = false;
+        }
+        if (done) { word.phase = "hold"; word.clock = 0; }
+      } else if (word.phase === "hold") {
+        word.clock += dt;
+        if (word.clock > 1700) {
+          word.phase = "out";
+          for (const p of P) { p.vx = (Math.random() - 0.5) * 1.6; p.vy = -(0.4 + Math.random() * 1.8); }
+        }
+      } else { // out
+        let alive = false;
+        for (const p of P) {
+          p.px = p.x; p.py = p.y;
+          p.vy += 0.05; p.x += p.vx; p.y += p.vy; p.life -= 0.012;
+          if (p.life > 0) alive = true;
+        }
+        if (!alive) { word = null; wordTimer = 3400; }
+      }
+    }
+
+    let last = performance.now();
+    function frame(now) {
+      const dt = Math.min(50, now - last); last = now;
+      requestAnimationFrame(frame);
+      if (document.hidden || !W || !H) return;
+
+      rocketTimer -= dt;
+      if (rocketTimer <= 0) { launch(); rocketTimer = 480 + Math.random() * 720; }
+      if (!word) { wordTimer -= dt; if (wordTimer <= 0) startWord(); }
+
+      // rockets
+      for (let i = rockets.length - 1; i >= 0; i--) {
+        const r = rockets[i];
+        r.y += r.vy;
+        if (r.y <= r.ty) { explode(r.x, r.y, r.color); rockets.splice(i, 1); }
+      }
+      // sparks physics
+      for (let i = sparks.length - 1; i >= 0; i--) {
+        const s = sparks[i];
+        s.px = s.x; s.py = s.y;
+        s.vx *= 0.985; s.vy = s.vy * 0.985 + 0.045;
+        s.x += s.vx; s.y += s.vy; s.life -= s.decay;
+        if (s.life <= 0) sparks.splice(i, 1);
+      }
+      if (sparks.length > 1400) sparks.splice(0, sparks.length - 1400);
+      updateWord(dt);
+
+      // draw
+      ctx.clearRect(0, 0, W, H);
+      ctx.globalCompositeOperation = "lighter";
+      ctx.lineCap = "round";
+      for (const r of rockets) {
+        ctx.strokeStyle = rgba(r.color, 0.9); ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.moveTo(r.x, r.y + 6); ctx.lineTo(r.x, r.y); ctx.stroke();
+      }
+      for (const s of sparks) {
+        ctx.strokeStyle = rgba(s.color, Math.max(0, s.life));
+        ctx.lineWidth = 1.6;
+        ctx.beginPath(); ctx.moveTo(s.px, s.py); ctx.lineTo(s.x, s.y); ctx.stroke();
+      }
+      if (word) {
+        const tw = (word.phase === "hold")
+          ? 0.75 + 0.25 * Math.sin(now / 140) : 1;
+        for (const p of word.parts) {
+          const a = Math.max(0, p.life) * tw;
+          ctx.fillStyle = rgba(p.color, a);
+          ctx.beginPath(); ctx.arc(p.x, p.y, 1.9, 0, Math.PI * 2); ctx.fill();
+        }
+      }
+      ctx.globalCompositeOperation = "source-over";
+    }
+    requestAnimationFrame(frame);
   })();
 
   loadHearings();

--- a/docs/src/dashboard/index.html
+++ b/docs/src/dashboard/index.html
@@ -393,6 +393,17 @@
   .m-muted { color: var(--text-muted); font-size: 13px; }
   .m-tags { display: inline-flex; flex-wrap: wrap; gap: 5px; }
   .m-loading { padding: 30px 0; text-align: center; color: var(--text-muted); }
+  /* Details modal: all non-link text reads at full contrast (white in dark
+     theme, near-black in light) — only anchors keep their link color. This wins
+     over the muted/secondary colors set above via source order. */
+  .modal-card { color: var(--text-primary); }
+  .modal-card .m-section > h3,
+  .modal-card .m-list li,
+  .modal-card .m-act .d,
+  .modal-card .m-muted,
+  .modal-card .m-loading,
+  .modal-card .m-chip { color: var(--text-primary); }
+  .modal-card .m-chip.is-law { color: var(--text-primary); }  /* keep green border */
 </style>
 <script>
   // Apply a saved theme choice before first paint to avoid a flash of the


### PR DESCRIPTION
## Summary

Two follow-up polish items on the Pages dashboards.

## 🔍 Live preview (auto-updates on every push to this branch)

**Hearings:** https://raw.githack.com/chihacknight/govbot/claude/legislation-dashboard-ui-ygjozc/docs/src/dashboard/hearings.html
**Legislation:** https://raw.githack.com/chihacknight/govbot/claude/legislation-dashboard-ui-ygjozc/docs/src/dashboard/index.html

### 1. Legislation details modal — full-contrast text
All non-hyperlink text in the bill-details modal now uses `--text-primary` (white in dark theme, near-black in light) instead of the muted/secondary grays — section labels, sponsor lists, action dates, chips, and the loading line. Only links keep their link color. Implemented as a scoped, source-order override so it can't leak outside the modal.

### 2. Committee Hearings — "250th" fireworks brand bar
Replaced the small CSS logo sparkle with a celebratory **night-sky canvas fireworks show**:
- Ambient 4th-of-July bursts (red/white/blue/gold) play behind an enlarged, glowing logo + wordmark.
- A recurring shell flies up and settles its sparks into the word **"250th"** (America's Semiquincentennial), holds with a twinkle, then falls.
- Self-contained (no libraries), DPR-aware, pauses when the tab is hidden, and **degrades to a static "250th"** under `prefers-reduced-motion`.

## Testing
- Headless Chromium render (Playwright): no console/page errors; canvas paints; the word legibly reads "250th" during its hold phase; the details modal's chips/text compute to white in dark theme.
- JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)