### PR TITLE
Elections: official CPS candidates from the Chicago BOE PDF + per-race potential-candidate queries

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -222,6 +222,25 @@ jobs:
           ls -lh docs/src/dashboard/elections.json docs/src/dashboard/elections.xml
           ls -1 docs/src/dashboard/elections/ 2>/dev/null | head -5 || true
 
+      # Official candidates from the Chicago Board of Elections' Candidate List PDF.
+      # The BOE publishes the authoritative roster only as a PDF, so we extract it
+      # with `pdftotext` (poppler-utils, a system tool like the DuckDB dependency)
+      # and merge the Board-of-Education races on the ballot (president + 20
+      # subdistricts). Runs before money (so committees can match) and before the
+      # feeds are written. Fully fail-soft: no poppler / no PDF leaves candidates as
+      # they were. As more offices appear on official lists, this populates them too.
+      - name: Populate official candidates from the Chicago BOE candidate list (PDF)
+        run: |
+          set -uo pipefail
+          sudo apt-get update && sudo apt-get install -y poppler-utils \
+            || echo "::warning::poppler-utils install failed; skipping BOE candidate PDF"
+          if command -v pdftotext >/dev/null 2>&1; then
+            python3 actions/scrape-elections/main.py \
+              --enrich-candidates-boe docs/src/dashboard/elections.json \
+              || echo "::warning::BOE candidate enrichment reported errors"
+          fi
+          python3 -c 'import json;d=json.load(open("docs/src/dashboard/elections.json"));n=sum(len(r.get("candidates") or []) for r in d["races"]);print(f"official candidates now: {n}")'
+
       # Potential candidates (unofficial): before filing opens, surface names the
       # press reports as running/exploring for each race, from a Google News
       # search — each tied to its article. Written straight into elections.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,21 @@ outline (citywide offices tint all of Chicago); CPS subdistricts have no publish
 so their map is omitted. Fail-soft: a portal outage leaves the committed `maps.json` in
 place. Geometry helpers are offline-tested: `python3 actions/scrape-maps/main.py --self-test`.
 
+**Official candidates** are populated from the Chicago Board of Elections' authoritative
+**Candidate List PDF** (linked from `chicagoelections.gov/getting-ballot/candidates`; the BOE
+publishes the roster only as a PDF). `deploy-docs.yml` installs `poppler-utils` and
+`main.py --enrich-candidates-boe docs/src/dashboard/elections.json` auto-discovers the newest
+`Candidate List_<date>.pdf`, extracts it with the `pdftotext` **system tool** (shelled out like
+DuckDB — no Python dep, so the stdlib-only rule holds), and merges candidates. The pure
+`parse_boe_candidate_list(text)` is scoped to Board-of-Education offices — the only Chicago-seed
+races on the Nov 2026 ballot (president + 20 subdistricts 1a–10b) — so the statewide/federal/
+judicial offices on the same list are ignored (critically, the statewide "Treasurer" is never
+misread as the Chicago City Treasurer); office context resets at every non-BOE header so trailing
+sections never leak into the last subdistrict. It's offline-tested against
+`__snapshots__/raw/boe_candidate_list.txt` (`pdftotext -layout` text; the shell-out lives only in
+the fetch wrapper). Runs before the money step (so committees can match) and before the RSS feeds
+are rebuilt. Fail-soft: no poppler / no PDF leaves rosters as they were; committed sample empty.
+
 **Campaign money** (Illinois SBE) attaches to each candidate via the SBE ID crosswalk
 (candidate name → `Candidates.txt` ID → `CmteCandidateLinks` → `Committees` → latest
 `D2Totals` row): receipts, spending, cash on hand. Only unambiguous name matches are kept

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,8 +242,13 @@ name only when a headline both names a person beside a candidacy verb (→ statu
 district race, its district token (word-boundary matched, so "5th ward" ≠ "25th ward").
 Honorifics are stripped ("Rep. Mike Quigley" → "Mike Quigley"), office/place/calendar words are
 rejected as names, and every name carries its source article(s) {title, url, publisher, date};
-a sourceless name is dropped — nothing is invented. One pooled news query per office group (plus
-one per citywide office); fail-soft (sources down → empty lists), committed sample empty. The
+a sourceless name is dropped — nothing is invented. Queries: one pooled query per office group
+for cross-cutting coverage, **plus a per-race query for every district race** (`Chicago alderman
+"45th ward" candidate 2027`, etc.) so each ward/subdistrict/police district gets its own coverage
+pool, plus one per citywide office. A bigger pool never loosens the match — the strict office +
+district gating is unchanged, so most down-ballot races legitimately stay empty until candidates
+actually appear in the press (2027 filing opens Nov 2026); the lists fill in on the twice-daily
+refresh as coverage grows. Fail-soft (sources down → empty lists), committed sample empty. The
 frontend renders it as a collapsed, dashed-amber "💭 Potential candidates · Unofficial · from
 news" block under each race. `deploy-docs.yml` runs it right after the base elections build
 (independent of official candidates), twice daily. Parsers are offline-tested in

--- a/actions/scrape-elections/README.md
+++ b/actions/scrape-elections/README.md
@@ -127,10 +127,18 @@ so it's out). A name is attached **only** when a headline both:
 Leading honorifics are stripped (`Rep. Mike Quigley` → `Mike Quigley`) so one
 person doesn't split in two, office/place/calendar words are rejected as names,
 and every surfaced name carries the article(s) it came from (headline, link,
-publisher, date). Nothing is invented; a name with no source is dropped. One
-pooled news query runs per office group (plus one per citywide office); each race
-extracts only names whose headline references it. Fully fail-soft — sources down
-leaves the lists empty.
+publisher, date). Nothing is invented; a name with no source is dropped.
+
+Queries: one **pooled query per office group** for cross-cutting coverage, plus a
+**per-race query for every district race** (`Chicago alderman "45th ward"
+candidate 2027`, …) so each ward / CPS subdistrict / police district gets its own
+coverage pool — a single pooled query can't cover 50 wards. The bigger pool never
+loosens the match: the strict office + district gating is unchanged, so a name
+still attaches only when a headline names the person with a candidacy verb *and*
+references that race. Because of that, **most down-ballot races legitimately stay
+empty** until candidates actually surface in the press (2027 filing opens Nov
+2026) — the lists fill in on the twice-daily refresh as coverage grows, never by
+guessing. Fully fail-soft — sources down leaves the lists empty.
 
 ```bash
 python3 actions/scrape-elections/main.py \

--- a/actions/scrape-elections/README.md
+++ b/actions/scrape-elections/README.md
@@ -42,6 +42,35 @@ no confirmed candidate keeps an empty list plus a link to its official source.
 > The exact live endpoints in `main.py` may need re-pointing against a real page
 > snapshot as a cycle opens.
 
+## Official candidates — Chicago BOE Candidate List (PDF)
+
+The Board of Elections publishes the authoritative candidate roster only as a
+**PDF** (`Candidate List_<date>.pdf`, linked from
+`chicagoelections.gov/getting-ballot/candidates`). `--enrich-candidates-boe`
+auto-discovers the newest one, extracts it with the `pdftotext` **system tool**
+(poppler-utils — shelled out like DuckDB, so no Python dependency is added), and
+merges the candidates into the matching races:
+
+```bash
+python3 actions/scrape-elections/main.py \
+  --enrich-candidates-boe docs/src/dashboard/elections.json
+# or point at a specific source (URL, local .pdf, or extracted .txt for testing):
+#   --boe-pdf "https://…/Candidate List_20260904-1_0.pdf"
+```
+
+`parse_boe_candidate_list(text)` is a pure parser over the `pdftotext -layout`
+output. It's **scoped to Board-of-Education offices** — the only Chicago-seed
+races on the Nov 2026 ballot (president + 20 subdistricts 1a–10b) — so the
+statewide / federal / judicial offices on the same ballot list are ignored. That
+scoping matters: it stops the statewide *Treasurer* from being misread as the
+Chicago City Treasurer, and the office context resets at every non-BOE header so
+trailing sections never leak into the last subdistrict. Pure/deterministic and
+offline-tested against `__snapshots__/raw/boe_candidate_list.txt`; only the fetch
+wrapper touches the network / shells out to `pdftotext`. Fail-soft: no poppler or
+no PDF leaves rosters untouched. The deploy runs this before the money step (so
+committees can match) and before the feeds are rebuilt; the committed sample
+ships empty.
+
 ## Springfield side feed — "the rules of the game"
 
 Beyond candidates, the build attaches a top-level `springfield` list: **Illinois

--- a/actions/scrape-elections/__snapshots__/raw/boe_candidate_list.txt
+++ b/actions/scrape-elections/__snapshots__/raw/boe_candidate_list.txt
@@ -1,0 +1,72 @@
+This Unofficial candidate list for the November 3, 2026 election includes only the offices and the names of candidates whose districts include all or
+part of the City of Chicago. Please note: This list will be updated if filing change.
+                                                                                                              Status as of 9/4/2026 3:30:15 PM
+
+                    Candidate Filings in Ballot Order, November 3, 2026
+     Ballot No. Candidate                                                                                                                   Status
+
+Treasurer
+  Vote for One
+      (13)      Max Solomon (Republican)                                                                                            Candidate
+
+      (14)      Michael W. Frerichs (Democratic)                                                                                    Candidate
+
+                Write-in                                                                                                                    N/A
+
+President of the Chicago Board of Education
+ Vote for One
+   (121)   Victor P. Henderson (Nonpartisan)                             Candidate
+
+   (122)   Jessica Biggs (Nonpartisan)                                   Candidate
+
+   (123)   Sendhil Revuluri (Nonpartisan)                                Withdrawn
+
+   (124)   Hilario Dominguez (Nonpartisan)                               Candidate
+
+           Write-in                                                           N/A
+
+
+
+
+                                                 Page 12 of 28
+   Ballot No. Candidate                                              Status
+
+Member of the Chicago Board of Education, Subdistrict 1A
+ Vote for One
+   (131)   Ed Bannon (Nonpartisan)                              Candidate
+
+   (132)   Margie B. Luczak (Nonpartisan)                       Candidate
+
+           Write-in                                                  N/A
+
+Member of the Chicago Board of Education, Subdistrict 2B
+ Vote for One
+   (131)   Deborah "Debby" Pope (Nonpartisan)                   Candidate
+
+   (132)   Kyna Lenhof (Nonpartisan)                            Objected
+
+   (133)   Daniel Basco (Nonpartisan)                           Candidate
+
+Member of the Chicago Board of Education, Subdistrict 4B
+ Vote for One
+   (131)   Ellen Rosenfeld (Nonpartisan)                          Candidate
+
+Member of the Chicago Board of Education, Subdistrict 10B
+ Vote for One
+   (131)   Connie Anderson (Nonpartisan)                        Candidate
+
+   (132)   Patrick C. Watson (Nonpartisan)                      Candidate
+
+           Write-in                                                  N/A
+
+
+
+
+                                                 Page 27 of 28
+   Ballot No. Candidate                                              Status
+
+Judge of the Circuit Court (Vacancy of Flanagan)
+  Vote for One
+     (301)     Should Not Be Attributed (Democratic)                                                                                Candidate
+
+                Write-in                                                                                                                    N/A

--- a/actions/scrape-elections/main.py
+++ b/actions/scrape-elections/main.py
@@ -1090,6 +1090,37 @@ _GROUP_QUERY = {
 }
 
 
+def _ordinal(n):
+    """1 -> '1st', 2 -> '2nd', 3 -> '3rd', 11 -> '11th', 22 -> '22nd', …"""
+    if 10 <= n % 100 <= 20:
+        suf = "th"
+    else:
+        suf = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suf}"
+
+
+def _race_news_query(race):
+    """A per-race query so each district race gets its own coverage pool (one
+    pooled group query can't cover 50 wards / 22 districts). Returns None for
+    citywide/unknown, which fall back to the pooled group query + _news_query_for_race."""
+    g = race.get("office_group")
+    yr = (race.get("ballot_date") or "")[:4]
+    if g == "council":
+        w = _ward(race.get("district"))
+        if w:
+            return f'Chicago alderman "{_ordinal(w)} ward" candidate {yr or "2027"}'
+    if g == "police_district_council":
+        pd = _police_district(race.get("district"))
+        if pd:
+            return f'Chicago "police district council" "{_ordinal(pd)} district" candidate'
+    if g == "cps_board" and not race.get("is_citywide"):
+        sub = _subdistrict(race.get("district"))
+        if sub:
+            n = re.match(r"(\d+)", sub).group(1)
+            return f'Chicago "Board of Education" "district {n}" candidate {yr or "2026"}'
+    return None
+
+
 def fetch_news_items(query):
     """Live fetch+parse of one news query. Fail-soft: any failure yields []."""
     return parse_news_rss(fetch_text(news_url(query)))
@@ -1178,28 +1209,35 @@ def build_potential(race, items, now, existing=None):
 
 def enrich_potential(doc, now, fetcher=fetch_news_items, sleep=POTENTIAL_FETCH_SLEEP):
     """Attach unofficial, news-sourced potential_candidates[] to each race in an
-    assembled elections doc, in place. One pooled news query per office group
-    (plus one per citywide office); each race extracts only names whose headline
-    references it. `fetcher` is injectable so tests run offline. Returns the
-    number of races given at least one potential candidate."""
+    assembled elections doc, in place.
+
+    Each race draws on: a broad pooled query for its office group (cross-cutting
+    coverage), PLUS a per-race query for district races (so each ward / CPS
+    subdistrict / police district gets its own coverage pool — one pooled query
+    can't cover 50 wards). Citywide races use their own office query. Extraction
+    is unchanged (strict office+district gating), so a bigger pool never means a
+    looser match — a name still attaches only when a headline names the person
+    with a candidacy verb AND references this race. `fetcher` is injectable so
+    tests run offline. Returns the number of races given >=1 potential candidate."""
     import time
     races = doc.get("races", [])
-    # Group fetches: pool district races by office group, citywide per race.
-    group_pool = {}
-    for g, q in _GROUP_QUERY.items():
-        if any(r.get("office_group") == g for r in races):
-            group_pool[g] = fetcher(q) or []
-            if sleep:
-                time.sleep(sleep)
+
+    def _fetch(q):
+        items = fetcher(q) or []
+        if sleep:
+            time.sleep(sleep)
+        return items
+
+    # Broad per-group pools (cheap: one request per group) for cross-cutting hits.
+    group_pool = {g: _fetch(q) for g, q in _GROUP_QUERY.items()
+                  if any(r.get("office_group") == g for r in races)}
+
     updated = 0
     for r in races:
         g = r.get("office_group")
-        if g in group_pool:
-            items = group_pool[g]
-        else:
-            items = fetcher(_news_query_for_race(r)) or []
-            if sleep:
-                time.sleep(sleep)
+        items = list(group_pool.get(g, []))
+        rq = _race_news_query(r)                 # per-district query, when applicable
+        items += _fetch(rq) if rq else (_fetch(_news_query_for_race(r)) if g not in group_pool else [])
         pcs = build_potential(r, items, now, existing=r.get("potential_candidates"))
         r["potential_candidates"] = pcs
         if pcs:

--- a/actions/scrape-elections/main.py
+++ b/actions/scrape-elections/main.py
@@ -95,6 +95,19 @@ def fetch_text(url, timeout=FETCH_TIMEOUT):
         return None
 
 
+def fetch_bytes(url, timeout=FETCH_TIMEOUT):
+    """GET a URL, returning the raw bytes or None on any failure (for the BOE
+    candidate-list PDF)."""
+    url = url.replace(" ", "%20")  # BOE blob names contain spaces; urllib rejects them
+    req = urllib.request.Request(url, headers={"user-agent": UA, "accept": "*/*"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read() if resp.status == 200 else None
+    except Exception as err:
+        print(f"warning: fetch failed {url}: {err}", file=sys.stderr)
+        return None
+
+
 # --------------------------------------------------------------------------- #
 # normalization + race matching
 # --------------------------------------------------------------------------- #
@@ -412,6 +425,167 @@ def parse_cook_clerk(text, source="Cook County Clerk"):
     seed carries Cook County / suburban races; kept so the adapter slot exists
     and the deploy wiring is stable."""
     return []
+
+
+# --------------------------------------------------------------------------- #
+# Chicago BOE official "Candidate List" PDF (ballot-order text)
+# --------------------------------------------------------------------------- #
+# The Board of Elections publishes the authoritative candidate roster as a PDF
+# ("Candidate List_<date>.pdf") linked from chicagoelections.gov/getting-ballot/
+# candidates. `pdftotext -layout` renders it as ballot-order text:
+#
+#     President of the Chicago Board of Education
+#      Vote for One
+#        (121)   Victor P. Henderson (Nonpartisan)                 Candidate
+#     Member of the Chicago Board of Education, Subdistrict 1A
+#      Vote for One
+#        (131)   Ed Bannon (Nonpartisan)                           Candidate
+#
+# We scope to the Board-of-Education offices (the only Chicago-seed races on the
+# Nov 2026 ballot); the statewide/federal/judicial offices on the same list are
+# ignored — critically, so the statewide "Treasurer" is never misread as the
+# Chicago City Treasurer. Pure/deterministic; the pdftotext shell-out lives in
+# the fetch wrapper, so this is exercised offline against the __snapshots__ text.
+_BOE_PDF_ROW = re.compile(
+    r'^\s*\(\d+\)\s+(\S.*?)\s{2,}'
+    r'(Candidate|Withdrawn|Objected|Removed|Disqualified|Not Certified)\s*$', re.I)
+_BOE_PDF_VOTE = re.compile(r'^\s*Vote (?:for|Yes)\b', re.I)
+_BOE_PDF_NOISE = re.compile(
+    r'^\s*(?:Page \d+ of \d+|Ballot No\.|Write-in\b|This\b|Status as of|'
+    r'Candidate Filings)', re.I)
+
+
+def _boe_pdf_status(raw):
+    """The list is the finalized ballot in ballot order, so a plain 'Candidate'
+    means on the ballot; other words map through the shared normalizer."""
+    return "on_ballot" if (raw or "").strip().lower() == "candidate" else normalize_status(raw)
+
+
+def parse_boe_candidate_list(text, source="Chicago Board of Elections (candidate list)"):
+    """Parse the `pdftotext -layout` text of the Chicago BOE Candidate List into
+    Board-of-Education candidate dicts. Office context is the most recent header
+    line naming a Board-of-Education office; it resets to None at any other office
+    header, so trailing sections never bleed into the last subdistrict."""
+    office = None
+    out = []
+    for ln in (text or "").splitlines():
+        if not ln.strip():
+            continue
+        m = _BOE_PDF_ROW.match(ln)
+        if m:
+            if office and "board of education" in office.lower():
+                np = m.group(1).strip()
+                pm = re.match(r'^(.*?)\s*\(([^)]+)\)\s*$', np)
+                name, party = (pm.group(1).strip(), pm.group(2).strip()) if pm else (np, None)
+                if party and party.lower() == "nonpartisan":
+                    party = None  # schema: party is for partisan races only
+                out.append(make_candidate(
+                    name=name, office=office, district=None, party=party,
+                    petition_status=_boe_pdf_status(m.group(2)), source=source))
+            continue
+        if _BOE_PDF_VOTE.match(ln) or _BOE_PDF_NOISE.match(ln):
+            continue
+        # Any other line is an office/section header: keep it as context only
+        # when it's a Board-of-Education office, else drop context.
+        office = ln.strip() if "board of education" in ln.lower() else None
+    return out
+
+
+BOE_CANDIDATES_PAGE = "https://chicagoelections.gov/getting-ballot/candidates"
+
+
+def discover_boe_pdf_url(page_html=None):
+    """Find the newest 'Candidate List ….pdf' link on the BOE candidates page
+    (other PDFs there are forms/guides). Newest wins by the YYYYMMDD in the name.
+    Pure given `page_html`; fetches the page when it's None."""
+    html = page_html if page_html is not None else fetch_text(BOE_CANDIDATES_PAGE)
+    if not html:
+        return None
+    urls = re.findall(r'https?://[^"\'<>]*?Candidate(?:%20|\s)*List[^"\'<>]*?\.pdf',
+                      html, re.I)
+    if not urls:
+        return None
+    return sorted(urls, key=lambda u: (re.search(r'(\d{8})', u) or [""])[0])[-1]
+
+
+def pdf_to_text(pdf_path):
+    """Extract ballot-order text from a PDF via the `pdftotext -layout` system
+    tool (poppler-utils), the way DuckDB is shelled out elsewhere. Returns None
+    if pdftotext is missing or fails — fully fail-soft."""
+    import subprocess
+    try:
+        r = subprocess.run(["pdftotext", "-layout", str(pdf_path), "-"],
+                           capture_output=True, timeout=120)
+        return r.stdout.decode("utf-8", "replace") if r.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError) as err:
+        print(f"warning: pdftotext failed ({err}); is poppler-utils installed?",
+              file=sys.stderr)
+        return None
+
+
+def fetch_boe_candidates(pdf_source=None):
+    """Resolve, download and parse the Chicago BOE Candidate List PDF into
+    candidate dicts. `pdf_source` may be a local text file (already extracted, for
+    testing), a local .pdf, a .pdf URL, or None (auto-discover). Fail-soft: any
+    step failing yields []."""
+    text = None
+    if pdf_source and pdf_source.lower().endswith((".txt",)):
+        try:
+            text = Path(pdf_source).read_text()
+        except OSError:
+            return []
+    else:
+        pdf_path = pdf_source
+        tmp = None
+        if not pdf_path or pdf_path.lower().startswith(("http://", "https://")):
+            url = pdf_source or discover_boe_pdf_url()
+            if not url:
+                return []
+            blob = fetch_bytes(url)
+            if not blob:
+                return []
+            import tempfile
+            tmp = Path(tempfile.mkstemp(suffix=".pdf")[1])
+            tmp.write_bytes(blob)
+            pdf_path = str(tmp)
+        text = pdf_to_text(pdf_path)
+        if tmp:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    return parse_boe_candidate_list(text) if text else []
+
+
+def merge_candidates(doc, candidates):
+    """Place scraped candidates into an assembled doc's races by resolved race id
+    (dedupe by name; a populated race flips 'upcoming' -> 'on_ballot'). Returns the
+    number placed. Mirrors assemble()'s placement so an enrichment run matches a
+    fresh build."""
+    by_id = {r["id"]: r for r in doc.get("races", [])}
+    placed = 0
+    for c in candidates:
+        rid = c.pop("_race_id", None)
+        race = by_id.get(rid) if rid else None
+        if not race:
+            continue
+        race.setdefault("candidates", [])
+        if any(x["name"].lower() == c["name"].lower() for x in race["candidates"]):
+            continue
+        if race.get("status") == "upcoming":
+            race["status"] = "on_ballot"
+        race["candidates"].append(c)
+        placed += 1
+    for r in doc.get("races", []):
+        r.get("candidates", []).sort(key=lambda c: c["name"].lower())
+    return placed
+
+
+def enrich_candidates_from_boe(doc, pdf_source=None):
+    """Attach official Chicago BOE candidates (currently the Board of Education
+    offices on the ballot) to an assembled elections doc, in place. Returns the
+    number placed."""
+    return merge_candidates(doc, fetch_boe_candidates(pdf_source))
 
 
 # --------------------------------------------------------------------------- #
@@ -1769,6 +1943,16 @@ def main():
                          "file's current potential_candidates so names/citations "
                          "accumulate across runs. Fail-soft: sources down leaves the "
                          "lists as they were")
+    ap.add_argument("--enrich-candidates-boe", default=None,
+                    help="Attach official candidates from the Chicago BOE Candidate "
+                         "List PDF to an existing elections.json (rewritten in place), "
+                         "then exit. Populates the Board-of-Education races on the "
+                         "ballot. Uses --boe-pdf or auto-discovers the latest PDF; needs "
+                         "the `pdftotext` system tool (poppler-utils). Fail-soft")
+    ap.add_argument("--boe-pdf", default=None,
+                    help="Source for --enrich-candidates-boe: a .pdf URL, a local .pdf, "
+                         "or a local .txt of already-extracted text (for tests). "
+                         "Omitted = auto-discover the latest from the BOE candidates page")
     ap.add_argument("--rss-from", default=None,
                     help="(Re)generate the RSS feeds from an existing elections.json "
                          "(no scrape), then exit — used by the deploy to rebuild feeds "
@@ -1804,6 +1988,15 @@ def main():
         n = enrich_potential(doc, now)
         Path(args.enrich_potential).write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
         print(f"attached news-sourced potential candidates to {n} race(s)", file=sys.stderr)
+        return 0
+
+    if args.enrich_candidates_boe:
+        doc = load_json(args.enrich_candidates_boe)
+        if doc is None:
+            return 0
+        n = enrich_candidates_from_boe(doc, args.boe_pdf)
+        Path(args.enrich_candidates_boe).write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+        print(f"attached {n} official Chicago BOE candidate(s)", file=sys.stderr)
         return 0
 
     if args.rss_from:

--- a/actions/scrape-elections/test_scrape_elections.py
+++ b/actions/scrape-elections/test_scrape_elections.py
@@ -472,6 +472,23 @@ class PotentialCandidates(unittest.TestCase):
         self.assertTrue(main.extract_candidacy(
             "Robin Example enters the race for alderman in Ward 5", ward5))
 
+    def test_ordinal(self):
+        self.assertEqual([main._ordinal(n) for n in (1, 2, 3, 4, 11, 13, 21, 22, 23, 50)],
+                         ["1st", "2nd", "3rd", "4th", "11th", "13th", "21st", "22nd", "23rd", "50th"])
+
+    def test_per_race_news_query(self):
+        # District races get a district-scoped query; citywide races don't.
+        ward = {"office": "Alderperson", "office_group": "council",
+                "is_citywide": False, "district": "Ward 45"}
+        self.assertIn('"45th ward"', main._race_news_query(ward))
+        police = {"office": "Police District Councilmember", "office_group": "police_district_council",
+                  "is_citywide": False, "district": "Police District 14"}
+        self.assertIn('"14th district"', main._race_news_query(police))
+        cps = {"office": "Member of the Board of Education", "office_group": "cps_board",
+               "is_citywide": False, "district": "Subdistrict 4A"}
+        self.assertIn('"district 4"', main._race_news_query(cps))
+        self.assertIsNone(main._race_news_query(self.mayor))  # citywide
+
     def test_enrich_potential_offline(self):
         seed = main.load_seed()
         doc, _ = main.assemble([], seed, "test", self.now)

--- a/actions/scrape-elections/test_scrape_elections.py
+++ b/actions/scrape-elections/test_scrape_elections.py
@@ -121,6 +121,69 @@ class ChicagoBOEParser(unittest.TestCase):
         self.assertEqual(main.parse_chicago_boe("<p>no table</p>"), [])
 
 
+class BOECandidateList(unittest.TestCase):
+    def setUp(self):
+        self.cands = main.parse_boe_candidate_list((RAW / "boe_candidate_list.txt").read_text())
+
+    def test_only_board_of_education_offices(self):
+        # The statewide Treasurer and the trailing Judge office must NOT resolve.
+        rids = {c["_race_id"] for c in self.cands}
+        self.assertNotIn(None, rids)
+        self.assertTrue(all(r.startswith("cps-") for r in rids))
+        names = {c["name"] for c in self.cands}
+        self.assertNotIn("Max Solomon", names)              # statewide Treasurer
+        self.assertNotIn("Michael W. Frerichs", names)      # statewide Treasurer
+        self.assertNotIn("Should Not Be Attributed", names)  # trailing judge office
+
+    def test_president_and_subdistricts_resolve(self):
+        by_race = {}
+        for c in self.cands:
+            by_race.setdefault(c["_race_id"], []).append(c["name"])
+        self.assertIn("Victor P. Henderson", by_race["cps-board-president"])
+        self.assertEqual(by_race["cps-board-member-1a"], ["Ed Bannon", "Margie B. Luczak"])
+        self.assertEqual(by_race["cps-board-member-4b"], ["Ellen Rosenfeld"])
+        # trailing content did not leak into the last subdistrict
+        self.assertEqual(by_race["cps-board-member-10b"], ["Connie Anderson", "Patrick C. Watson"])
+
+    def test_status_mapping(self):
+        st = {c["name"]: c["petition_status"] for c in self.cands}
+        self.assertEqual(st["Victor P. Henderson"], "on_ballot")
+        self.assertEqual(st["Sendhil Revuluri"], "withdrawn")
+        self.assertEqual(st["Kyna Lenhof"], "objected")
+
+    def test_nonpartisan_party_nulled(self):
+        # CPS is non-partisan; the "(Nonpartisan)" tag is dropped (schema: party is
+        # for partisan races only).
+        self.assertTrue(all(c["party"] is None for c in self.cands))
+
+    def test_name_with_quotes(self):
+        self.assertIn("Deborah \"Debby\" Pope", {c["name"] for c in self.cands})
+
+    def test_discover_pdf_url_picks_newest_candidate_list(self):
+        html = ('<a href="https://x/prod/2026-03/2026 Candidates Guide.pdf">guide</a>'
+                '<a href="https://x/prod/2026-06/Candidate List_20260604-1_0.pdf">old</a>'
+                '<a href="https://x/prod/2026-09/Candidate List_20260904-1_0.pdf">new</a>'
+                '<a href="https://x/general/Candidate-Withdrawal-Form.pdf">form</a>')
+        self.assertEqual(main.discover_boe_pdf_url(html),
+                         "https://x/prod/2026-09/Candidate List_20260904-1_0.pdf")
+        self.assertIsNone(main.discover_boe_pdf_url("<a href='/no/lists/here.pdf'>x</a>"))
+
+    def test_merge_into_doc(self):
+        doc = {"races": [{"id": "cps-board-member-1a", "status": "upcoming", "candidates": []},
+                         {"id": "cps-board-president", "status": "upcoming", "candidates": []}]}
+        n = main.merge_candidates(doc, main.parse_boe_candidate_list(
+            (RAW / "boe_candidate_list.txt").read_text()))
+        self.assertGreater(n, 0)
+        one_a = next(r for r in doc["races"] if r["id"] == "cps-board-member-1a")
+        self.assertEqual([c["name"] for c in one_a["candidates"]], ["Ed Bannon", "Margie B. Luczak"])
+        self.assertEqual(one_a["status"], "on_ballot")
+        self.assertNotIn("_race_id", one_a["candidates"][0])  # stripped on placement
+
+    def test_bad_input_empty(self):
+        self.assertEqual(main.parse_boe_candidate_list(""), [])
+        self.assertEqual(main.parse_boe_candidate_list("no offices\njust prose"), [])
+
+
 class Assemble(unittest.TestCase):
     def setUp(self):
         self.seed = main.load_seed()


### PR DESCRIPTION
Two related changes to fill in the Elections Happening in IL races.

## 1. Official candidates from the Chicago BOE Candidate List PDF (the CPS fix)

Investigating "why are the CPS races empty" turned up that the **seed structure is already correct** — verified against Chalkbeat/WTTW/Ballotpedia, the Nov 3 2026 ballot is president + all 20 subdistricts (1a–10b), so I did **not** change it. The real gap was that the Board of Elections publishes its authoritative candidate roster **only as a PDF**, which nothing was ingesting.

This wires that official source in:
- **`parse_boe_candidate_list(text)`** — a pure parser over `pdftotext -layout` output, **scoped to Board-of-Education offices** (the only Chicago-seed races on the 2026 ballot). Office context resets at every non-BOE header, so the statewide **Treasurer** on the same list is never misread as the Chicago City Treasurer, and trailing sections (judicial, etc.) never leak into the last subdistrict. Maps ballot status (`Candidate → on_ballot`, `Withdrawn`/`Objected`/…) and drops the `(Nonpartisan)` tag.
- **fetch/discover/merge wrapper** — `discover_boe_pdf_url()` finds the newest `Candidate List_<date>.pdf` on the BOE candidates page; `pdf_to_text()` shells out to **`pdftotext`** (poppler-utils, a system tool like the existing DuckDB dependency — no Python package, so the stdlib-only rule holds); `fetch_bytes()` downloads it (encoding the spaces BOE blob names carry); `merge_candidates()` places candidates exactly like `assemble()`.
- **CLI** `--enrich-candidates-boe [--boe-pdf <url|pdf|txt>]`; a **deploy step** installs poppler-utils and runs it before the money step (so committees can match) and the feed rebuild. Fully fail-soft.
- Offline fixture `__snapshots__/raw/boe_candidate_list.txt` + tests (guarding the statewide/judicial exclusion, status mapping, URL discovery, merge). **Committed sample stays empty; CI populates.**

Verified end-to-end on the real Sep-4 list: **42 official candidates across all 21 CPS races** (president + 20 subdistricts), e.g. Ed Bannon & Margie B. Luczak in 1a, Ellen Rosenfeld unopposed in 4b — matching press coverage.

## 2. Per-race potential-candidate news queries

Every district race (50 wards, 22 police districts, 20 CPS subdistricts) shared one pooled news query, which couldn't cover them individually. Each district race now gets its **own** query (`Chicago alderman "45th ward" candidate 2027`, …) unioned with the group pool. The **strict office + district-token gating is unchanged**, so a bigger pool never loosens the match — most 2027 down-ballot races legitimately stay empty until candidates surface in the press, then auto-fill on the twice-daily refresh.

## Validation
- `test_scrape_elections.py` (73) and `test_scrape_hearings.py` (43) pass; offline. New tests for the BOE parser, per-race query, and ordinal helper.
- Full live path exercised: auto-discover → download → `pdftotext` → parse → merge → rebuild feeds; the CPS per-race feeds now carry official candidate items, and the page renders the rosters (screenshot shared with the author).
- Deploy YAML lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq6dwxrKJHgZBMQoxmG5wE