### PR TITLE
Add govbot catalog and LLM guide for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@ This file provides senior engineering-level guidance for Claude Code when workin
 
 This is **govbot** - a monorepo for distributed data analysis of government updates. Git repos function as datasets, including legislation from 47+ states/jurisdictions. The `actions/` folder contains self-contained modules that can run as shell scripts or GitHub Actions.
 
+**AI-readable catalog access**: `llms.txt` (repo root) is a plain-language guide that
+teaches any AI assistant to read the `govbot-data/{code}-legislation` catalogs directly
+over HTTPS — no CLI, phone-friendly — and `catalog.json` (repo root) is the
+machine-readable directory of every jurisdiction repo plus the bill path pattern. Keep
+both in sync with the real data layout (the authoritative per-repo pattern lives in each
+repo's own `data.json`); the README's "Read it from an AI assistant" section links them.
+
 ## Senior Engineering Prompts
 
 Use these meta-prompts to guide architectural decisions and code quality.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@
 | **< 1 min** | to clone every dataset |
 | **$0** | cost to tag bills — models run locally on free CI |
 
+## Table of Contents
+
+- [Example Projects](#example-projects)
+- [Quick Start](#quick-start)
+- [Legislation Data Catalogs](#data-catalogs)
+  - [Data Structure](#data-structure)
+  - [Read it from an AI assistant (no install)](#read-it-from-an-ai-assistant-no-install)
+- [Contribute](#contribute)
+
 ## Example Projects
 
 Point govbot at a topic and it publishes a live feed for it. Two running today:
@@ -71,6 +80,8 @@ govbot update              # update govbot to latest version
 govbot --help              # see all commands and options
 ```
 
+<a id="data-catalogs"></a>
+
 # 🏛️ Govbot Legislation Data Catalogs
 
 Formatted legislation data for all 56 jurisdictions is available at [github.com/govbot-data](https://github.com/orgs/govbot-data/repositories).
@@ -103,6 +114,30 @@ Each jurisdiction has its own repo. The root of that repo IS the dataset — no 
 Federal and state jurisdictions share one path pattern (`state:usa` for federal), so downstream tooling doesn't need special-casing.
 
 See [`actions/format/docs/DATA_STRUCTURES.md`](actions/format/docs/DATA_STRUCTURES.md) for the full schema reference (bill metadata, logs, events, error tracking).
+
+### Read it from an AI assistant (no install)
+
+You don't need the CLI to explore the catalogs. Two files let any AI assistant
+(Claude, ChatGPT, etc.) read the data directly from GitHub — great from a phone:
+
+- [`llms.txt`](llms.txt) — a plain-language guide an AI reads first: the filing
+  rule that turns a jurisdiction + bill number into a fetchable URL, the bill
+  fields, discovery recipes, and guardrails (cite official sources, read the
+  timeline, don't invent bills).
+- [`catalog.json`](catalog.json) — a machine-readable directory of every
+  jurisdiction data repo plus the bill path pattern.
+
+**Try it:** paste this into Claude or ChatGPT on your phone —
+
+> Read this guide, then follow it to answer my question:
+> https://raw.githubusercontent.com/chihacknight/govbot/main/llms.txt
+>
+> Question: What's the status of Wyoming HB0001 in the 2025 session, who
+> sponsored it, and what's the official source link?
+
+This lookup-by-reading path is best for **specific** questions ("what is IL
+SB0813", "what did this sponsor introduce"). For big cross-state number-crunching,
+use the CLI + DuckDB above.
 
 ## Contribute
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,0 +1,470 @@
+{
+  "$comment": "Machine-readable directory of the govbot legislation data catalogs. See llms.txt for the plain-language guide an AI assistant should read first.",
+  "name": "govbot legislation data catalogs",
+  "description": "U.S. legislation for every state, D.C., the territories, and the federal Congress, published as ordinary public GitHub repositories. One repo per jurisdiction.",
+  "updated": "2026-09-12",
+  "canonical_org": "https://github.com/govbot-data",
+  "repo_naming": "govbot-data/{code}-legislation  (e.g. Illinois -> govbot-data/il-legislation)",
+  "raw_file_base": "https://raw.githubusercontent.com/govbot-data/{repo}/HEAD/{path}",
+  "path_pattern": "country:{country_code}/state:{jurisdiction_code}/sessions/{session_id}/bills/{bill_id}/metadata.json",
+  "authoritative_pattern_note": "Each repo also publishes its own data.json whose distribution.ex:pathPattern is the authoritative layout for THAT repo. Federal (usa) can differ from the states. When in doubt, read the repo's data.json first.",
+  "how_to_discover": {
+    "list_sessions": "https://api.github.com/repos/govbot-data/{repo}/contents/country:us/state:{code}/sessions",
+    "list_bills_in_session": "https://api.github.com/repos/govbot-data/{repo}/contents/country:us/state:{code}/sessions/{session_id}/bills",
+    "list_everything_recursive": "https://api.github.com/repos/govbot-data/{repo}/git/trees/HEAD?recursive=1"
+  },
+  "bill_fields": [
+    "identifier (e.g. HB0001)",
+    "title",
+    "legislative_session",
+    "classification",
+    "sponsorships[] (name, classification, primary)",
+    "subject[]",
+    "actions[] (description, date, classification) - the bill's timeline",
+    "versions[] / documents[] (links to official PDFs)",
+    "sources[] (link to the official government page)",
+    "jurisdiction (name, classification)"
+  ],
+  "jurisdictions": [
+    {
+      "code": "ak",
+      "name": "Alaska",
+      "type": "state",
+      "repo": "ak-legislation",
+      "browse": "https://github.com/govbot-data/ak-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ak-legislation/HEAD/data.json"
+    },
+    {
+      "code": "al",
+      "name": "Alabama",
+      "type": "state",
+      "repo": "al-legislation",
+      "browse": "https://github.com/govbot-data/al-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/al-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ar",
+      "name": "Arkansas",
+      "type": "state",
+      "repo": "ar-legislation",
+      "browse": "https://github.com/govbot-data/ar-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ar-legislation/HEAD/data.json"
+    },
+    {
+      "code": "az",
+      "name": "Arizona",
+      "type": "state",
+      "repo": "az-legislation",
+      "browse": "https://github.com/govbot-data/az-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/az-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ca",
+      "name": "California",
+      "type": "state",
+      "repo": "ca-legislation",
+      "browse": "https://github.com/govbot-data/ca-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ca-legislation/HEAD/data.json"
+    },
+    {
+      "code": "co",
+      "name": "Colorado",
+      "type": "state",
+      "repo": "co-legislation",
+      "browse": "https://github.com/govbot-data/co-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/co-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ct",
+      "name": "Connecticut",
+      "type": "state",
+      "repo": "ct-legislation",
+      "browse": "https://github.com/govbot-data/ct-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ct-legislation/HEAD/data.json"
+    },
+    {
+      "code": "de",
+      "name": "Delaware",
+      "type": "state",
+      "repo": "de-legislation",
+      "browse": "https://github.com/govbot-data/de-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/de-legislation/HEAD/data.json"
+    },
+    {
+      "code": "fl",
+      "name": "Florida",
+      "type": "state",
+      "repo": "fl-legislation",
+      "browse": "https://github.com/govbot-data/fl-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/fl-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ga",
+      "name": "Georgia",
+      "type": "state",
+      "repo": "ga-legislation",
+      "browse": "https://github.com/govbot-data/ga-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ga-legislation/HEAD/data.json"
+    },
+    {
+      "code": "gu",
+      "name": "Guam",
+      "type": "territory",
+      "repo": "gu-legislation",
+      "browse": "https://github.com/govbot-data/gu-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/gu-legislation/HEAD/data.json"
+    },
+    {
+      "code": "hi",
+      "name": "Hawaii",
+      "type": "state",
+      "repo": "hi-legislation",
+      "browse": "https://github.com/govbot-data/hi-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/hi-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ia",
+      "name": "Iowa",
+      "type": "state",
+      "repo": "ia-legislation",
+      "browse": "https://github.com/govbot-data/ia-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ia-legislation/HEAD/data.json"
+    },
+    {
+      "code": "id",
+      "name": "Idaho",
+      "type": "state",
+      "repo": "id-legislation",
+      "browse": "https://github.com/govbot-data/id-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/id-legislation/HEAD/data.json"
+    },
+    {
+      "code": "il",
+      "name": "Illinois",
+      "type": "state",
+      "repo": "il-legislation",
+      "browse": "https://github.com/govbot-data/il-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/il-legislation/HEAD/data.json"
+    },
+    {
+      "code": "in",
+      "name": "Indiana",
+      "type": "state",
+      "repo": "in-legislation",
+      "browse": "https://github.com/govbot-data/in-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/in-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ks",
+      "name": "Kansas",
+      "type": "state",
+      "repo": "ks-legislation",
+      "browse": "https://github.com/govbot-data/ks-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ks-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ky",
+      "name": "Kentucky",
+      "type": "state",
+      "repo": "ky-legislation",
+      "browse": "https://github.com/govbot-data/ky-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ky-legislation/HEAD/data.json"
+    },
+    {
+      "code": "la",
+      "name": "Louisiana",
+      "type": "state",
+      "repo": "la-legislation",
+      "browse": "https://github.com/govbot-data/la-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/la-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ma",
+      "name": "Massachusetts",
+      "type": "state",
+      "repo": "ma-legislation",
+      "browse": "https://github.com/govbot-data/ma-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ma-legislation/HEAD/data.json"
+    },
+    {
+      "code": "md",
+      "name": "Maryland",
+      "type": "state",
+      "repo": "md-legislation",
+      "browse": "https://github.com/govbot-data/md-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/md-legislation/HEAD/data.json"
+    },
+    {
+      "code": "me",
+      "name": "Maine",
+      "type": "state",
+      "repo": "me-legislation",
+      "browse": "https://github.com/govbot-data/me-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/me-legislation/HEAD/data.json"
+    },
+    {
+      "code": "mi",
+      "name": "Michigan",
+      "type": "state",
+      "repo": "mi-legislation",
+      "browse": "https://github.com/govbot-data/mi-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/mi-legislation/HEAD/data.json"
+    },
+    {
+      "code": "mn",
+      "name": "Minnesota",
+      "type": "state",
+      "repo": "mn-legislation",
+      "browse": "https://github.com/govbot-data/mn-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/mn-legislation/HEAD/data.json"
+    },
+    {
+      "code": "mo",
+      "name": "Missouri",
+      "type": "state",
+      "repo": "mo-legislation",
+      "browse": "https://github.com/govbot-data/mo-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/mo-legislation/HEAD/data.json"
+    },
+    {
+      "code": "mp",
+      "name": "Northern Mariana Islands",
+      "type": "territory",
+      "repo": "mp-legislation",
+      "browse": "https://github.com/govbot-data/mp-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/mp-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ms",
+      "name": "Mississippi",
+      "type": "state",
+      "repo": "ms-legislation",
+      "browse": "https://github.com/govbot-data/ms-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ms-legislation/HEAD/data.json"
+    },
+    {
+      "code": "mt",
+      "name": "Montana",
+      "type": "state",
+      "repo": "mt-legislation",
+      "browse": "https://github.com/govbot-data/mt-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/mt-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nc",
+      "name": "North Carolina",
+      "type": "state",
+      "repo": "nc-legislation",
+      "browse": "https://github.com/govbot-data/nc-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nc-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nd",
+      "name": "North Dakota",
+      "type": "state",
+      "repo": "nd-legislation",
+      "browse": "https://github.com/govbot-data/nd-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nd-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ne",
+      "name": "Nebraska",
+      "type": "state",
+      "repo": "ne-legislation",
+      "browse": "https://github.com/govbot-data/ne-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ne-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nh",
+      "name": "New Hampshire",
+      "type": "state",
+      "repo": "nh-legislation",
+      "browse": "https://github.com/govbot-data/nh-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nh-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nj",
+      "name": "New Jersey",
+      "type": "state",
+      "repo": "nj-legislation",
+      "browse": "https://github.com/govbot-data/nj-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nj-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nm",
+      "name": "New Mexico",
+      "type": "state",
+      "repo": "nm-legislation",
+      "browse": "https://github.com/govbot-data/nm-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nm-legislation/HEAD/data.json"
+    },
+    {
+      "code": "nv",
+      "name": "Nevada",
+      "type": "state",
+      "repo": "nv-legislation",
+      "browse": "https://github.com/govbot-data/nv-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/nv-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ny",
+      "name": "New York",
+      "type": "state",
+      "repo": "ny-legislation",
+      "browse": "https://github.com/govbot-data/ny-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ny-legislation/HEAD/data.json"
+    },
+    {
+      "code": "oh",
+      "name": "Ohio",
+      "type": "state",
+      "repo": "oh-legislation",
+      "browse": "https://github.com/govbot-data/oh-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/oh-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ok",
+      "name": "Oklahoma",
+      "type": "state",
+      "repo": "ok-legislation",
+      "browse": "https://github.com/govbot-data/ok-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ok-legislation/HEAD/data.json"
+    },
+    {
+      "code": "or",
+      "name": "Oregon",
+      "type": "state",
+      "repo": "or-legislation",
+      "browse": "https://github.com/govbot-data/or-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/or-legislation/HEAD/data.json"
+    },
+    {
+      "code": "pa",
+      "name": "Pennsylvania",
+      "type": "state",
+      "repo": "pa-legislation",
+      "browse": "https://github.com/govbot-data/pa-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/pa-legislation/HEAD/data.json"
+    },
+    {
+      "code": "pr",
+      "name": "Puerto Rico",
+      "type": "territory",
+      "repo": "pr-legislation",
+      "browse": "https://github.com/govbot-data/pr-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/pr-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ri",
+      "name": "Rhode Island",
+      "type": "state",
+      "repo": "ri-legislation",
+      "browse": "https://github.com/govbot-data/ri-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ri-legislation/HEAD/data.json"
+    },
+    {
+      "code": "sc",
+      "name": "South Carolina",
+      "type": "state",
+      "repo": "sc-legislation",
+      "browse": "https://github.com/govbot-data/sc-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/sc-legislation/HEAD/data.json"
+    },
+    {
+      "code": "sd",
+      "name": "South Dakota",
+      "type": "state",
+      "repo": "sd-legislation",
+      "browse": "https://github.com/govbot-data/sd-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/sd-legislation/HEAD/data.json"
+    },
+    {
+      "code": "tn",
+      "name": "Tennessee",
+      "type": "state",
+      "repo": "tn-legislation",
+      "browse": "https://github.com/govbot-data/tn-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/tn-legislation/HEAD/data.json"
+    },
+    {
+      "code": "tx",
+      "name": "Texas",
+      "type": "state",
+      "repo": "tx-legislation",
+      "browse": "https://github.com/govbot-data/tx-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/tx-legislation/HEAD/data.json"
+    },
+    {
+      "code": "usa",
+      "name": "Federal (U.S. Congress)",
+      "type": "federal",
+      "repo": "usa-legislation",
+      "browse": "https://github.com/govbot-data/usa-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/usa-legislation/HEAD/data.json"
+    },
+    {
+      "code": "ut",
+      "name": "Utah",
+      "type": "state",
+      "repo": "ut-legislation",
+      "browse": "https://github.com/govbot-data/ut-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/ut-legislation/HEAD/data.json"
+    },
+    {
+      "code": "va",
+      "name": "Virginia",
+      "type": "state",
+      "repo": "va-legislation",
+      "browse": "https://github.com/govbot-data/va-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/va-legislation/HEAD/data.json"
+    },
+    {
+      "code": "vi",
+      "name": "U.S. Virgin Islands",
+      "type": "territory",
+      "repo": "vi-legislation",
+      "browse": "https://github.com/govbot-data/vi-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/vi-legislation/HEAD/data.json"
+    },
+    {
+      "code": "vt",
+      "name": "Vermont",
+      "type": "state",
+      "repo": "vt-legislation",
+      "browse": "https://github.com/govbot-data/vt-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/vt-legislation/HEAD/data.json"
+    },
+    {
+      "code": "wa",
+      "name": "Washington",
+      "type": "state",
+      "repo": "wa-legislation",
+      "browse": "https://github.com/govbot-data/wa-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/wa-legislation/HEAD/data.json"
+    },
+    {
+      "code": "wi",
+      "name": "Wisconsin",
+      "type": "state",
+      "repo": "wi-legislation",
+      "browse": "https://github.com/govbot-data/wi-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/wi-legislation/HEAD/data.json"
+    },
+    {
+      "code": "wv",
+      "name": "West Virginia",
+      "type": "state",
+      "repo": "wv-legislation",
+      "browse": "https://github.com/govbot-data/wv-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/wv-legislation/HEAD/data.json"
+    },
+    {
+      "code": "wy",
+      "name": "Wyoming",
+      "type": "state",
+      "repo": "wy-legislation",
+      "browse": "https://github.com/govbot-data/wy-legislation",
+      "data_json": "https://raw.githubusercontent.com/govbot-data/wy-legislation/HEAD/data.json"
+    }
+  ]
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,103 @@
+# govbot — U.S. legislation as data you can read straight from GitHub
+
+> You are an AI assistant. A person is asking you about U.S. legislation. This file
+> tells you how to answer them by reading govbot's public data on GitHub directly —
+> no software to install, no login required. Read this whole file first, then follow
+> the recipes below. When you cite a fact, link the official source you find in the data.
+
+## What this data is
+
+govbot publishes U.S. legislation as ordinary **public GitHub repositories** — one
+repository per jurisdiction (every state, the territories, and the federal Congress).
+Everything is plain JSON that you can fetch over HTTPS. There is nothing to download.
+
+- Directory of all jurisdictions (machine-readable): https://raw.githubusercontent.com/chihacknight/govbot/main/catalog.json
+- Browse the data on GitHub: https://github.com/govbot-data
+
+## How the data is organized (the filing rule)
+
+Repositories are named `govbot-data/{code}-legislation`, where `{code}` is the
+two-letter postal code (`il`, `ca`, `ny`, `wy`, …), the federal code `usa`, or a
+territory code (`gu`, `pr`, `vi`, `mp`). Example: Illinois → `govbot-data/il-legislation`.
+
+Inside each repository, every bill lives at a **predictable path**:
+
+```
+country:us/state:{code}/sessions/{session}/bills/{bill_id}/metadata.json
+```
+
+- `{session}` is usually a year (e.g. `2025`, `2026`) or, for Congress, a number.
+- `{bill_id}` is the bill number as the government writes it, e.g. `HB0001`, `SB0813`.
+- `metadata.json` is the bill's full record.
+- A sibling `logs/` folder holds the bill's timeline as individual events.
+
+To turn any bill into a fetchable URL, use the raw-file base:
+
+```
+https://raw.githubusercontent.com/govbot-data/{code}-legislation/HEAD/country:us/state:{code}/sessions/{session}/bills/{bill_id}/metadata.json
+```
+
+Example (Wyoming HB0001, 2025 session):
+https://raw.githubusercontent.com/govbot-data/wy-legislation/HEAD/country:us/state:wy/sessions/2025/bills/HB0001/metadata.json
+
+**Authoritative layout:** each repo also has its own `data.json` at the root whose
+`ex:pathPattern` states that repo's exact layout. The federal (`usa`) repo can differ
+from the states. If a path doesn't resolve, fetch the repo's `data.json` and follow the
+pattern it gives.
+
+## What's inside a bill (metadata.json)
+
+Key fields you'll use to answer questions:
+
+- `identifier` — the bill number (e.g. `HB0001`)
+- `title` and `other_titles` — short and full titles
+- `legislative_session` — the session/year
+- `sponsorships[]` — who introduced/backed it (`name`, `primary`, `classification`)
+- `subject[]` — topic tags (may be empty)
+- `actions[]` — the **timeline**: each has `description`, `date`, `classification`
+  (this is how you say what has "happened" to a bill and whether it's moving)
+- `versions[]` / `documents[]` — links to official bill-text and fiscal-note **PDFs**
+- `sources[]` — the link to the official government page for the bill (cite this)
+- `jurisdiction` — the government it belongs to (name, state vs. federal)
+
+## How to find things
+
+**You already know the bill number and state** → build the raw URL above and fetch it. Fastest path.
+
+**You need to discover sessions or bills** → list folders with the GitHub contents API
+(no login for modest use):
+
+- Sessions: `https://api.github.com/repos/govbot-data/{code}-legislation/contents/country:us/state:{code}/sessions`
+- Bills in a session: `https://api.github.com/repos/govbot-data/{code}-legislation/contents/country:us/state:{code}/sessions/{session}/bills`
+
+**You want everything in one repo at once** → the recursive tree
+(`https://api.github.com/repos/govbot-data/{code}-legislation/git/trees/HEAD?recursive=1`)
+lists every file path. Use for smaller jurisdictions; large states return a lot.
+
+## Rules for answering well (please follow these)
+
+1. **Fetch narrowly.** Grab the one or few bills the question needs. Do not try to read
+   an entire state, and never try to read all 55 repositories — it won't fit and it's
+   not what this is for.
+2. **Cite the official source.** When you state a fact about a bill, include the link
+   from its `sources[]` (and the official PDF from `versions[]` when relevant) so the
+   person can verify it.
+3. **Read the timeline before saying a bill's status.** A bill's current state comes
+   from the most recent entry in `actions[]`, not from its title.
+4. **Don't invent bills or numbers.** If a path returns "404 / Not Found", the bill or
+   session doesn't exist at that path — say so, or list the folder to find the real id,
+   rather than guessing.
+5. **Know the limit.** This lookup-by-reading approach is great for specific questions
+   ("what is IL SB0813", "what did this sponsor introduce", "any transportation bills
+   moving in Wyoming this session"). It is **not** for big cross-state number-crunching
+   ("trends across all 56 states over 5 years") — for that, point the person to the
+   `govbot` command-line tool and its DuckDB support (https://github.com/chihacknight/govbot).
+
+## A worked example
+
+Question: *"What's the status of Wyoming HB0001 this session, and who sponsored it?"*
+
+1. Build the URL from the filing rule: state `wy`, session `2025`, bill `HB0001`.
+2. Fetch that `metadata.json`.
+3. Read `sponsorships[]` for the sponsor, and the last item of `actions[]` for status.
+4. Answer in plain language, and link `sources[0].url` (the official wyoleg.gov page).


### PR DESCRIPTION
## Summary

This PR adds two new reference files to help AI assistants and developers discover and use govbot's distributed legislation data:

1. **`catalog.json`** — A machine-readable directory of all 56 U.S. jurisdictions (50 states, D.C., 4 territories, and federal Congress) with repository URLs, data.json endpoints, and discovery patterns.
2. **`llms.txt`** — A plain-language guide for AI assistants explaining how to fetch and cite legislation data directly from GitHub without installing software or logging in.

## Key Changes

- **catalog.json**: Comprehensive registry of all `govbot-data/{code}-legislation` repositories with:
  - Jurisdiction metadata (code, name, type: state/territory/federal)
  - Direct links to browse on GitHub and fetch `data.json`
  - Documented path patterns and discovery APIs for sessions and bills
  - Bill field definitions (identifier, title, sponsorships, actions timeline, versions, sources)

- **llms.txt**: Practical guide covering:
  - What govbot data is and how it's organized (the filing rule)
  - How to construct raw GitHub URLs to fetch bill metadata
  - What fields are inside `metadata.json` and how to interpret them
  - Discovery recipes (direct URL construction, GitHub API listing, recursive tree)
  - Rules for answering well (fetch narrowly, cite sources, read timelines, don't invent bills)
  - Worked example (Wyoming HB0001 status and sponsor lookup)

## Implementation Details

- `catalog.json` follows a schema-first approach with metadata about the catalog itself (`$comment`, `name`, `description`, `updated`, `canonical_org`) before the jurisdictions array
- Includes helper fields like `repo_naming`, `raw_file_base`, `path_pattern`, and `how_to_discover` to guide both humans and machines
- `llms.txt` uses Markdown with clear section headers and code blocks for URLs and examples
- Both files are designed to be read first by AI assistants before attempting to fetch bill data, reducing errors and improving citation quality

These files enable AI assistants to answer questions about U.S. legislation by reading govbot's public GitHub data directly, with proper attribution to official government sources.

https://claude.ai/code/session_01WqqJh8UHP3FiQbw4MQ8YzN