### PR TITLE
Hearings: label date kind, show bill names, fuller locations

### DIFF
--- a/actions/scrape-hearings/__snapshots__/expected_hearings.json
+++ b/actions/scrape-hearings/__snapshots__/expected_hearings.json
@@ -146,7 +146,7 @@
       "scheduled_iso": "2026-09-10T13:00:00",
       "scheduled_display": "2026-09-10T13:00:00",
       "timezone": "America/Anchorage",
-      "location": "ANCH LIO DENALI Rm",
+      "location": "Anchorage Legislative Information Office DENALI Room",
       "status": "scheduled",
       "bills": [],
       "details_url": "https://www.akleg.gov/basis/Meeting/Detail?Meeting=HRES%202026-09-10%2013:00:00",
@@ -163,7 +163,7 @@
       "scheduled_iso": "2026-09-10T13:00:00",
       "scheduled_display": "2026-09-10T13:00:00",
       "timezone": "America/Anchorage",
-      "location": "ANCH LIO DENALI Rm",
+      "location": "Anchorage Legislative Information Office DENALI Room",
       "status": "scheduled",
       "bills": [],
       "details_url": "https://www.akleg.gov/basis/Meeting/Detail?Meeting=SRES%202026-09-10%2013:00:00",
@@ -236,7 +236,7 @@
       "scheduled_iso": "2026-09-03T14:00:00",
       "scheduled_display": "2026-09-03T14:00:00",
       "timezone": "America/New_York",
-      "location": "428A · Boston",
+      "location": "Room 428A · 24 Beacon Street · Boston, MA",
       "status": "scheduled",
       "bills": [],
       "details_url": "https://malegislature.gov/Events/Hearings/Detail/5774",
@@ -253,43 +253,50 @@
       "scheduled_iso": "2026-09-10T09:00:00",
       "scheduled_display": "2026-09-10T09:00:00",
       "timezone": "America/New_York",
-      "location": "Written Testimony Only · Boston",
+      "location": "Written Testimony Only · 24 Beacon Street · Boston, MA",
       "status": "scheduled",
       "bills": [
         {
           "id": "H5516",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/H5516"
+          "url": "https://malegislature.gov/Bills/194/H5516",
+          "title": "An Act regulating condominium associations and management companies"
         },
         {
           "id": "H5583",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/H5583"
+          "url": "https://malegislature.gov/Bills/194/H5583",
+          "title": "An Act authorizing the town of Webster to grant a license for the sale of all alcoholic beverages not to be drunk on the premises"
         },
         {
           "id": "H5602",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/H5602"
+          "url": "https://malegislature.gov/Bills/194/H5602",
+          "title": "An Act authorizing the town of Ludlow to grant an additional all alcohol license for on premises consumption"
         },
         {
           "id": "H5605",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/H5605"
+          "url": "https://malegislature.gov/Bills/194/H5605",
+          "title": "An Act relative to liquor license extensions in the town of Hanover"
         },
         {
           "id": "S3234",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/S3234"
+          "url": "https://malegislature.gov/Bills/194/S3234",
+          "title": "An Act authorizing the town of Millbury to grant additional liquor licenses"
         },
         {
           "id": "H5481",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/H5481"
+          "url": "https://malegislature.gov/Bills/194/H5481",
+          "title": "An Act authorizing the town of Wayland to grant additional licenses for the sale of all alcoholic beverages to be drunk on the premises"
         },
         {
           "id": "S3261",
           "slips": null,
-          "url": "https://malegislature.gov/Bills/194/S3261"
+          "url": "https://malegislature.gov/Bills/194/S3261",
+          "title": "An Act authorizing the city of Greenfield to grant an additional liquor license for the sale of all alcoholic beverages to be drunk on the premises"
         }
       ],
       "details_url": "https://malegislature.gov/Events/Hearings/Detail/5769",
@@ -306,7 +313,7 @@
       "scheduled_iso": "2026-10-20T13:00:00",
       "scheduled_display": "2026-10-20T13:00:00",
       "timezone": "America/New_York",
-      "location": "437 · Boston",
+      "location": "Room 437 · 24 Beacon Street · Boston, MA",
       "status": "scheduled",
       "bills": [],
       "details_url": "https://malegislature.gov/Events/Hearings/Detail/5697",

--- a/actions/scrape-hearings/main.py
+++ b/actions/scrape-hearings/main.py
@@ -546,6 +546,21 @@ def _ma_real_committee_code(code):
     return code if re.match(r"^[HSJ]\d+$", code or "") else None
 
 
+def _ma_location(loc):
+    """A location a reader can act on: "Room 428A · 24 Beacon Street · Boston, MA"
+    rather than a bare "428A · Boston". A room number/code is labeled "Room" so it
+    reads as one; the State House street address and state are folded in from the
+    API so the room isn't context-free."""
+    if not isinstance(loc, dict):
+        return ""
+    room = (loc.get("LocationName") or "").strip()
+    if room and room[0].isdigit():  # "428A"/"437" -> "Room 428A"; leave "Virtual …"
+        room = "Room " + room
+    city_state = ", ".join(p for p in [(loc.get("City") or "").strip(),
+                                       (loc.get("State") or "").strip()] if p)
+    return join_location(room, (loc.get("AddressLine1") or "").strip(), city_state)
+
+
 def parse_ma_hearing_list(json_text):
     """Pure: ordered event ids from the /api/Hearings stub list."""
     try:
@@ -578,19 +593,24 @@ def parse_ma_hearing(json_text):
     real_code = _ma_real_committee_code(code)
     when = d.get("StartTime") or d.get("EventDate") or ""
     when = when.strip() if isinstance(when, str) else ""
-    loc = d.get("Location") or {}
-    location = join_location(loc.get("LocationName") or "", loc.get("City") or "")
+    location = _ma_location(d.get("Location"))
     canceled = str(d.get("Status") or "").lower() == "canceled"
-    # Bills: every document on every agenda, de-duplicated, normalized (H5516).
-    bill_urls = {}
+    # Bills: every document on every agenda, de-duplicated, normalized (H5516),
+    # with the bill's title (MA is not in govbot's dataset, so the name shown next
+    # to the number comes from MA's own feed rather than govbot enrichment).
+    bills_by_num = {}
     for agenda in d.get("HearingAgendas") or []:
         for doc in (agenda or {}).get("DocumentsInAgenda") or []:
             num = str((doc or {}).get("BillNumber") or "").replace(" ", "").upper()
-            if not num:
+            if not num or num in bills_by_num:
                 continue
             gc = (doc or {}).get("GeneralCourtNumber") or general_court or 194
-            bill_urls.setdefault(num, ma_bill_url(num, gc))
-    bills = [{"id": bid, "slips": None, "url": url} for bid, url in bill_urls.items()]
+            bill = {"id": num, "slips": None, "url": ma_bill_url(num, gc)}
+            title = str((doc or {}).get("Title") or "").strip()
+            if title:
+                bill["title"] = title
+            bills_by_num[num] = bill
+    bills = list(bills_by_num.values())
     return {
         "id": f"ma-{chamber}-{d['EventId']}",
         "jurisdiction": "ma",
@@ -681,6 +701,27 @@ def ak_meeting_detail_url(raw_url):
     return raw_url.replace("http://", "https://").replace(" ", "%20")
 
 
+# akleg abbreviates the meeting room. Expand only the unambiguous ones so a
+# reader isn't left decoding "ANCH LIO … Rm"; committee-room names (BARNES 124,
+# SENATE FINANCE 532 — rooms in the Juneau Capitol) are already words and pass
+# through untouched.
+_AK_LOC_TERMS = [
+    ("ANCH LIO", "Anchorage Legislative Information Office"),
+    ("FBX LIO", "Fairbanks Legislative Information Office"),
+    ("JNU LIO", "Juneau Legislative Information Office"),
+    ("LIO", "Legislative Information Office"),
+    ("Conf Rm", "Conference Room"),
+    ("Rm", "Room"),
+]
+
+
+def _ak_location(raw):
+    s = (raw or "").strip()
+    for abbr, full in _AK_LOC_TERMS:
+        s = re.sub(r"\b" + re.escape(abbr) + r"\b", full, s)
+    return s
+
+
 def parse_ak_meetings(json_text):
     """Pure: normalize the BASIS meetings document into hearing records within the
     current legislature. De-duplicates a joint committee that BASIS lists once per
@@ -716,7 +757,7 @@ def parse_ak_meetings(json_text):
             "scheduled_iso": iso or None,
             "scheduled_display": iso,
             "timezone": "America/Anchorage",
-            "location": (m.get("Location") or "").strip(),
+            "location": _ak_location(m.get("Location")),
             "status": "canceled" if m.get("MeetingCanceled") else "scheduled",
             "bills": [],
             "details_url": ak_meeting_detail_url(m.get("Url")),

--- a/actions/scrape-hearings/test_scrape_hearings.py
+++ b/actions/scrape-hearings/test_scrape_hearings.py
@@ -116,9 +116,18 @@ class MassachusettsParser(unittest.TestCase):
         self.assertEqual(h["chamber"], "joint")
         self.assertEqual(h["status"], "scheduled")
         self.assertEqual(h["scheduled_iso"], "2026-09-10T09:00:00")
-        self.assertIn("H5516", [b["id"] for b in h["bills"]])
-        self.assertTrue(h["bills"][0]["url"].startswith("https://malegislature.gov/Bills/194/"))
+        bills = {b["id"]: b for b in h["bills"]}
+        self.assertIn("H5516", bills)
+        self.assertTrue(bills["H5516"]["url"].startswith("https://malegislature.gov/Bills/194/"))
+        # The bill name is carried from MA's own feed (MA isn't in govbot data).
+        self.assertIn("condominium", bills["H5516"]["title"].lower())
         self.assertEqual(h["committee_url"], "https://malegislature.gov/Committees/Detail/J17/194")
+
+    def test_location_has_room_and_address(self):
+        # "437" alone is context-free; the room is labeled and the State House
+        # address folded in.
+        self.assertEqual(self._hearing(5697)["location"],
+                         "Room 437 · 24 Beacon Street · Boston, MA")
 
     def test_canceled_status(self):
         self.assertEqual(self._hearing(5675)["status"], "canceled")
@@ -165,6 +174,10 @@ class AlaskaParser(unittest.TestCase):
 
     def test_canceled_status(self):
         self.assertTrue(any(h["status"] == "canceled" for h in self.hearings))
+
+    def test_location_abbreviations_expanded(self):
+        h = next(h for h in self.hearings if h["committee"] == "Resources")
+        self.assertEqual(h["location"], "Anchorage Legislative Information Office DENALI Room")
 
     def test_bad_json_is_empty_not_crash(self):
         self.assertEqual(main.parse_ak_meetings("<html>nope</html>"), [])

--- a/docs/src/dashboard/hearings.html
+++ b/docs/src/dashboard/hearings.html
@@ -401,6 +401,13 @@
   .hearing-row.is-canceled { opacity: 0.62; }
   .h-when { color: var(--text-secondary); font-size: 13px; }
   .h-when b { color: var(--text-primary); font-weight: 600; }
+  /* Says what the date means: a scheduled hearing time vs. a submission deadline. */
+  .h-kind {
+    display: inline-block; margin-bottom: 3px; padding: 1px 6px; border-radius: 4px;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+    color: var(--series-1); border: 1px solid var(--series-1);
+  }
+  .h-kind.is-due { color: var(--series-3); border-color: var(--series-3); }
   .h-badge {
     display: inline-block; margin-left: 8px; padding: 1px 7px; border-radius: 999px;
     font-size: 11px; font-weight: 600; color: var(--series-6);
@@ -740,8 +747,12 @@
     const row = eln("div", "hearing-row" + (h.status === "canceled" ? " is-canceled" : ""));
 
     const when = eln("div", "h-when");
-    when.append(eln("b", null, hearingWhen(h)));
-    if (h.status === "canceled") when.append(eln("span", "h-badge", "Canceled"));
+    const kind = whenKind(h);
+    when.append(eln("span", "h-kind" + (kind.cls ? " " + kind.cls : ""), kind.text));
+    const timeRow = eln("div", "h-when-time");
+    timeRow.append(eln("b", null, hearingWhen(h)));
+    if (h.status === "canceled") timeRow.append(eln("span", "h-badge", "Canceled"));
+    when.append(timeRow);
     row.append(when);
 
     const main = eln("div", "h-main");
@@ -806,10 +817,19 @@
   // ISO-looking strings ourselves from their parts — never via Date(), which
   // would re-interpret the naive time in the viewer's zone — and fall back to
   // the source's own display string (already friendly for IL).
+  // What the date on a row means. State/territory rows are a hearing happening at
+  // that time; federal rows are a public-comment window whose date is the deadline.
+  function whenKind(h) {
+    return h.jurisdiction === "us"
+      ? { text: "Comment due", cls: "is-due" }
+      : { text: "Hearing", cls: "" };
+  }
   function hearingWhen(h) {
-    // Federal items already carry a human "Comments due …" string; show it as-is
-    // rather than reformatting the deadline into a wall-clock time.
-    if (h.jurisdiction === "us") return h.scheduled_display || "Open for comment";
+    // Federal items carry a "Comments due …" deadline string; the "Comment due"
+    // label now says that, so show just the date to avoid repeating the words.
+    if (h.jurisdiction === "us") {
+      return (h.scheduled_display || "Open for comment").replace(/^comments?\s+due\s+/i, "");
+    }
     let disp = prettyLocal(h.scheduled_display) || prettyLocal(h.scheduled_iso)
       || h.scheduled_display || h.scheduled_iso || "Time TBA";
     const zone = TZ_ABBR[h.timezone];

--- a/schemas/govbot.hearings.schema.json
+++ b/schemas/govbot.hearings.schema.json
@@ -81,6 +81,7 @@
             "properties": {
               "id": { "type": "string", "description": "Compact bill id, e.g. HB1643, SB25." },
               "url": { "type": "string", "description": "Official page for this bill (IL: Bill Status; WA: bill summary)." },
+              "title": { "type": "string", "description": "Bill/measure name from the hearing source itself, shown beside the number when the bill isn't in govbot's dataset (e.g. the MA agenda title, the federal docket title)." },
               "govbot_title": { "type": "string", "description": "Bill title from govbot's own dataset, when govbot tracks this bill (build-time enrichment)." },
               "govbot_tags": { "type": "array", "items": { "type": "string" }, "description": "govbot topic tags for this bill, when tracked." },
               "slips": {


### PR DESCRIPTION
## Summary

Three detail improvements to the Committee Hearings & Witness Slips page, from user feedback.

### 1. Say what each date means
Every row now carries a small label before the date:
- **HEARING** (blue) — a committee hearing scheduled *for* that date/time (states & territories).
- **COMMENT DUE** (amber) — a federal public-comment window whose date is the *deadline*.

So a reader isn't left guessing whether a date is when something happens or when something is due. The redundant "Comments due" prefix is dropped from the federal date now that the label carries it.

### 2. Bill name beside the number
Massachusetts isn't in govbot's bill dataset, so its hearing bills had no title. The MA scraper now carries each bill's name from MA's own agenda feed (e.g. `H5516 — An Act regulating condominium associations and management companies`). Added `title` to the bills schema (federal already used it).

### 3. Fuller locations
MA hearings showed a bare `428A · Boston`; the room is now labeled and the State House street address + state folded in → `Room 428A · 24 Beacon Street · Boston, MA`. Alaska's abbreviated rooms expand the unambiguous bits (`ANCH LIO … Rm` → `Anchorage Legislative Information Office … Room`); Juneau Capitol committee-room names pass through untouched.

## Testing
- `python3 actions/scrape-hearings/test_scrape_hearings.py` — **41 tests pass** (2 new: MA location room+address, AK abbreviation expansion; MA bill-title assertion added).
- Offline snapshot regenerated; hearings schema validates.
- Rendered in a real browser: date labels (HEARING / COMMENT DUE), MA bill names, and the fuller MA/AK locations all display correctly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012V2MqFwBKCPRDo5maDKL6u)_