### PR TITLE
Elections: fix potential-candidate misattribution across wards (appointed incumbents + negated candidacies)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,9 @@ a sourceless name is dropped — nothing is invented. Extraction is tuned for re
 headlines: verbs match case-insensitively (title-case "… Launches …", "… Running …"), an adverb
 between the name and the verb is skipped ("Aida Flores **Again** Running"), and names are gated
 against truncation (a trailing initial or split particle like "Matthew J. O" / "Daniel La") and
-against verb/event words captured as a name. Queries: one pooled query per office group
+against verb/event words captured as a name. A **negated** candidacy is dropped, not surfaced
+("… O'Shea **Won't** Seek Reelection", "will not run") — the check is local to each match, so a
+compound headline naming a retiring incumbent *and* a real challenger keeps only the challenger. Queries: one pooled query per office group
 for cross-cutting coverage, **plus a per-race query for every district race** (`Chicago alderman
 "45th ward" candidate 2027`, etc.) so each ward/subdistrict/police district gets its own coverage
 pool, plus one per citywide office. A bigger pool never loosens the match — the strict office +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,12 @@ any name already in that race's official `candidates` (populated earlier in the 
 name only when a headline both names a person beside a candidacy verb (→ status
 `announced`/`exploring`/`reported`) *and* references the race — its office keyword plus, for a
 district race, its district token (word-boundary matched, so "5th ward" ≠ "25th ward").
+It also recognizes a **mid-term appointment/confirmation** to a seat (→ status `incumbent`):
+the appointee is captured (e.g. "Mayor Brandon Johnson's pick, **Anthony Quezada**, to replace
+… 35th Ward Alderman …" → Anthony Quezada), never the owner of the pick (the mayor) nor the
+outgoing member ("to replace …"). Appointment patterns run only for seat-specific district
+races — not citywide ones, where a bare "mayor"/"clerk"/"treasurer" is usually just a title —
+so a ward appointee never leaks into the mayor's race.
 Honorifics are stripped ("Rep. Mike Quigley" → "Mike Quigley"), office/place/calendar words are
 rejected as names, and every name carries its source article(s) {title, url, publisher, date};
 a sourceless name is dropped — nothing is invented. Extraction is tuned for real local-outlet

--- a/actions/scrape-elections/README.md
+++ b/actions/scrape-elections/README.md
@@ -180,7 +180,11 @@ merely a title in the headline.
 Leading honorifics are stripped (`Rep. Mike Quigley` → `Mike Quigley`) so one
 person doesn't split in two, office/place/calendar words are rejected as names,
 and every surfaced name carries the article(s) it came from (headline, link,
-publisher, date). Nothing is invented; a name with no source is dropped.
+publisher, date). Nothing is invented; a name with no source is dropped. A
+**negated** candidacy is the opposite of one, so it is dropped rather than
+surfaced (`… O'Shea Won't Seek Reelection`, `will not run`); the negation is
+judged locally around each match, so a compound headline naming a retiring
+incumbent *and* a real challenger still keeps the challenger.
 
 Queries: one **pooled query per office group** for cross-cutting coverage, plus a
 **per-race query for every district race** (`Chicago alderman "45th ward"

--- a/actions/scrape-elections/README.md
+++ b/actions/scrape-elections/README.md
@@ -166,9 +166,16 @@ so it's out). A name is attached **only** when a headline both:
 
 1. names a person next to a candidacy verb (`announces` / `to run` / `enters` →
    *announced*; `mulls` / `weighing` / `rumored` → *exploring*; `candidate NAME`
-   → *reported*), and
+   → *reported*; appointed/`confirmed as … Alderperson` or `…'s pick, NAME,` →
+   *incumbent*), and
 2. references the race — its office keyword, plus the **district token** for a
    district race (word-boundary matched, so "5th ward" never matches "25th ward").
+
+For the *incumbent* (mid-term appointment) case the appointee is captured, never
+the owner of the pick (e.g. the mayor) or the outgoing member (`to replace …`);
+and appointment patterns run only for seat-specific district races, so a ward
+appointee is never misfiled under a citywide race whose office word ("mayor") was
+merely a title in the headline.
 
 Leading honorifics are stripped (`Rep. Mike Quigley` → `Mike Quigley`) so one
 person doesn't split in two, office/place/calendar words are rejected as names,

--- a/actions/scrape-elections/main.py
+++ b/actions/scrape-elections/main.py
@@ -1103,7 +1103,20 @@ _NAME_STOPWORDS = {
     "running", "challenges", "challenger", "unseat", "mulls", "weighs", "faces",
     "considers", "eyes", "explores", "propels", "boosts", "backs", "taps",
     "urges", "pushes", "picks", "names", "leads", "vows", "rips", "slams",
+    # negation contractions — a title-case "Won't"/"Can't" captured as a name
+    # token means a NOT-running headline slid in ("… O'Shea Won't Seek …").
+    "wont", "cant", "cannot", "dont", "doesnt", "didnt", "wouldnt", "couldnt",
+    "shouldnt", "isnt", "arent", "aint", "hasnt", "havent", "quits",
 }
+
+# A candidacy verb that is NEGATED is the opposite of a candidacy — the person is
+# leaving, not entering ("Won't Seek Reelection", "will not run", "won't seek").
+# If a match's span carries any of these, it is dropped rather than surfaced.
+_NEGATION_RE = re.compile(
+    r"(?i:\b(?:won'?t|will not|would not|wouldn'?t|do(?:es)?\s*n'?t|"
+    r"not\s+(?:seek|seeking|run|running|be)|no longer|drops?\s+out|"
+    r"bows?\s+out|steps?\s+(?:down|aside)|calls?\s+it\s+quits|"
+    r"retir(?:e|es|ing)|ends?\s+(?:his|her|their)?\s*(?:bid|campaign|run))\b)")
 
 
 def _office_terms(race):
@@ -1247,6 +1260,13 @@ def extract_candidacy(headline, race):
         patterns[2:2] = [(_APPOINT_RE, "incumbent"), (_APPOINTEE_RE, "incumbent")]
     for regex, status in patterns:
         for m in regex.finditer(text):
+            # A negated candidacy is the opposite of one ("… Won't Seek
+            # Reelection", "will not run"). Check the local span around the match
+            # (not the whole headline) so a real candidate elsewhere in a compound
+            # headline still counts.
+            span = text[max(0, m.start() - 16):m.end() + 4]
+            if _NEGATION_RE.search(span):
+                continue
             name = _strip_titles(m.group(1))
             # Drop leading verb/place/garbage words the pattern swept into the name
             # ("… Propels Claudia Zuno To Run" -> "Claudia Zuno"), keeping >=2 tokens.

--- a/actions/scrape-elections/main.py
+++ b/actions/scrape-elections/main.py
@@ -1060,6 +1060,19 @@ _REVERSE_COLON_RE = re.compile(
     r"\b(?i:candidate|hopeful|contender|challenger)(?:\s+(?i:for)\s+[a-z]+){0,2}"
     r"\s*:\s*" + _NAME + r"\b")
 _BID_RE = re.compile(_NAME + r"['’]s\s+(?i:bid|campaign|run)\b")
+# Appointment / confirmation to a seat mid-term — the appointee is the sitting
+# officeholder (a presumptive candidate), so we surface them with the honest
+# status "incumbent" rather than "announced". Two forms:
+#   name-first  — "Anthony Quezada Confirmed as 35th Ward Alderperson"
+#   appointee   — "…Mayor Brandon Johnson's pick, Anthony Quezada, to replace…"
+# The appointee form deliberately anchors on "pick,"/"appointee" so it captures
+# the person named AFTER it (Quezada), never the owner before it (the mayor);
+# and it excludes "replace"/"succeed", so the OUTGOING member is never grabbed.
+_APPOINT_RE = re.compile(
+    _NAME + _ADV + r"\s+(?i:confirmed|appointed|sworn[\s-]?in|tapped|"
+    r"takes? office|assumes? office)\b")
+_APPOINTEE_RE = re.compile(
+    r"\b(?i:pick|appointee)\b\s*,?\s+(?:the\s+)?" + _NAME + r"\b")
 
 # Tokens that are never a person's given/sur-name in this context; a candidate
 # match containing any of these is rejected (kills "Chicago Mayor", "Ward Five",
@@ -1221,9 +1234,18 @@ def extract_candidacy(headline, race):
     if not headline_matches_race(text, race):
         return []
     found = {}  # name_key -> (display_name, status)
-    for regex, status in ((_ANNOUNCE_RE, "announced"), (_BID_RE, "announced"),
-                          (_REVERSE_RE, "reported"), (_REVERSE_COLON_RE, "reported"),
-                          (_EXPLORE_RE, "exploring")):
+    patterns = [(_ANNOUNCE_RE, "announced"), (_BID_RE, "announced"),
+                (_REVERSE_RE, "reported"), (_REVERSE_COLON_RE, "reported"),
+                (_EXPLORE_RE, "exploring")]
+    # Appointment/confirmation coverage names a person filling a *specific* seat.
+    # Only attach it to a seat-specific (district) race, whose district token the
+    # headline had to contain to match. A citywide race matches on a bare office
+    # word that is often just a title ("Mayor Brandon Johnson's pick, …"), so
+    # letting the appointee attach there would misfile a ward appointee under the
+    # mayor's race — skip appointment patterns for citywide races.
+    if not race.get("is_citywide"):
+        patterns[2:2] = [(_APPOINT_RE, "incumbent"), (_APPOINTEE_RE, "incumbent")]
+    for regex, status in patterns:
         for m in regex.finditer(text):
             name = _strip_titles(m.group(1))
             # Drop leading verb/place/garbage words the pattern swept into the name
@@ -1235,8 +1257,8 @@ def extract_candidacy(headline, race):
             if not _valid_person(name):
                 continue
             key = name.lower()
-            # Strongest signal wins (announced > exploring > reported).
-            rank = {"announced": 3, "exploring": 2, "reported": 1}
+            # Strongest signal wins (announced > incumbent > exploring > reported).
+            rank = {"announced": 4, "incumbent": 3, "exploring": 2, "reported": 1}
             if key not in found or rank[status] > rank[found[key][1]]:
                 found[key] = (name, status)
     return list(found.values())
@@ -1385,7 +1407,7 @@ def build_potential(race, items, now, existing=None):
                 if s.get("date"):
                     rec["_dates"].add(s["date"])
 
-    rank = {"announced": 3, "exploring": 2, "reported": 1, None: 0}
+    rank = {"announced": 4, "incumbent": 3, "exploring": 2, "reported": 1, None: 0}
 
     def _add_source(rec, it):
         url = it.get("link")
@@ -1435,7 +1457,7 @@ def build_potential(race, items, now, existing=None):
             "sources": rec["sources"][:POTENTIAL_MAX_SOURCES],
         })
     # Most-cited first, then firmest signal, then name — stable and useful.
-    rank2 = {"announced": 3, "exploring": 2, "reported": 1, None: 0}
+    rank2 = {"announced": 4, "incumbent": 3, "exploring": 2, "reported": 1, None: 0}
     out.sort(key=lambda p: (-p["mentions"], -rank2[p["status"]], p["name"].lower()))
     return out[:POTENTIAL_MAX_PER_RACE]
 

--- a/actions/scrape-elections/test_scrape_elections.py
+++ b/actions/scrape-elections/test_scrape_elections.py
@@ -540,6 +540,29 @@ class PotentialCandidates(unittest.TestCase):
         self.assertEqual(main.extract_candidacy(h1, mayor), [])
         self.assertEqual(main.extract_candidacy(h1, w5), [])
 
+    def test_negated_candidacy_is_not_a_candidacy(self):
+        # "Won't Seek Reelection" is the OPPOSITE of running — the retiring
+        # incumbent must not be surfaced (and "Won't" must not become a name).
+        w19 = {"office": "Alderperson", "office_group": "council",
+               "is_citywide": False, "district": "Ward 19"}
+        self.assertEqual(main.extract_candidacy(
+            "19th Ward Alderman Matt O'Shea Won't Seek Reelection After 16 Years, "
+            "Backs Chief of Staff", w19), [])
+        self.assertEqual(main.extract_candidacy(
+            "Jane Q. Smith Will Not Run For 19th Ward Alderman", w19), [])
+        self.assertEqual(main.extract_candidacy(
+            "Ald. Matt O'Shea becomes third council member to not seek reelection "
+            "in 2027", w19), [])
+
+    def test_negation_is_local_not_whole_headline(self):
+        # A compound headline naming a retiring incumbent AND a real challenger
+        # keeps the challenger — negation is judged near each match, not globally.
+        w19 = {"office": "Alderperson", "office_group": "council",
+               "is_citywide": False, "district": "Ward 19"}
+        self.assertEqual(main.extract_candidacy(
+            "19th Ward Alderman O'Shea won't seek reelection, but Melanie Stathis "
+            "launches her campaign", w19), [("Melanie Stathis", "announced")])
+
     def test_titlecase_fix_does_not_break_district_guard(self):
         # The case-insensitive verbs must NOT let a different city's alderman
         # (no Chicago ward number in the headline) attach to a ward race.

--- a/actions/scrape-elections/test_scrape_elections.py
+++ b/actions/scrape-elections/test_scrape_elections.py
@@ -512,6 +512,34 @@ class PotentialCandidates(unittest.TestCase):
             dict(main.extract_candidacy("25th Ward candidate for alderman: Hilario Dominguez", ward25)),
             {"Hilario Dominguez": "reported"})
 
+    def test_appointment_extracts_the_appointee_not_the_mayor(self):
+        # A mid-term appointment headline names two people: the mayor (owner of
+        # the pick) and the appointee. We surface the appointee as an "incumbent",
+        # never the mayor, and never the OUTGOING member ("to replace …").
+        w35 = {"id": "chicago-alderperson-ward-35", "office": "Alderperson",
+               "office_group": "council", "is_citywide": False, "district": "Ward 35"}
+        h1 = ("Chicago City Council approves Mayor Brandon Johnson's pick, "
+              "Anthony Quezada, to replace ex 35th Ward Alderman Carlos Ramirez-Rosa")
+        h3 = "Anthony Quezada Confirmed as 35th Ward Alderperson by Chicago City Council"
+        self.assertEqual(main.extract_candidacy(h1, w35), [("Anthony Quezada", "incumbent")])
+        self.assertEqual(main.extract_candidacy(h3, w35), [("Anthony Quezada", "incumbent")])
+        names = [n for n, _ in main.extract_candidacy(h1, w35)]
+        self.assertNotIn("Brandon Johnson", names)      # the mayor (owner of the pick)
+        self.assertFalse(any("Ramirez" in n for n in names))  # the outgoing member
+
+    def test_appointment_does_not_leak_to_citywide_race(self):
+        # "Mayor" in the headline is Brandon Johnson's title, not the contested
+        # office — the appointee must not be filed under the mayor's race, and a
+        # different ward (different district token) must not pick it up either.
+        mayor = {"office": "Mayor", "office_group": "citywide", "is_citywide": True,
+                 "district": None}
+        w5 = {"office": "Alderperson", "office_group": "council",
+              "is_citywide": False, "district": "Ward 5"}
+        h1 = ("Chicago City Council approves Mayor Brandon Johnson's pick, "
+              "Anthony Quezada, to replace ex 35th Ward Alderman Carlos Ramirez-Rosa")
+        self.assertEqual(main.extract_candidacy(h1, mayor), [])
+        self.assertEqual(main.extract_candidacy(h1, w5), [])
+
     def test_titlecase_fix_does_not_break_district_guard(self):
         # The case-insensitive verbs must NOT let a different city's alderman
         # (no Chicago ward number in the headline) attach to a ward race.

--- a/docs/src/dashboard/elections.html
+++ b/docs/src/dashboard/elections.html
@@ -303,6 +303,9 @@
   .pc-sig.announced { color: #fff; background: var(--series-3); border: 1px solid var(--series-3); }
   .pc-sig.exploring { color: var(--series-3); border: 1px solid var(--series-3); }
   .pc-sig.reported { color: var(--text-muted); border: 1px solid var(--border); }
+  /* Appointed incumbent — a firm, factual signal (holds the seat now), filled
+     blue to read distinctly from the amber "announced". */
+  .pc-sig.incumbent { color: #fff; background: var(--series-1); border: 1px solid var(--series-1); }
   .pc-when { font-size: 10.5px; color: var(--text-muted); margin-top: 2px; }
   .pc-srcs { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px 12px; font-size: 11px; }
   .pc-srcs a { font-weight: 600; color: var(--series-1); text-decoration: none; }
@@ -1223,7 +1226,8 @@
 
   // Unofficial potential candidates: a collapsed, clearly-labeled block listing
   // names news outlets have reported for this race, each linked to its source(s).
-  const PC_SIG_LABEL = { announced: "Announced", exploring: "Exploring", reported: "In coverage" };
+  const PC_SIG_LABEL = { announced: "Announced", incumbent: "Incumbent (appointed)",
+                         exploring: "Exploring", reported: "In coverage" };
   function renderPotential(pcs, r) {
     const det = document.createElement("details"); det.className = "potential";
     const sum = document.createElement("summary");
@@ -1236,9 +1240,10 @@
     det.append(sum);
 
     const note = document.createElement("div"); note.className = "pc-note";
-    note.textContent = "Names reported in the press as running, exploring, or "
-      + "rumored — not official filings and not on any ballot list. Check each "
-      + "source and the official list before relying on these.";
+    note.textContent = "Names reported in the press as running, exploring, "
+      + "rumored, or currently holding the seat (an appointed incumbent) — not "
+      + "official filings and not on any ballot list. Check each source and the "
+      + "official list before relying on these.";
     det.append(note);
 
     const list = document.createElement("div"); list.className = "pc-list";

--- a/schemas/govbot.elections.schema.json
+++ b/schemas/govbot.elections.schema.json
@@ -221,15 +221,15 @@
     },
     "PotentialCandidate": {
       "type": "object",
-      "description": "An unofficial, news-sourced name for a race — someone reported as running/exploring who has NOT been confirmed as a filed candidate. Always carries its source article(s); never a ballot record.",
+      "description": "An unofficial, news-sourced name for a race — someone reported as running/exploring, or an appointed/confirmed sitting incumbent, who has NOT been confirmed as a filed candidate for the upcoming election. Always carries its source article(s); never a ballot record.",
       "required": ["name", "sources"],
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string", "description": "The person's name exactly as it appeared in coverage. Never normalized against a voter file — this is a coverage signal, not a ballot name." },
         "status": {
           "type": ["string", "null"],
-          "description": "How the coverage characterized the candidacy: 'announced' (declared/entered/filed to run), 'exploring' (considering/weighing/rumored), or 'reported' (named as a candidate without a clear signal verb).",
-          "enum": ["announced", "exploring", "reported", null]
+          "description": "How the coverage characterized the candidacy: 'announced' (declared/entered/filed to run), 'incumbent' (appointed/confirmed to the seat mid-term — the sitting officeholder and a presumptive candidate), 'exploring' (considering/weighing/rumored), or 'reported' (named as a candidate without a clear signal verb).",
+          "enum": ["announced", "incumbent", "exploring", "reported", null]
         },
         "mentions": { "type": "integer", "minimum": 1, "description": "Number of distinct source articles backing this name." },
         "first_seen": { "type": ["string", "null"], "description": "Earliest article date across the sources, ISO YYYY-MM-DD; null when no dates parse." },


### PR DESCRIPTION
## Two misattribution bugs found by auditing all 50 ward feeds

### 1. Ward 35 surfaced the mayor instead of the appointee
The ABC7 headline names two people:
> "Chicago City Council approves Mayor **Brandon Johnson**'s pick, **Anthony Quezada**, to replace ex 35th Ward Alderman Carlos Ramirez-Rosa"

Quezada was *appointed* to the seat mid-term — a category the extractor had no pattern for, so it grabbed the wrong name (the mayor). Fix: recognize mid-term appointment/confirmation with a new, honest status **`incumbent`**:
- Two forms — name-first ("Anthony Quezada **Confirmed** as 35th Ward Alderperson") and appointee ("…Johnson's **pick, Anthony Quezada**, to replace…").
- Captures the appointee, never the **owner** of the pick (the mayor); excludes `replace`/`succeed` so the **outgoing** member isn't grabbed.
- Runs only for seat-specific **district** races, so a ward appointee can't leak into a citywide race whose office word ("mayor") was merely a title.

### 2. Ward 19 surfaced a retiring incumbent as "announced"
> "19th Ward Alderman Matt O'Shea **Won't** Seek Reelection After 16 Years…"

The extractor read "Matt O'Shea Won't" + "Seek" as an announcement — but O'Shea is *retiring*. Fix: a **negated candidacy is dropped**, not surfaced:
- Negation contractions (`won't`/`can't`/…) can no longer be captured as a name token.
- A local negation guard drops a match whose span carries `won't` / `will not` / `not seek(ing)` / `not run(ning)` / `drops out` / `bows out` / `steps down` / `retires` / `ends bid`. The check is **local to each match**, so a compound headline naming a retiring incumbent *and* a real challenger keeps only the challenger.

## Audit result
Those two were the only bad entries across the 50 ward feeds; every other listed name is a plausible real person. The negation guard can only *remove* wrong entries, never add — and all existing announced-candidate cases still extract unchanged.

## Threaded through consistently
Status ranking (`announced > incumbent > exploring > reported`) in both `extract_candidacy` and `build_potential`; the schema `status` enum + `PotentialCandidate` description; and the frontend, which renders a filled-blue **"Incumbent (appointed)"** signal with an updated block note.

## Verification
- `python3 actions/scrape-elections/test_scrape_elections.py` → **83 tests pass** (4 new: Quezada extraction, citywide/other-ward guards, negated candidacy, local-negation-in-compound-headline).
- End-to-end `build_potential` on the real Ward 35 headlines → exactly `Anthony Quezada` (`incumbent`); Ward 19 → only `Melanie Jacobs Stathis`, no "O'Shea Won't".

Reaches the live feeds on the next twice-daily deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq6dwxrKJHgZBMQoxmG5wE